### PR TITLE
fix(rpc): prevent race condition on agent reload

### DIFF
--- a/packages/forest_admin_agent/lib/forest_admin_agent/builder/agent_factory.rb
+++ b/packages/forest_admin_agent/lib/forest_admin_agent/builder/agent_factory.rb
@@ -13,6 +13,11 @@ module ForestAdminAgent
       attr_reader :customizer, :container, :has_env_secret
       attr_accessor :schema_only_mode
 
+      def initialize
+        super
+        @reloading = false
+      end
+
       def setup(options)
         @options = options
         @has_env_secret = options.to_h.key?(:env_secret)
@@ -75,6 +80,14 @@ module ForestAdminAgent
       end
 
       def reload!
+        if @reloading
+          @logger.log('Info', 'Agent is already reloading. Do nothing.')
+          return
+        end
+
+        @reloading = true
+        @logger.log('Info', 'Agent is reloading...')
+
         begin
           @customizer.reload!(logger: @logger)
         rescue StandardError => e
@@ -89,6 +102,8 @@ module ForestAdminAgent
         @logger.log('Info', 'route cache cleared due to agent reload')
 
         send_schema
+      ensure
+        @reloading = false
       end
 
       def send_schema(force: false)

--- a/packages/forest_admin_agent/spec/lib/forest_admin_agent/builder/agent_factory_spec.rb
+++ b/packages/forest_admin_agent/spec/lib/forest_admin_agent/builder/agent_factory_spec.rb
@@ -160,6 +160,64 @@ module ForestAdminAgent
             expect(instance.container).not_to have_received(:register)
             expect(instance).not_to have_received(:send_schema)
           end
+
+          it 'skips reload if another reload is already in progress' do
+            instance = described_class.instance
+
+            logger = instance_spy(Services::LoggerService)
+            instance.instance_variable_set(:@logger, logger)
+
+            # Simulate a long-running reload by blocking inside customizer.reload!
+            reload_started = Queue.new
+            proceed = Queue.new
+
+            allow(instance.customizer).to receive(:reload!) do
+              reload_started << true
+              proceed.pop
+            end
+            allow(instance).to receive(:send_schema)
+
+            first_thread = Thread.new { instance.reload! }
+            reload_started.pop # wait until the first reload is inside customizer.reload!
+
+            # Second reload should be skipped
+            instance.reload!
+
+            expect(logger).to have_received(:log).with('Info', 'Agent is already reloading. Do nothing.')
+
+            proceed << true # unblock first reload
+            first_thread.join
+          end
+
+          it 'allows a new reload after the previous one completes' do
+            instance = described_class.instance
+
+            allow(instance.customizer).to receive(:reload!)
+            allow(instance).to receive(:send_schema)
+
+            instance.reload!
+            instance.reload!
+
+            expect(instance.customizer).to have_received(:reload!).twice
+          end
+
+          it 'resets the reloading flag even when an error occurs' do
+            instance = described_class.instance
+
+            logger = instance_spy(Services::LoggerService)
+            instance.instance_variable_set(:@logger, logger)
+
+            allow(instance.customizer).to receive(:reload!).and_raise(StandardError.new('Boom'))
+            allow(instance).to receive(:send_schema)
+
+            instance.reload!
+
+            # Should allow a subsequent reload (flag was reset despite the error)
+            allow(instance.customizer).to receive(:reload!)
+            instance.reload!
+
+            expect(instance.customizer).to have_received(:reload!).twice
+          end
         end
 
         describe 'send_schema' do


### PR DESCRIPTION
## Definition of Done

### General

- [ ] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [ ] Test manually the implemented changes
- [ ] Validate the code quality (indentation, syntax, style, simplicity, readability)

### Security

- [ ] Consider the security impact of the changes made


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix race condition in `AgentFactory#reload!` with re-entrancy guard
> - Adds a `@reloading` flag to `AgentFactory` that prevents concurrent reloads: if `reload!` is called while a reload is in progress, it logs an info message and returns immediately.
> - The flag is reset in an `ensure` block so subsequent reloads are always allowed, even after an error.
> - On error, the datasource replacement and schema send are skipped, matching existing error-handling behavior.
> - New specs in [agent_factory_spec.rb](https://github.com/ForestAdmin/agent-ruby/pull/297/files#diff-cb4acd2e6ea1ac2f75e0089e6f71d4aa6bea0108aa793a89a79708282932d17e) cover concurrent reload suppression, post-completion re-entry, and flag reset after failure.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 910e5ec.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->