### PR TITLE
chore(security): remove 2 redundant resolutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,6 @@
     "semantic-release-slack-bot": "4.0.2"
   },
   "resolutions": {
-    "semantic-release-slack-bot/**/micromatch": "^4.0.8",
-    "lodash": "^4.18.0",
-    "lodash-es": "^4.18.0"
-  } 
+    "semantic-release-slack-bot/**/micromatch": "^4.0.8"
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2268,7 +2268,7 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
-lodash-es@^4.17.21, lodash-es@^4.18.0:
+lodash-es@^4.17.21:
   version "4.18.1"
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.18.1.tgz#b962eeb80d9d983a900bf342961fb7418ca10b1d"
   integrity sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==
@@ -2343,7 +2343,7 @@ lodash.upperfirst@^4.3.1:
   resolved "https://registry.yarnpkg.com/lodash.upperfirst/-/lodash.upperfirst-4.3.1.tgz#1365edf431480481ef0d1c68957a5ed99d49f7ce"
   integrity sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==
 
-lodash@^4.17.15, lodash@^4.17.4, lodash@^4.18.0:
+lodash@^4.17.15, lodash@^4.17.4:
   version "4.18.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.18.1.tgz#ff2b66c1f6326d59513de2407bf881439812771c"
   integrity sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==


### PR DESCRIPTION
## Summary
0 fixed, 0 ignored, 0 deferred, 0 resolutions added, 2 resolutions removed. | label: :lock: security applied

No open Dependabot alerts at the time of this run — shipping for resolution hygiene only.

## Fixed
None — no open alerts.

## Ignored
None.

## Deferred
None.

## Resolutions added
None.

## Resolutions removed
| File | Pinned package + version | Reason |
| --- | --- | --- |
| `package.json` | `lodash: ^4.18.0` | Redundant. `@semantic-release/changelog`, `@semantic-release/git`, and `@commitlint/cli` declare `lodash: ^4.17.4`; with the entry removed, `yarn install` still resolves `lodash@4.18.1` (verified via `yarn why lodash`). |
| `package.json` | `lodash-es: ^4.18.0` | Redundant. `@semantic-release/exec` declares `lodash-es: ^4.17.21`; with the entry removed, `yarn install` still resolves `lodash-es@4.18.1` (verified via `yarn why lodash-es`). |

`semantic-release-slack-bot/**/micromatch: ^4.0.8` was tested and **kept** — without it, `semantic-release-slack-bot@4.0.2` pins `micromatch@4.0.2`, below the patched range for [GHSA-952p-6rrq-rcjv](https://github.com/advisories/GHSA-952p-6rrq-rcjv) (ReDoS, fixed in 4.0.8).

## Risks
No behavior change. Resolved versions of `lodash` (4.18.1), `lodash-es` (4.18.1), and `micromatch` (4.0.8) are all unchanged in `yarn.lock` — verified via `yarn why <pkg>` after the install. The package.json entries were redundant pins, not active overrides.

## Manual testing
Covered by CI.

## Validation
✅ CI green
