### PR TITLE
fix(rpc-agent): return JSON error responses instead of HTML for exceptions

### DIFF
--- a/packages/forest_admin_rpc_agent/lib/forest_admin_rpc_agent/routes/base_route.rb
+++ b/packages/forest_admin_rpc_agent/lib/forest_admin_rpc_agent/routes/base_route.rb
@@ -33,9 +33,11 @@ module ForestAdminRpcAgent
 
       def register_rails(router)
         handler = proc do |hash|
-          handle_rails_request(hash)
-        rescue StandardError => e
-          handle_rails_exception(e)
+          begin
+            handle_rails_request(hash)
+          rescue StandardError => e
+            handle_rails_exception(e)
+          end
         end
 
         router.match @url,

--- a/packages/forest_admin_rpc_agent/lib/forest_admin_rpc_agent/routes/base_route.rb
+++ b/packages/forest_admin_rpc_agent/lib/forest_admin_rpc_agent/routes/base_route.rb
@@ -35,22 +35,26 @@ module ForestAdminRpcAgent
         handler = proc do |hash|
           request = ActionDispatch::Request.new(hash)
 
-          # Skip authentication for health check (root path)
-          if @url == '/'
-            params = request.query_parameters.merge(request.request_parameters)
-            result = handle_request({ params: params, caller: nil })
-            [200, { 'Content-Type' => 'application/json' }, [serialize_response(result)]]
-          else
-            auth_middleware = ForestAdminRpcAgent::Middleware::Authentication.new(->(_env) { [200, {}, ['OK']] })
-            status, headers, response = auth_middleware.call(request.env)
-
-            if status == 200
+          begin
+            # Skip authentication for health check (root path)
+            if @url == '/'
               params = request.query_parameters.merge(request.request_parameters)
-              result = handle_request({ params: params, caller: headers[:caller] })
+              result = handle_request({ params: params, caller: nil })
               [200, { 'Content-Type' => 'application/json' }, [serialize_response(result)]]
             else
-              [status, headers, response]
+              auth_middleware = ForestAdminRpcAgent::Middleware::Authentication.new(->(_env) { [200, {}, ['OK']] })
+              status, headers, response = auth_middleware.call(request.env)
+
+              if status == 200
+                params = request.query_parameters.merge(request.request_parameters)
+                result = handle_request({ params: params, caller: headers[:caller] })
+                [200, { 'Content-Type' => 'application/json' }, [serialize_response(result)]]
+              else
+                [status, headers, response]
+              end
             end
+          rescue StandardError => e
+            handle_rails_exception(e)
           end
         end
 
@@ -78,6 +82,26 @@ module ForestAdminRpcAgent
         return result if result.is_a?(String) && (result.start_with?('{', '['))
 
         result.to_json
+      end
+
+      def handle_rails_exception(exception)
+        http_exception = ForestAdminAgent::Http::ErrorTranslator.translate(exception)
+
+        headers = { 'Content-Type' => 'application/json' }
+        headers.merge!(http_exception.custom_headers || {})
+
+        data = {
+          errors: [
+            {
+              name: http_exception.name,
+              detail: http_exception.message,
+              status: http_exception.status,
+              data: http_exception.data
+            }.compact
+          ]
+        }
+
+        [http_exception.status, headers, [data.to_json]]
       end
     end
   end

--- a/packages/forest_admin_rpc_agent/lib/forest_admin_rpc_agent/routes/base_route.rb
+++ b/packages/forest_admin_rpc_agent/lib/forest_admin_rpc_agent/routes/base_route.rb
@@ -33,11 +33,9 @@ module ForestAdminRpcAgent
 
       def register_rails(router)
         handler = proc do |hash|
-          begin
-            handle_rails_request(hash)
-          rescue StandardError => e
-            handle_rails_exception(e)
-          end
+          handle_rails_request(hash)
+        rescue StandardError => e
+          handle_rails_exception(e)
         end
 
         router.match @url,

--- a/packages/forest_admin_rpc_agent/spec/lib/forest_admin_rpc_agent/routes/base_route_spec.rb
+++ b/packages/forest_admin_rpc_agent/spec/lib/forest_admin_rpc_agent/routes/base_route_spec.rb
@@ -135,8 +135,8 @@ module ForestAdminRpcAgent
             handler_proc = nil
 
             # Capture the handler proc that's passed to match
-            allow(rails_router).to receive(:match) do |_url, **options, &_block|
-              handler_proc = options[:to]
+            allow(rails_router).to receive(:match) do |_url, **opts|
+              handler_proc = opts[:to]
             end
 
             not_found_route.send(:register_rails, rails_router)

--- a/packages/forest_admin_rpc_agent/spec/lib/forest_admin_rpc_agent/routes/base_route_spec.rb
+++ b/packages/forest_admin_rpc_agent/spec/lib/forest_admin_rpc_agent/routes/base_route_spec.rb
@@ -135,8 +135,8 @@ module ForestAdminRpcAgent
             handler_proc = nil
 
             # Capture the handler proc that's passed to match
-            allow(rails_router).to receive(:match) do |_url, **_options, &block|
-              handler_proc = _options[:to]
+            allow(rails_router).to receive(:match) do |_url, **options, &_block|
+              handler_proc = options[:to]
             end
 
             not_found_route.send(:register_rails, rails_router)

--- a/packages/forest_admin_rpc_agent/spec/lib/forest_admin_rpc_agent/routes/base_route_spec.rb
+++ b/packages/forest_admin_rpc_agent/spec/lib/forest_admin_rpc_agent/routes/base_route_spec.rb
@@ -18,6 +18,13 @@ module ForestAdminRpcAgent
       end
     end
 
+    # Test route that raises a NotFoundError
+    class TestNotFoundRoute < BaseRoute
+      def handle_request(_params)
+        raise ForestAdminAgent::Http::Exceptions::NotFoundError, 'Resource not found'
+      end
+    end
+
     describe BaseRoute do
       subject(:route) { TestRoute.new('/test', 'get', 'test_route') }
 
@@ -118,6 +125,38 @@ module ForestAdminRpcAgent
               as: 'test_route',
               route_alias: 'test_route'
             )
+          end
+        end
+
+        context 'when the route raises a NotFoundError' do
+          subject(:not_found_route) { TestNotFoundRoute.new('/not-found', 'get', 'not_found_route') }
+
+          it 'returns a JSON error response with 404 status' do
+            handler_proc = nil
+
+            # Capture the handler proc that's passed to match
+            allow(rails_router).to receive(:match) do |_url, **_options, &block|
+              handler_proc = _options[:to]
+            end
+
+            not_found_route.send(:register_rails, rails_router)
+
+            # Call the handler with a mock request
+            mock_env = {}
+            allow(middleware).to receive(:call).and_return([200, { caller: 'test' }, ['OK']])
+
+            status, headers, body = handler_proc.call(mock_env)
+
+            expect(status).to eq(404)
+            expect(headers['Content-Type']).to eq('application/json')
+            expect(headers['x-error-type']).to eq('object-not-found')
+
+            parsed_body = JSON.parse(body[0])
+            expect(parsed_body).to have_key('errors')
+            expect(parsed_body['errors']).to be_an(Array)
+            expect(parsed_body['errors'][0]['name']).to eq('NotFoundError')
+            expect(parsed_body['errors'][0]['detail']).to eq('Resource not found')
+            expect(parsed_body['errors'][0]['status']).to eq(404)
           end
         end
       end


### PR DESCRIPTION
## Summary
- Fix exception handling in `forest_admin_rpc_agent` package to return JSON error responses instead of HTML
- Add `rescue StandardError` block in `register_rails` method to catch exceptions
- Add `handle_rails_exception` method that uses `ErrorTranslator` to format errors as JSON
- Add test to verify 404 errors return proper JSON response with correct headers

## Problem
When exceptions are raised in RPC agent routes (like `NotFoundError` for non-existent collections or resources), they were not caught and Rails would return HTML error pages instead of JSON.

## Solution
Similar to how `forest_admin_rails` handles exceptions in its `ForestController`, the RPC agent now:
1. Catches all `StandardError` exceptions in the route handler
2. Uses `ErrorTranslator` to convert them to HTTP exceptions
3. Returns properly formatted JSON responses with:
   - Correct HTTP status code (e.g., 404)
   - Content-Type: application/json header
   - Custom headers (e.g., x-error-type: object-not-found)
   - Error details in standardized format

## Test plan
- [x] Add test for NotFoundError returning JSON 404 response
- [ ] Run existing test suite to ensure no regressions
- [ ] Manually test with a Rails app using RPC agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)