### PR TITLE
fix(rpc-agent): qualify Decorators namespace in datasource customizer

### DIFF
--- a/packages/forest_admin_rpc_agent/lib/forest_admin_rpc_agent/datasource_customizer.rb
+++ b/packages/forest_admin_rpc_agent/lib/forest_admin_rpc_agent/datasource_customizer.rb
@@ -3,15 +3,16 @@ module ForestAdminRpcAgent
     def add_datasource(datasource, options)
       @stack.queue_customization(lambda {
         if options[:include] || options[:exclude]
-          publication_decorator = Decorators::Publication::PublicationDatasourceDecorator.new(datasource)
+          publication_decorator = ForestAdminDatasourceCustomizer::Decorators::Publication::PublicationDatasourceDecorator.new(datasource)
           publication_decorator.keep_collections_matching(options[:include], options[:exclude])
           datasource = publication_decorator
         end
 
         if options[:rename]
-          rename_collection_decorator = Decorators::RenameCollection::RenameCollectionDatasourceDecorator.new(
-            datasource
-          )
+          rename_collection_decorator =
+            ForestAdminDatasourceCustomizer::Decorators::RenameCollection::RenameCollectionDatasourceDecorator.new(
+              datasource
+            )
           rename_collection_decorator.rename_collections(options[:rename])
           datasource = rename_collection_decorator
         end


### PR DESCRIPTION
## Summary

`ForestAdminRpcAgent::DatasourceCustomizer#add_datasource` overrides its parent to add the `mark_collections_callback` hook, but the override re-uses the unqualified `Decorators::Publication::...` / `Decorators::RenameCollection::...` constants from the parent's body verbatim. The parent class lives in `ForestAdminDatasourceCustomizer`, where those constants resolve via `ForestAdminDatasourceCustomizer::Decorators::...`. The override lives in `ForestAdminRpcAgent`, where there is no `Decorators` module — so the same identifiers fail to resolve.

The result: any leaf RPC agent calling `agent.add_datasource(ds, include: [...])`, `exclude: [...]`, or `rename: [...]` crashes at boot with `uninitialized constant ForestAdminRpcAgent::DatasourceCustomizer::Decorators (NameError)`. Without those options the path is never hit, so the bug stayed silent until now.

## Fix

Fully qualify both constants:

- `Decorators::Publication::PublicationDatasourceDecorator` → `ForestAdminDatasourceCustomizer::Decorators::Publication::PublicationDatasourceDecorator`
- `Decorators::RenameCollection::RenameCollectionDatasourceDecorator` → `ForestAdminDatasourceCustomizer::Decorators::RenameCollection::RenameCollectionDatasourceDecorator`

Two-line constant change. No behavioural change for callers that don't pass these options.

## Test plan

- [ ] `cd packages/forest_admin_rpc_agent && BUNDLE_GEMFILE=Gemfile-test bundle exec rspec` passes (105 examples, 0 failures — verified locally)
- [ ] `bundle exec rubocop` clean
- [ ] Smoke test in a real leaf RPC agent: `agent.add_datasource(some_ds, include: ['SomeCollection'])` boots without raising and the resulting RPC schema only exposes the included collection (verified locally against the Snowflake datasource)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Qualify Decorators namespace references in `DatasourceCustomizer#add_datasource`
> Fixes unqualified `Decorators::` references in [`datasource_customizer.rb`](https://github.com/ForestAdmin/agent-ruby/pull/295/files#diff-5011dbf24f09ad9fe45585dd8f4264585ec5989ac98c92a8d266cd86a34316fd) by prefixing them with `ForestAdminDatasourceCustomizer::`. This ensures `PublicationDatasourceDecorator` and `RenameCollectionDatasourceDecorator` resolve to the correct namespace when called from the `ForestAdminRpcAgent` context.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d7ce117.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->