### PR TITLE
fix(ci): use BUNDLE_PATH to avoid insecure install path with Ruby 4.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     env:
-      BUNDLE_PATH: ${{ runner.temp }}/bundle
+      BUNDLE_PATH: /tmp/bundle
     strategy:
       matrix:
         ruby-version: ["3.4", "4.0"]
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [lint]
     env:
-      BUNDLE_PATH: ${{ runner.temp }}/bundle
+      BUNDLE_PATH: /tmp/bundle
     strategy:
       matrix:
         ruby-version: ["3.4", "4.0"]


### PR DESCRIPTION
Bundler 4.0 (shipped with Ruby 4.0) has stricter security checks on gem installation paths. GitHub Actions runners have world-writable gem directories which trigger InsecureInstallPathError (exit code 38).

Setting BUNDLE_PATH at the job level redirects all gem installs to a temp directory with proper permissions.

