### PR TITLE
fix: safely load id for many-to-one relationships

### DIFF
--- a/packages/forest_admin_agent/lib/forest_admin_agent/routes/abstract_authenticated_route.rb
+++ b/packages/forest_admin_agent/lib/forest_admin_agent/routes/abstract_authenticated_route.rb
@@ -16,7 +16,7 @@ module ForestAdminAgent
         args[:params][:data][:relationships]&.map do |field, value|
           schema = @collection.schema[:fields][field]
 
-          record[schema.foreign_key] = value['data']['id'] if schema.type == 'ManyToOne'
+          record[schema.foreign_key] = value.dig('data', 'id') if schema.type == 'ManyToOne'
         end
 
         record || {}


### PR DESCRIPTION
Fixed issue where params were being parsed even when the attributes for a given association were missing.

## Definition of Done

### General

- [ ] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [ ] Test manually the implemented changes
- [ ] Validate the code quality (indentation, syntax, style, simplicity, readability)

### Security

- [ ] Consider the security impact of the changes made
