### PR TITLE
fix: add setting to disable route cache

### DIFF
--- a/packages/forest_admin_rails/lib/forest_admin_rails.rb
+++ b/packages/forest_admin_rails/lib/forest_admin_rails.rb
@@ -29,6 +29,7 @@ module ForestAdminRails
   setting :limit_export_size, default: nil
   setting :append_schema_path, default: nil
   setting :skip_schema_update, default: false
+  setting :disable_route_cache, default: false
 
   if defined?(Rails::Railtie)
     # logic for cors middleware,... here // or it might be into Engine


### PR DESCRIPTION
## Definition of Done

Added missing setting for disabling route cache
This is already implemented as a check in the `ForestAdminAgent::Http::Router` but there is currently no way to set the setting

### General

- [x ] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [x ] Test manually the implemented changes
- [ x] Validate the code quality (indentation, syntax, style, simplicity, readability)

### Security

- [ ] Consider the security impact of the changes made
