### PR TITLE
fix(zendesk): align version.rb with semantic-release sed pattern

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -108,6 +108,7 @@ Style/MutableConstant:
     - 'packages/forest_admin_test_toolkit/lib/forest_admin_test_toolkit/version.rb'
     - 'packages/forest_admin_datasource_customizer/lib/forest_admin_datasource_customizer/version.rb'
     - 'packages/forest_admin_datasource_active_record/lib/forest_admin_datasource_active_record/version.rb'
+    - 'packages/forest_admin_datasource_zendesk/lib/forest_admin_datasource_zendesk/version.rb'
 
 # Offense count: 38
 # This cop supports safe autocorrection (--autocorrect).
@@ -188,6 +189,7 @@ Style/StringLiterals:
     - 'packages/forest_admin_datasource_active_record/lib/forest_admin_datasource_active_record.rb'
     - 'packages/forest_admin_datasource_active_record/lib/forest_admin_datasource_active_record/version.rb'
     - 'packages/forest_admin_datasource_active_record/spec/spec_helper.rb'
+    - 'packages/forest_admin_datasource_zendesk/lib/forest_admin_datasource_zendesk/version.rb'
 
 # Offense count: 1
 # This cop supports safe autocorrection (--autocorrect).

--- a/packages/forest_admin_datasource_zendesk/lib/forest_admin_datasource_zendesk/version.rb
+++ b/packages/forest_admin_datasource_zendesk/lib/forest_admin_datasource_zendesk/version.rb
@@ -1,3 +1,3 @@
 module ForestAdminDatasourceZendesk
-  VERSION = '0.1.0'.freeze
+  VERSION = "1.28.0"
 end


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Fix `VERSION` constant in Zendesk datasource to match semantic-release sed pattern
The `VERSION` constant in [`version.rb`](https://github.com/ForestAdmin/agent-ruby/pull/296/files#diff-1777d1317ac13e4ddf700f43ad4d4bcf9d59bc1a3c45727417fcde3863f640dd) is rewritten as a bare string literal without `.freeze`, so the semantic-release sed pattern can update it correctly during releases. The file is also excluded from the `Style/MutableConstant` and `Style/StringLiterals` RuboCop cops in [`.rubocop.yml`](https://github.com/ForestAdmin/agent-ruby/pull/296/files#diff-4f894049af3375c2bd4e608f546f8d4a0eed95464efcdea850993200db9fef5c) to suppress the resulting offenses.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 614a9b0.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->