### PR TITLE
fix(parser): condition tree parser on HasMany or Polymorphic relations

### DIFF
--- a/packages/forest_admin_agent/lib/forest_admin_agent/utils/condition_tree_parser.rb
+++ b/packages/forest_admin_agent/lib/forest_admin_agent/utils/condition_tree_parser.rb
@@ -31,6 +31,11 @@ module ForestAdminAgent
 
       def self.parse_value(collection, leaf)
         schema = Collection.get_field_schema(collection, leaf[:field])
+
+        if ['ManyToOne', 'PolymorphicManyToOne'].include?(schema.type)
+          schema = collection.schema[:fields][schema.foreign_key]
+        end
+
         expected_type = get_expected_type_for_condition(leaf, schema)
 
         cast_to_type(leaf[:value], expected_type)

--- a/packages/forest_admin_agent/spec/lib/forest_admin_agent/utils/condition_tree_parser_spec.rb
+++ b/packages/forest_admin_agent/spec/lib/forest_admin_agent/utils/condition_tree_parser_spec.rb
@@ -11,8 +11,9 @@ module ForestAdminAgent
     describe ConditionTreeParser do
       subject(:condition_tree_parser) { described_class }
 
+      let(:datasource) { Datasource.new }
+
       let(:collection_category) do
-        datasource = Datasource.new
         collection_category = Collection.new(datasource, 'Category')
         collection_category.add_fields(
           {
@@ -26,6 +27,27 @@ module ForestAdminAgent
         datasource.add_collection(collection_category)
 
         return collection_category
+      end
+
+      let(:collection_product) do
+        collection_product = Collection.new(datasource, 'Product')
+        collection_product.add_fields(
+          {
+            'id' => ColumnSchema.new(column_type: 'Uuid', is_primary_key: true,
+                                     filter_operators: [Operators::EQUAL, Operators::IN, Operators::NOT_IN]),
+            'category_id' => ColumnSchema.new(column_type: 'Uuid',
+                                              filter_operators: [Operators::EQUAL, Operators::IN, Operators::NOT_IN]),
+            'category' => ForestAdminDatasourceToolkit::Schema::Relations::ManyToOneSchema.new(
+              foreign_key: 'category_id',
+              foreign_key_target: 'id',
+              foreign_collection: 'Category'
+            )
+          }
+        )
+
+        datasource.add_collection(collection_product)
+
+        return collection_product
       end
 
       it 'failed if provided something else' do
@@ -158,6 +180,29 @@ module ForestAdminAgent
 
           expect(condition_tree_parser.from_plain_object(collection_category, filters))
             .to have_attributes(field: filters[:field], operator: filters[:operator], value: %w[tag1 tag2 tag3])
+        end
+      end
+
+      context 'with ManyToOne relation field' do
+        it 'works with "IN" on a ManyToOne relation field' do
+          filters = { field: 'category', operator: Operators::IN, value: 'uuid1,uuid2' }
+
+          expect(condition_tree_parser.from_plain_object(collection_product, filters))
+            .to have_attributes(field: 'category', operator: Operators::IN, value: %w[uuid1 uuid2])
+        end
+
+        it 'works with "NOT_IN" on a ManyToOne relation field' do
+          filters = { field: 'category', operator: Operators::NOT_IN, value: 'uuid1,uuid2' }
+
+          expect(condition_tree_parser.from_plain_object(collection_product, filters))
+            .to have_attributes(field: 'category', operator: Operators::NOT_IN, value: %w[uuid1 uuid2])
+        end
+
+        it 'works with "EQUAL" on a ManyToOne relation field' do
+          filters = { field: 'category', operator: Operators::EQUAL, value: 'some-uuid' }
+
+          expect(condition_tree_parser.from_plain_object(collection_product, filters))
+            .to have_attributes(field: 'category', operator: Operators::EQUAL, value: 'some-uuid')
         end
       end
     end


### PR DESCRIPTION
## Definition of Done

### General

- [ ] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [ ] Test manually the implemented changes
- [ ] Validate the code quality (indentation, syntax, style, simplicity, readability)

### Security

- [ ] Consider the security impact of the changes made


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `ConditionTreeParser.parse_value` to cast values using foreign key schema for ManyToOne relations
> When a filter targets a `ManyToOne` or `PolymorphicManyToOne` relation field, `parse_value` was using the relation type itself to determine casting, causing incorrect value handling. The fix resolves the field schema to the relation's foreign key schema before casting, so operators like `IN`, `NOT_IN`, and `EQUAL` on relation fields produce correctly typed values.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 35a03b9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->