### PR TITLE
fix(polymorphic): skip pre-delete FK nullify when datasource cascades

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -237,6 +237,8 @@ Metrics/ParameterLists:
     - 'packages/forest_admin_datasource_customizer/lib/forest_admin_datasource_customizer/dsl/builders/form_builder.rb'
     - 'packages/forest_admin_datasource_mongoid/lib/forest_admin_datasource_mongoid/datasource.rb'
     - 'packages/forest_admin_datasource_toolkit/lib/forest_admin_datasource_toolkit/schema/relations/many_to_many_schema.rb'
+    - 'packages/forest_admin_datasource_toolkit/lib/forest_admin_datasource_toolkit/schema/relations/polymorphic_one_to_many_schema.rb'
+    - 'packages/forest_admin_datasource_toolkit/lib/forest_admin_datasource_toolkit/schema/relations/polymorphic_one_to_one_schema.rb'
     - 'packages/forest_admin_datasource_toolkit/lib/forest_admin_datasource_toolkit/schema/column_schema.rb'
     - 'packages/forest_admin_datasource_toolkit/lib/forest_admin_datasource_toolkit/components/caller.rb'
     - 'packages/forest_admin_datasource_toolkit/lib/forest_admin_datasource_toolkit/components/query/filter.rb'

--- a/packages/forest_admin_agent/lib/forest_admin_agent/routes/resources/delete.rb
+++ b/packages/forest_admin_agent/lib/forest_admin_agent/routes/resources/delete.rb
@@ -41,6 +41,7 @@ module ForestAdminAgent
 
           context.collection.schema[:fields].each_value do |field_schema|
             next unless ['PolymorphicOneToOne', 'PolymorphicOneToMany'].include?(field_schema.type)
+            next if field_schema.respond_to?(:cascade_on_delete) && field_schema.cascade_on_delete
 
             origin_values = selection_ids[:ids].map do |pk_hash|
               if pk_hash.is_a?(Hash)

--- a/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/resources/delete_spec.rb
+++ b/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/resources/delete_spec.rb
@@ -380,6 +380,105 @@ module ForestAdminAgent
               end
             end
           end
+
+          context 'with polymorphic relation that cascades on delete' do
+            before do
+              cache = FileCache.new('app', 'tmp/cache/forest_admin')
+              cache.clear
+
+              agent_factory = ForestAdminAgent::Builder::AgentFactory.instance
+              agent_factory.setup(
+                {
+                  auth_secret: 'cba803d01a4d43b55010cab41fa1ea1f1f51a95e',
+                  env_secret: '89719c6d8e2e2de2694c2f220fe2dbf02d5289487364daf1e4c6b13733ed0cdb',
+                  is_production: false,
+                  cache_dir: 'tmp/cache/forest_admin',
+                  schema_path: File.join('tmp', '.forestadmin-schema.json'),
+                  forest_server_url: 'https://api.development.forestadmin.com',
+                  debug: true,
+                  prefix: 'forest',
+                  customize_error_message: nil,
+                  append_schema_path: nil
+                }
+              )
+
+              feedback_class = Struct.new(:id, :body)
+              evidence_class = Struct.new(:id, :evidence_id, :evidence_type)
+              stub_const('Feedback', feedback_class)
+              stub_const('AchievementEvidence', evidence_class)
+
+              datasource = Datasource.new
+
+              feedback_collection = build_collection(
+                name: 'feedback',
+                schema: {
+                  fields: {
+                    'id' => ColumnSchema.new(
+                      column_type: 'Number',
+                      is_primary_key: true,
+                      filter_operators: [Operators::IN, Operators::EQUAL]
+                    ),
+                    'body' => ColumnSchema.new(column_type: 'String'),
+                    'achievement_evidences' => Relations::PolymorphicOneToManySchema.new(
+                      foreign_collection: 'achievement_evidence',
+                      origin_key: 'evidence_id',
+                      origin_key_target: 'id',
+                      origin_type_field: 'evidence_type',
+                      origin_type_value: 'Feedback',
+                      cascade_on_delete: true
+                    )
+                  }
+                },
+                delete: true
+              )
+
+              evidence_collection = build_collection(
+                name: 'achievement_evidence',
+                schema: {
+                  fields: {
+                    'id' => ColumnSchema.new(
+                      column_type: 'Number',
+                      is_primary_key: true,
+                      filter_operators: [Operators::IN, Operators::EQUAL]
+                    ),
+                    'evidence_id' => ColumnSchema.new(column_type: 'Number'),
+                    'evidence_type' => ColumnSchema.new(column_type: 'String')
+                  }
+                },
+                update: true
+              )
+
+              allow(agent_factory).to receive(:send_schema).and_return(nil)
+              datasource.add_collection(feedback_collection)
+              datasource.add_collection(evidence_collection)
+              agent_factory.add_datasource(datasource)
+              agent_factory.build
+
+              @datasource = ForestAdminAgent::Facades::Container.datasource
+              allow(@datasource.get_collection('feedback')).to receive(:delete)
+              allow(@datasource.get_collection('achievement_evidence')).to receive(:update)
+            end
+
+            let(:params) do
+              {
+                'collection_name' => 'feedback',
+                'timezone' => 'Europe/Paris',
+                'id' => 1
+              }
+            end
+
+            it 'does not nullify the polymorphic FK on the foreign collection' do
+              delete.handle_request(args)
+
+              expect(@datasource.get_collection('achievement_evidence')).not_to have_received(:update)
+            end
+
+            it 'still calls delete on the parent collection' do
+              delete.handle_request(args)
+
+              expect(@datasource.get_collection('feedback')).to have_received(:delete)
+            end
+          end
         end
       end
     end

--- a/packages/forest_admin_datasource_active_record/lib/forest_admin_datasource_active_record/collection.rb
+++ b/packages/forest_admin_datasource_active_record/lib/forest_admin_datasource_active_record/collection.rb
@@ -83,6 +83,10 @@ module ForestAdminDatasourceActiveRecord
       association.polymorphic?
     end
 
+    def cascade_on_delete?(association)
+      %i[destroy destroy_async delete_all].include?(association.options[:dependent])
+    end
+
     # rubocop:disable Metrics/BlockNesting
     def fetch_associations
       associations(@model, support_polymorphic_relations: @support_polymorphic_relations).each do |association|
@@ -118,7 +122,8 @@ module ForestAdminDatasourceActiveRecord
                   origin_key: association.foreign_key,
                   origin_key_target: association.association_primary_key,
                   origin_type_field: association.inverse_of.foreign_type,
-                  origin_type_value: @model.name
+                  origin_type_value: @model.name,
+                  cascade_on_delete: cascade_on_delete?(association)
                 )
               )
             else
@@ -192,7 +197,8 @@ module ForestAdminDatasourceActiveRecord
                   origin_key: association.foreign_key,
                   origin_key_target: association.association_primary_key,
                   origin_type_field: association.inverse_of.foreign_type,
-                  origin_type_value: @model.name
+                  origin_type_value: @model.name,
+                  cascade_on_delete: cascade_on_delete?(association)
                 )
               )
             else

--- a/packages/forest_admin_datasource_active_record/spec/lib/forest_admin_datasource_active_record/collection_spec.rb
+++ b/packages/forest_admin_datasource_active_record/spec/lib/forest_admin_datasource_active_record/collection_spec.rb
@@ -155,6 +155,18 @@ module ForestAdminDatasourceActiveRecord
           expect(datasource.get_collection('Address').schema[:fields].keys).to include('addressable')
         end
 
+        it 'sets cascade_on_delete=true on polymorphic has_many when dependent: :destroy is declared' do
+          members = datasource.get_collection('Project').schema[:fields]['members']
+          expect(members).to be_a(Relations::PolymorphicOneToManySchema)
+          expect(members.cascade_on_delete).to be true
+        end
+
+        it 'leaves cascade_on_delete=false on polymorphic has_one without dependent option' do
+          address = datasource.get_collection('User').schema[:fields]['address']
+          expect(address).to be_a(Relations::PolymorphicOneToOneSchema)
+          expect(address.cascade_on_delete).to be false
+        end
+
         it 'sets foreign_type_field/value for has_many :through with polymorphic source_type' do
           user_collection = datasource.get_collection('User')
           projects_relation = user_collection.schema[:fields]['projects']

--- a/packages/forest_admin_datasource_toolkit/lib/forest_admin_datasource_toolkit/schema/relations/polymorphic_one_to_many_schema.rb
+++ b/packages/forest_admin_datasource_toolkit/lib/forest_admin_datasource_toolkit/schema/relations/polymorphic_one_to_many_schema.rb
@@ -3,14 +3,16 @@ module ForestAdminDatasourceToolkit
     module Relations
       class PolymorphicOneToManySchema < RelationSchema
         attr_accessor :origin_key, :origin_type_value
-        attr_reader :origin_key_target, :origin_type_field
+        attr_reader :origin_key_target, :origin_type_field, :cascade_on_delete
 
-        def initialize(origin_key:, origin_key_target:, foreign_collection:, origin_type_field:, origin_type_value:)
+        def initialize(origin_key:, origin_key_target:, foreign_collection:, origin_type_field:, origin_type_value:,
+                       cascade_on_delete: false)
           super(foreign_collection, 'PolymorphicOneToMany')
           @origin_key = origin_key
           @origin_key_target = origin_key_target
           @origin_type_field = origin_type_field
           @origin_type_value = origin_type_value
+          @cascade_on_delete = cascade_on_delete
         end
       end
     end

--- a/packages/forest_admin_datasource_toolkit/lib/forest_admin_datasource_toolkit/schema/relations/polymorphic_one_to_one_schema.rb
+++ b/packages/forest_admin_datasource_toolkit/lib/forest_admin_datasource_toolkit/schema/relations/polymorphic_one_to_one_schema.rb
@@ -3,14 +3,16 @@ module ForestAdminDatasourceToolkit
     module Relations
       class PolymorphicOneToOneSchema < RelationSchema
         attr_accessor :origin_key, :origin_type_value
-        attr_reader :origin_key_target, :origin_type_field
+        attr_reader :origin_key_target, :origin_type_field, :cascade_on_delete
 
-        def initialize(origin_key:, origin_key_target:, foreign_collection:, origin_type_field:, origin_type_value:)
+        def initialize(origin_key:, origin_key_target:, foreign_collection:, origin_type_field:, origin_type_value:,
+                       cascade_on_delete: false)
           super(foreign_collection, 'PolymorphicOneToOne')
           @origin_key = origin_key
           @origin_key_target = origin_key_target
           @origin_type_field = origin_type_field
           @origin_type_value = origin_type_value
+          @cascade_on_delete = cascade_on_delete
         end
       end
     end

--- a/packages/forest_admin_datasource_toolkit/spec/lib/forest_admin_datasource_toolkit/schema/relations/polymorphic_one_to_many_schema_spec.rb
+++ b/packages/forest_admin_datasource_toolkit/spec/lib/forest_admin_datasource_toolkit/schema/relations/polymorphic_one_to_many_schema_spec.rb
@@ -21,6 +21,21 @@ module ForestAdminDatasourceToolkit
           it { expect(relation.origin_type_field).to eq 'origin_type_field' }
           it { expect(relation.origin_type_value).to eq 'origin_type_value' }
           it { expect(relation.foreign_collection).to eq 'foreign_collection' }
+          it { expect(relation.cascade_on_delete).to be false }
+        end
+
+        describe 'cascade_on_delete' do
+          it 'accepts an explicit cascade_on_delete value' do
+            relation = described_class.new(
+              origin_key: 'origin_key',
+              origin_key_target: 'origin_key_target',
+              origin_type_field: 'origin_type_field',
+              origin_type_value: 'origin_type_value',
+              foreign_collection: 'foreign_collection',
+              cascade_on_delete: true
+            )
+            expect(relation.cascade_on_delete).to be true
+          end
         end
       end
     end

--- a/packages/forest_admin_datasource_toolkit/spec/lib/forest_admin_datasource_toolkit/schema/relations/polymorphic_one_to_one_schema_spec.rb
+++ b/packages/forest_admin_datasource_toolkit/spec/lib/forest_admin_datasource_toolkit/schema/relations/polymorphic_one_to_one_schema_spec.rb
@@ -21,6 +21,21 @@ module ForestAdminDatasourceToolkit
           it { expect(relation.origin_type_field).to eq 'origin_type_field' }
           it { expect(relation.origin_type_value).to eq 'origin_type_value' }
           it { expect(relation.foreign_collection).to eq 'foreign_collection' }
+          it { expect(relation.cascade_on_delete).to be false }
+        end
+
+        describe 'cascade_on_delete' do
+          it 'accepts an explicit cascade_on_delete value' do
+            relation = described_class.new(
+              origin_key: 'origin_key',
+              origin_key_target: 'origin_key_target',
+              origin_type_field: 'origin_type_field',
+              origin_type_value: 'origin_type_value',
+              foreign_collection: 'foreign_collection',
+              cascade_on_delete: true
+            )
+            expect(relation.cascade_on_delete).to be true
+          end
         end
       end
     end


### PR DESCRIPTION
## Summary

Fixes #289. The agent's `delete_records` action pre-emptively `UPDATE`s polymorphic child rows to `NULL` both the FK id and type column **before** issuing the parent delete. For ActiveRecord parents that declare `dependent: :destroy`, this breaks deletion entirely:

- Rails 5+ `belongs_to :foo, polymorphic: true` adds a presence validator → the UPDATE fails with `Validation failed: <relation> must exist`.
- A `null: false` FK column → the UPDATE violates the NOT NULL constraint.
- Even when the FK is nullable, the manual nullify defeats `dependent: :destroy`: by the time Rails' destroy callback runs, its `WHERE notable_id = ? AND notable_type = ?` matches zero rows, silently orphaning the children.

The reporter showed the bug works correctly from the Rails console (Rails handles the cascade), but fails through Forest because of this pre-delete UPDATE.

## Fix

Plumb a `cascade_on_delete` flag through to the polymorphic schemas; when true, the agent skips its manual nullify and lets the datasource handle the cascade itself.

- **Toolkit** — added `cascade_on_delete` (default `false`) to `PolymorphicOneToManySchema` and `PolymorphicOneToOneSchema`. The flag rides through the RPC layer for free (`**schema` reconstruction + `.to_json` serializer dumps all instance vars).
- **AR datasource** — sets `cascade_on_delete: true` when the association declares `dependent: :destroy`, `:destroy_async`, or `:delete_all`.
- **Agent route** — `delete_records` skips the polymorphic-cleanup loop body when `field_schema.cascade_on_delete` is truthy. Guarded with `respond_to?` for compat with anything the customizer might inject.

Mongoid / Snowflake / RPC keep the existing behavior (`cascade_on_delete` defaults to false, so the manual cleanup still runs).

## Test plan

- [x] `forest_admin_datasource_toolkit` rspec — 463 examples, 0 failures (added defaults + explicit-flag specs on both schemas)
- [x] `forest_admin_datasource_active_record` rspec — 147 examples, 0 failures (added: `cascade_on_delete=true` for `Project.has_many :members, as: :memberable, dependent: :destroy`; `=false` for `User.has_one :address, as: :addressable`)
- [x] `forest_admin_agent` rspec — 683 examples, 0 failures (new `with polymorphic relation that cascades on delete` context: foreign collection's `update` is NOT called, parent `delete` still is)
- [x] `forest_admin_datasource_rpc` rspec — 160 examples, 0 failures (sanity: schema round-trips through RPC unchanged)
- [x] End-to-end repro against a Rails 8.1 / PG 15 app: a `Customer` with `has_many :notes, as: :notable, dependent: :destroy` and `notable_id`/`notable_type` `null: false` — delete now performs the same SQL as `customer.destroy!` (children deleted via cascade, then parent), instead of erroring on the nullify.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Skip FK nullification before delete for polymorphic relations when datasource cascades
> - Adds a `cascade_on_delete` flag (default `false`) to `PolymorphicOneToManySchema` and `PolymorphicOneToOneSchema` in the toolkit.
> - The ActiveRecord datasource sets this flag based on the association's `dependent` option (`:destroy`, `:destroy_async`, or `:delete_all`) via a new `cascade_on_delete?` helper in [`Collection`](https://github.com/ForestAdmin/agent-ruby/pull/291/files#diff-394937cf0ee68635c26a0af527b70b25e67ac962f1137a31cb25f490e36c686f).
> - The delete route in [`Delete#delete_records`](https://github.com/ForestAdmin/agent-ruby/pull/291/files#diff-146db32b6d7a7192178c2bdb7ddedb09860d103a5985db4b0bcafabd99d21114) now skips the pre-delete FK nullify step for polymorphic relations when `cascade_on_delete` is `true`, avoiding redundant or conflicting updates before the DB cascade fires.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 198e837.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->