### PR TITLE
chore(security): patch 4 Dependabot alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,9 +23,7 @@
   },
   "resolutions": {
     "semantic-release-slack-bot/**/micromatch": "^4.0.8",
-    "lodash": "^4.17.23",
-    "lodash-es": "^4.17.23",
-    "js-yaml": "^4.1.1",
-    "ajv": "^8.18.0"
+    "lodash": "^4.18.0",
+    "lodash-es": "^4.18.0"
   } 
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -856,7 +856,7 @@ aggregate-error@^5.0.0:
     clean-stack "^5.2.0"
     indent-string "^5.0.0"
 
-ajv@^8.11.0, ajv@^8.18.0:
+ajv@^8.11.0:
   version "8.18.0"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.18.0.tgz#8864186b6738d003eb3a933172bb3833e10cefbc"
   integrity sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==
@@ -2060,7 +2060,7 @@ js-tokens@^4.0.0:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@^4.1.0, js-yaml@^4.1.1:
+js-yaml@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.1.tgz#854c292467705b699476e1a2decc0c8a3458806b"
   integrity sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==
@@ -2268,10 +2268,10 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
-lodash-es@^4.17.21, lodash-es@^4.17.23:
-  version "4.17.23"
-  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.23.tgz#58c4360fd1b5d33afc6c0bbd3d1149349b1138e0"
-  integrity sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==
+lodash-es@^4.17.21, lodash-es@^4.18.0:
+  version "4.18.1"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.18.1.tgz#b962eeb80d9d983a900bf342961fb7418ca10b1d"
+  integrity sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==
 
 lodash.camelcase@^4.3.0:
   version "4.3.0"
@@ -2343,10 +2343,10 @@ lodash.upperfirst@^4.3.1:
   resolved "https://registry.yarnpkg.com/lodash.upperfirst/-/lodash.upperfirst-4.3.1.tgz#1365edf431480481ef0d1c68957a5ed99d49f7ce"
   integrity sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==
 
-lodash@^4.17.15, lodash@^4.17.23, lodash@^4.17.4:
-  version "4.17.23"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.23.tgz#f113b0378386103be4f6893388c73d0bde7f2c5a"
-  integrity sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==
+lodash@^4.17.15, lodash@^4.17.4, lodash@^4.18.0:
+  version "4.18.1"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.18.1.tgz#ff2b66c1f6326d59513de2407bf881439812771c"
+  integrity sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==
 
 longest-streak@^2.0.0:
   version "2.0.4"


### PR DESCRIPTION
## Summary

**4 fixed, 0 ignored, 0 deferred, 0 resolutions added, 2 resolutions removed.**

All four open Dependabot alerts were on `lodash` / `lodash-es` at `4.17.23`; the fix is a single bump of the existing root-level resolutions to `^4.18.0` (which now resolves to `4.18.1` in `yarn.lock`). No alerts were deferred (all are 12+ days old, past the 7-day gate) and none qualified for any of the IGNORE reasons.

## Fixed

| # | Package | Ecosystem | From → To | Severity | What was bumped |
| --- | --- | --- | --- | --- | --- |
| 65 | `lodash-es` | npm | 4.17.23 → 4.18.1 | high | Existing root `resolutions["lodash-es"]` bumped from `^4.17.23` to `^4.18.0` |
| 66 | `lodash-es` | npm | 4.17.23 → 4.18.1 | medium | Same bump as #65 (same pinned chain) |
| 67 | `lodash` | npm | 4.17.23 → 4.18.1 | high | Existing root `resolutions["lodash"]` bumped from `^4.17.23` to `^4.18.0` |
| 68 | `lodash` | npm | 4.17.23 → 4.18.1 | medium | Same bump as #67 (same pinned chain) |

## Ignored

None.

## Deferred

None (all alerts are older than the 7-day gate).

## Resolutions added

None — both affected packages already had root-level `resolutions` entries; we only needed to raise the lower bound. The existing entries stayed unconditional at the root because `lodash`/`lodash-es` are pulled in via several unrelated chains (`semantic-release`, `@commitlint`, `@semantic-release/*`, `semantic-release-slack-bot`).

## Resolutions removed

Two existing entries were found to be redundant during the resolutions audit (removed, re-ran `yarn install`, verified `yarn why` still reports a version that satisfies the original pin's intent):

| File | Package + pinned range | Reason |
| --- | --- | --- |
| `package.json` | `js-yaml: ^4.1.1` | **Redundant.** Natural request range is `js-yaml@^4.1.0` from `cosmiconfig`. After removal and fresh install, `yarn why js-yaml` still reports `4.1.1` — the registry's latest `4.x` satisfies the original intent without the pin. |
| `package.json` | `ajv: ^8.18.0` | **Redundant.** Natural request range is `ajv@^8.11.0` from `@commitlint/config-validator`. After removal and fresh install, `yarn why ajv` still reports `8.18.0`. The pin is no longer doing anything — upstream has already moved. |

The `semantic-release-slack-bot/**/micromatch: ^4.0.8` entry was tested for removal too, but removal regresses `semantic-release-slack-bot#micromatch` to `4.0.2`, so it was **restored** — it is still load-bearing.

## Risks

- **lodash 4.17.23 → 4.18.1.** Upstream 4.18.x backports the two advisories patched here (`_.unset`/`_.omit` path-bypass, `_.template` imports key-name code injection) and contains no API changes. All call sites in this repo route through `semantic-release`, `@commitlint`, and friends — we don't import `lodash` directly.
- **lodash-es 4.17.23 → 4.18.1.** Same story as `lodash`; ESM variant, same patch contents, no consumer-facing API changes.
- **js-yaml / ajv resolution removals.** Post-install `yarn why` confirms the resolved versions are unchanged (`js-yaml@4.1.1`, `ajv@8.18.0`), so this is a no-op at runtime — it just removes stale pins from `package.json`.

No peer-dep bumps, no breaking majors, no test updates expected.

## Manual testing

Covered by CI.

## Validation

✅ CI green
