### PR TITLE
chore(deps): align rubocop version across the monorepo

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -59,6 +59,24 @@ Lint/EmptyFile:
   Exclude:
     - 'packages/forest_admin_rails/app/models/forest_admin_rails/application_record.rb'
 
+Lint/InterpolationCheck:
+  Exclude:
+    - 'packages/forest_admin_agent/spec/lib/forest_admin_agent/http/error_translator_spec.rb'
+    - 'packages/forest_admin_rails/lib/generators/forest_admin_rails/install_generator.rb'
+
+Naming/MethodName:
+  Exclude:
+    - 'packages/forest_admin_datasource_toolkit/spec/lib/forest_admin_datasource_toolkit/utils/collection_spec.rb'
+
+Style/OneClassPerFile:
+  Exclude:
+    - 'packages/forest_admin_rails/lib/forest_admin_rails/engine.rb'
+
+Style/SelectByKind:
+  Exclude:
+    - 'packages/forest_admin_agent/lib/forest_admin_agent/utils/schema/frontend_validation_utils.rb'
+    - 'packages/forest_admin_datasource_customizer/lib/forest_admin_datasource_customizer/decorators/empty/empty_collection_decorator.rb'
+
 Metrics/AbcSize:
   Enabled: false
 
@@ -425,10 +443,6 @@ Lint/DuplicateBranch:
     - 'packages/forest_admin_datasource_active_record/lib/forest_admin_datasource_active_record/utils/error_handler.rb'
 
 Style/PercentLiteralDelimiters:
-  Exclude:
-    - 'packages/forest_admin_rails/lib/generators/forest_admin_rails/install_generator.rb'
-
-Lint/InterpolationCheck:
   Exclude:
     - 'packages/forest_admin_rails/lib/generators/forest_admin_rails/install_generator.rb'
 

--- a/Gemfile
+++ b/Gemfile
@@ -5,9 +5,9 @@ gemspec
 group :development, :tests do
   gem "overcommit", "~> 0.60"
   gem "rspec", "~> 3.0"
-  gem "rubocop", "1.77"
-  gem "rubocop-performance", "1.25.0"
-  gem "rubocop-rspec", "3.5.0"
+  gem "rubocop", "1.86.1"
+  gem "rubocop-performance", "1.26.1"
+  gem "rubocop-rspec", "3.9.0"
   gem 'simplecov', "~> 0.22", require: false
   gem 'simplecov_json_formatter', "~> 0.1.4"
 end

--- a/packages/forest_admin_agent/Gemfile
+++ b/packages/forest_admin_agent/Gemfile
@@ -7,6 +7,9 @@ group :development, :test do
   gem 'forest_admin_datasource_toolkit', path: '../forest_admin_datasource_toolkit'
   gem 'forest_admin_test_toolkit', path: '../forest_admin_test_toolkit'
   gem 'rspec', '~> 3.0'
+  gem 'rubocop', '1.86.1'
+  gem 'rubocop-performance', '1.26.1'
+  gem 'rubocop-rspec', '3.9.0'
   gem 'simplecov', '~> 0.22', require: false
   gem 'simplecov-html', '~> 0.12.3'
   gem 'simplecov_json_formatter', '~> 0.1.4'

--- a/packages/forest_admin_agent/Gemfile-test
+++ b/packages/forest_admin_agent/Gemfile-test
@@ -7,6 +7,9 @@ group :development, :test do
   gem 'forest_admin_datasource_toolkit', path: '../forest_admin_datasource_toolkit'
   gem 'forest_admin_test_toolkit', path: '../forest_admin_test_toolkit'
   gem 'rspec', '~> 3.0'
+  gem 'rubocop', '1.86.1'
+  gem 'rubocop-performance', '1.26.1'
+  gem 'rubocop-rspec', '3.9.0'
   gem 'simplecov', '~> 0.22', require: false
   gem 'simplecov-html', '~> 0.12.3'
   gem 'simplecov_json_formatter', '~> 0.1.4'

--- a/packages/forest_admin_agent/lib/forest_admin_agent/routes/resources/related/count_related.rb
+++ b/packages/forest_admin_agent/lib/forest_admin_agent/routes/resources/related/count_related.rb
@@ -8,6 +8,7 @@ module ForestAdminAgent
           include ForestAdminAgent::Builder
           include ForestAdminDatasourceToolkit::Utils
           include ForestAdminDatasourceToolkit::Components::Query
+
           def setup_routes
             add_route(
               'forest_related_count',

--- a/packages/forest_admin_agent/lib/forest_admin_agent/routes/resources/related/dissociate_related.rb
+++ b/packages/forest_admin_agent/lib/forest_admin_agent/routes/resources/related/dissociate_related.rb
@@ -8,6 +8,7 @@ module ForestAdminAgent
           include ForestAdminAgent::Builder
           include ForestAdminDatasourceToolkit::Utils
           include ForestAdminDatasourceToolkit::Components::Query
+
           def setup_routes
             add_route(
               'forest_related_dissociate',

--- a/packages/forest_admin_agent/lib/forest_admin_agent/routes/resources/show.rb
+++ b/packages/forest_admin_agent/lib/forest_admin_agent/routes/resources/show.rb
@@ -8,6 +8,7 @@ module ForestAdminAgent
         include ForestAdminAgent::Builder
         include ForestAdminAgent::Utils
         include ForestAdminDatasourceToolkit::Components::Query
+
         def setup_routes
           add_route('forest_show', 'get', '/:collection_name/:id', ->(args) { handle_request(args) })
 

--- a/packages/forest_admin_agent/lib/forest_admin_agent/routes/resources/store.rb
+++ b/packages/forest_admin_agent/lib/forest_admin_agent/routes/resources/store.rb
@@ -7,6 +7,7 @@ module ForestAdminAgent
       class Store < AbstractAuthenticatedRoute
         include ForestAdminAgent::Builder
         include ForestAdminDatasourceToolkit::Components::Query
+
         def setup_routes
           add_route('forest_store', 'post', '/:collection_name', ->(args) { handle_request(args) })
 

--- a/packages/forest_admin_agent/lib/forest_admin_agent/routes/security/scope_invalidation.rb
+++ b/packages/forest_admin_agent/lib/forest_admin_agent/routes/security/scope_invalidation.rb
@@ -4,6 +4,7 @@ module ForestAdminAgent
       class ScopeInvalidation < AbstractRoute
         include ForestAdminAgent::Builder
         include ForestAdminAgent::Services
+
         def setup_routes
           add_route(
             'forest_scope_invalidation',

--- a/packages/forest_admin_agent/lib/forest_admin_agent/routes/system/health_check.rb
+++ b/packages/forest_admin_agent/lib/forest_admin_agent/routes/system/health_check.rb
@@ -3,6 +3,7 @@ module ForestAdminAgent
     module System
       class HealthCheck < AbstractRoute
         include ForestAdminAgent::Builder
+
         def setup_routes
           add_route('forest', 'GET', '/', ->(args) { handle_request(args) })
 

--- a/packages/forest_admin_agent/spec/lib/forest_admin_agent/auth/oauth2/forest_provider_spec.rb
+++ b/packages/forest_admin_agent/spec/lib/forest_admin_agent/auth/oauth2/forest_provider_spec.rb
@@ -5,6 +5,7 @@ module ForestAdminAgent
   module Auth
     module OAuth2
       include ForestAdminAgent::Utils
+
       describe ForestProvider do
         let(:rendering_id) { 10 }
         let(:attributes) do

--- a/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/capabilities/collections_spec.rb
+++ b/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/capabilities/collections_spec.rb
@@ -7,6 +7,7 @@ module ForestAdminAgent
       include ForestAdminDatasourceToolkit::Components::Query::ConditionTree
       include ForestAdminDatasourceToolkit::Schema
       include ForestAdminDatasourceToolkit::Schema::Relations
+
       describe Collections do
         include_context 'with caller'
         subject(:capabilities_collections) { described_class.new }

--- a/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/resources/count_spec.rb
+++ b/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/resources/count_spec.rb
@@ -8,6 +8,7 @@ module ForestAdminAgent
       include ForestAdminDatasourceToolkit
       include ForestAdminDatasourceToolkit::Schema
       include ForestAdminDatasourceToolkit::Components::Query::ConditionTree::Nodes
+
       describe Count do
         include_context 'with caller'
         subject(:count) { described_class.new }

--- a/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/resources/csv_spec.rb
+++ b/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/resources/csv_spec.rb
@@ -10,6 +10,7 @@ module ForestAdminAgent
       include ForestAdminDatasourceToolkit
       include ForestAdminDatasourceToolkit::Components::Query::ConditionTree
       include ForestAdminDatasourceToolkit::Schema
+
       describe Csv do
         include_context 'with caller'
         subject(:csv) { described_class.new }

--- a/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/resources/delete_spec.rb
+++ b/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/resources/delete_spec.rb
@@ -8,6 +8,7 @@ module ForestAdminAgent
       include ForestAdminDatasourceToolkit
       include ForestAdminDatasourceToolkit::Components::Query::ConditionTree
       include ForestAdminDatasourceToolkit::Schema
+
       describe Delete do
         include_context 'with caller'
         subject(:delete) { described_class.new }

--- a/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/resources/related/associate_related_spec.rb
+++ b/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/resources/related/associate_related_spec.rb
@@ -11,6 +11,7 @@ module ForestAdminAgent
         include ForestAdminDatasourceToolkit
         include ForestAdminDatasourceToolkit::Schema
         include ForestAdminDatasourceToolkit::Components::Query::ConditionTree
+
         describe AssociateRelated do
           include_context 'with caller'
           subject(:associate) { described_class.new }

--- a/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/resources/related/count_related_spec.rb
+++ b/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/resources/related/count_related_spec.rb
@@ -11,6 +11,7 @@ module ForestAdminAgent
         include ForestAdminDatasourceToolkit
         include ForestAdminDatasourceToolkit::Schema
         include ForestAdminDatasourceToolkit::Components::Query::ConditionTree
+
         describe CountRelated do
           include_context 'with caller'
           subject(:count) { described_class.new }

--- a/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/resources/related/csv_related_spec.rb
+++ b/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/resources/related/csv_related_spec.rb
@@ -11,6 +11,7 @@ module ForestAdminAgent
         include ForestAdminDatasourceToolkit
         include ForestAdminDatasourceToolkit::Schema
         include ForestAdminDatasourceToolkit::Components::Query::ConditionTree
+
         describe CsvRelated do
           include_context 'with caller'
           subject(:csv) { described_class.new }

--- a/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/resources/related/dissociate_related_spec.rb
+++ b/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/resources/related/dissociate_related_spec.rb
@@ -7,6 +7,7 @@ module ForestAdminAgent
         include ForestAdminDatasourceToolkit
         include ForestAdminDatasourceToolkit::Schema
         include ForestAdminDatasourceToolkit::Components::Query::ConditionTree
+
         describe DissociateRelated do
           include_context 'with caller'
           subject(:dissociate) { described_class.new }

--- a/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/resources/related/list_related_spec.rb
+++ b/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/resources/related/list_related_spec.rb
@@ -11,6 +11,7 @@ module ForestAdminAgent
         include ForestAdminDatasourceToolkit
         include ForestAdminDatasourceToolkit::Schema
         include ForestAdminDatasourceToolkit::Components::Query::ConditionTree
+
         describe ListRelated do
           include_context 'with caller'
           subject(:list) { described_class.new }

--- a/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/resources/related/update_related_spec.rb
+++ b/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/resources/related/update_related_spec.rb
@@ -7,6 +7,7 @@ module ForestAdminAgent
         include ForestAdminDatasourceToolkit
         include ForestAdminDatasourceToolkit::Schema
         include ForestAdminDatasourceToolkit::Components::Query::ConditionTree
+
         describe UpdateRelated do
           include_context 'with caller'
           subject(:update) { described_class.new }

--- a/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/resources/show_spec.rb
+++ b/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/resources/show_spec.rb
@@ -8,6 +8,7 @@ module ForestAdminAgent
       include ForestAdminDatasourceToolkit
       include ForestAdminDatasourceToolkit::Schema
       include ForestAdminDatasourceToolkit::Components::Query::ConditionTree
+
       describe Show do
         include_context 'with caller'
         subject(:show) { described_class.new }

--- a/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/resources/store_spec.rb
+++ b/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/resources/store_spec.rb
@@ -8,6 +8,7 @@ module ForestAdminAgent
       include ForestAdminDatasourceToolkit
       include ForestAdminDatasourceToolkit::Components::Query::ConditionTree
       include ForestAdminDatasourceToolkit::Schema
+
       describe Store do
         include_context 'with caller'
         subject(:store) { described_class.new }

--- a/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/resources/update_spec.rb
+++ b/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/resources/update_spec.rb
@@ -8,6 +8,7 @@ module ForestAdminAgent
       include ForestAdminDatasourceToolkit
       include ForestAdminDatasourceToolkit::Components::Query::ConditionTree
       include ForestAdminDatasourceToolkit::Schema
+
       describe Update do
         include_context 'with caller'
         subject(:update) { described_class.new }

--- a/packages/forest_admin_agent/spec/lib/forest_admin_agent/utils/csv_generator_spec.rb
+++ b/packages/forest_admin_agent/spec/lib/forest_admin_agent/utils/csv_generator_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 module ForestAdminAgent
   module Utils
     include ForestAdminDatasourceToolkit::Components::Query
+
     describe CsvGenerator do
       let(:projection) { Projection.new(%w[id last_name first_name email active created_at updated_at address:planet]) }
       let(:records) do

--- a/packages/forest_admin_agent/spec/lib/forest_admin_agent/utils/csv_generator_stream_spec.rb
+++ b/packages/forest_admin_agent/spec/lib/forest_admin_agent/utils/csv_generator_stream_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 module ForestAdminAgent
   module Utils
     include ForestAdminDatasourceToolkit::Components::Query
+
     describe CsvGeneratorStream do
       let(:projection) { Projection.new(%w[id first_name last_name]) }
       let(:filter) { Filter.new }

--- a/packages/forest_admin_agent/spec/lib/forest_admin_agent/utils/id_spec.rb
+++ b/packages/forest_admin_agent/spec/lib/forest_admin_agent/utils/id_spec.rb
@@ -97,9 +97,11 @@ module ForestAdminAgent
                 parent_association_name: nil,
                 all_records: true,
                 all_records_subset_query: [
-                  'fields[Car]' => 'id,first_name,last_name',
-                  'page[number]' => 1,
-                  'page[size]' => 15
+                  {
+                    'fields[Car]' => 'id,first_name,last_name',
+                    'page[number]' => 1,
+                    'page[size]' => 15
+                  }
                 ],
                 all_records_ids_excluded: ['4'],
                 smart_action_id: nil
@@ -122,9 +124,11 @@ module ForestAdminAgent
                 parent_association_name: nil,
                 all_records: false,
                 all_records_subset_query: [
-                  'fields[Car]' => 'id,first_name,last_name',
-                  'page[number]' => 1,
-                  'page[size]' => 15
+                  {
+                    'fields[Car]' => 'id,first_name,last_name',
+                    'page[number]' => 1,
+                    'page[size]' => 15
+                  }
                 ],
                 all_records_ids_excluded: ['4'],
                 smart_action_id: nil

--- a/packages/forest_admin_agent/spec/lib/forest_admin_agent/utils/query_validator_spec.rb
+++ b/packages/forest_admin_agent/spec/lib/forest_admin_agent/utils/query_validator_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 module ForestAdminAgent
   module Utils
     include ForestAdminDatasourceToolkit::Exceptions
+
     describe QueryValidator do
       describe 'valid queries' do
         it 'allows a simple SELECT query' do

--- a/packages/forest_admin_agent/spec/lib/forest_admin_agent/utils/schema/generator_collection_spec.rb
+++ b/packages/forest_admin_agent/spec/lib/forest_admin_agent/utils/schema/generator_collection_spec.rb
@@ -5,6 +5,7 @@ module ForestAdminAgent
     module Schema
       include ForestAdminDatasourceToolkit
       include ForestAdminDatasourceToolkit::Schema
+
       describe GeneratorCollection do
         before do
           @datasource = Datasource.new

--- a/packages/forest_admin_agent/spec/lib/forest_admin_agent/utils/schema/generator_field_many_to_many_spec.rb
+++ b/packages/forest_admin_agent/spec/lib/forest_admin_agent/utils/schema/generator_field_many_to_many_spec.rb
@@ -5,6 +5,7 @@ module ForestAdminAgent
     module Schema
       include ForestAdminDatasourceToolkit
       include ForestAdminDatasourceToolkit::Schema
+
       describe GeneratorField do
         context 'when field is OneToMany relation' do
           before do

--- a/packages/forest_admin_agent/spec/lib/forest_admin_agent/utils/schema/generator_field_one_to_many_spec.rb
+++ b/packages/forest_admin_agent/spec/lib/forest_admin_agent/utils/schema/generator_field_one_to_many_spec.rb
@@ -5,6 +5,7 @@ module ForestAdminAgent
     module Schema
       include ForestAdminDatasourceToolkit
       include ForestAdminDatasourceToolkit::Schema
+
       describe GeneratorField do
         context 'when field is OneToMany relation' do
           before do

--- a/packages/forest_admin_agent/spec/lib/forest_admin_agent/utils/schema/generator_field_one_to_one_spec.rb
+++ b/packages/forest_admin_agent/spec/lib/forest_admin_agent/utils/schema/generator_field_one_to_one_spec.rb
@@ -5,6 +5,7 @@ module ForestAdminAgent
     module Schema
       include ForestAdminDatasourceToolkit
       include ForestAdminDatasourceToolkit::Schema
+
       describe GeneratorField do
         context 'when field is OneToOne relation' do
           before do

--- a/packages/forest_admin_agent/spec/lib/forest_admin_agent/utils/schema/generator_field_polymorphic_spec.rb
+++ b/packages/forest_admin_agent/spec/lib/forest_admin_agent/utils/schema/generator_field_polymorphic_spec.rb
@@ -5,6 +5,7 @@ module ForestAdminAgent
     module Schema
       include ForestAdminDatasourceToolkit
       include ForestAdminDatasourceToolkit::Schema
+
       describe GeneratorField do
         context 'when field is polymorphic relation' do
           before do

--- a/packages/forest_admin_agent/spec/lib/forest_admin_agent/utils/schema/generator_field_spec.rb
+++ b/packages/forest_admin_agent/spec/lib/forest_admin_agent/utils/schema/generator_field_spec.rb
@@ -6,6 +6,7 @@ module ForestAdminAgent
       include ForestAdminDatasourceToolkit
       include ForestAdminDatasourceToolkit::Components::Query::ConditionTree
       include ForestAdminDatasourceToolkit::Schema
+
       describe GeneratorField do
         before do
           @datasource = Datasource.new

--- a/packages/forest_admin_datasource_active_record/Gemfile
+++ b/packages/forest_admin_datasource_active_record/Gemfile
@@ -8,7 +8,9 @@ gem 'forest_admin_agent', path: '../forest_admin_agent'
 gem 'forest_admin_datasource_customizer', path: '../forest_admin_datasource_customizer'
 gem 'forest_admin_datasource_toolkit', path: '../forest_admin_datasource_toolkit'
 gem 'rake', '~> 13.0'
-gem 'rubocop', '~> 1.21'
+gem 'rubocop', '1.86.1'
+gem 'rubocop-performance', '1.26.1'
+gem 'rubocop-rspec', '3.9.0'
 
 group :development, :test do
   gem 'rails'

--- a/packages/forest_admin_datasource_active_record/Gemfile-test
+++ b/packages/forest_admin_datasource_active_record/Gemfile-test
@@ -4,7 +4,9 @@ source "https://rubygems.org"
 gemspec
 
 gem 'rake', '~> 13.0'
-gem 'rubocop', '~> 1.21'
+gem 'rubocop', '1.86.1'
+gem 'rubocop-performance', '1.26.1'
+gem 'rubocop-rspec', '3.9.0'
 
 group :development, :test do
   gem 'database_cleaner-active_record'

--- a/packages/forest_admin_datasource_active_record/lib/forest_admin_datasource_active_record/parser/validation.rb
+++ b/packages/forest_admin_datasource_active_record/lib/forest_admin_datasource_active_record/parser/validation.rb
@@ -2,6 +2,7 @@ module ForestAdminDatasourceActiveRecord
   module Parser
     module Validation
       include ForestAdminDatasourceToolkit::Components::Query::ConditionTree
+
       def get_validations(column)
         validations = []
         # NOTICE: Do not consider validations if a before_validation Active Records

--- a/packages/forest_admin_datasource_active_record/lib/forest_admin_datasource_active_record/utils/query_aggregate.rb
+++ b/packages/forest_admin_datasource_active_record/lib/forest_admin_datasource_active_record/utils/query_aggregate.rb
@@ -44,8 +44,8 @@ module ForestAdminDatasourceActiveRecord
         rows.map do |row|
           {
             'value' => row.send(@operation.to_sym),
-            'group' => @aggregation.groups.each_with_object({}) do |group, memo|
-              memo[group[:field]] = row.send(group[:field].to_sym)
+            'group' => @aggregation.groups.to_h do |group|
+              [group[:field], row.send(group[:field].to_sym)]
             end
           }
         end

--- a/packages/forest_admin_datasource_active_record/spec/lib/forest_admin_datasource_active_record/collection_spec.rb
+++ b/packages/forest_admin_datasource_active_record/spec/lib/forest_admin_datasource_active_record/collection_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 module ForestAdminDatasourceActiveRecord
   include ForestAdminDatasourceToolkit::Schema
+
   describe Collection do
     context 'without polymorphic support' do
       let(:datasource) { Datasource.new({ adapter: 'sqlite3', database: 'db/database.db' }) }

--- a/packages/forest_admin_datasource_customizer/Gemfile
+++ b/packages/forest_admin_datasource_customizer/Gemfile
@@ -5,7 +5,9 @@ gemspec
 gem 'forest_admin_agent', path: '../forest_admin_agent'
 gem 'forest_admin_datasource_toolkit', path: '../forest_admin_datasource_toolkit'
 gem 'rake', '~> 13.0'
-gem 'rubocop', '~> 1.21'
+gem 'rubocop', '1.86.1'
+gem 'rubocop-performance', '1.26.1'
+gem 'rubocop-rspec', '3.9.0'
 
 group :development, :test do
   gem 'forest_admin_test_toolkit', path: '../forest_admin_test_toolkit'

--- a/packages/forest_admin_datasource_customizer/Gemfile-test
+++ b/packages/forest_admin_datasource_customizer/Gemfile-test
@@ -3,7 +3,9 @@ source "https://rubygems.org"
 gemspec
 
 gem 'rake', '~> 13.0'
-gem 'rubocop', '~> 1.21'
+gem 'rubocop', '1.86.1'
+gem 'rubocop-performance', '1.26.1'
+gem 'rubocop-rspec', '3.9.0'
 
 group :development, :test do
   gem 'forest_admin_agent', path: '../forest_admin_agent'

--- a/packages/forest_admin_datasource_customizer/lib/forest_admin_datasource_customizer/collection_customizer.rb
+++ b/packages/forest_admin_datasource_customizer/lib/forest_admin_datasource_customizer/collection_customizer.rb
@@ -2,6 +2,7 @@ module ForestAdminDatasourceCustomizer
   class CollectionCustomizer
     include ForestAdminDatasourceToolkit::Validations
     include DSL::CollectionHelpers
+
     attr_reader :datasource_customizer, :stack, :name
 
     def initialize(datasource_customizer, stack, name)

--- a/packages/forest_admin_datasource_customizer/lib/forest_admin_datasource_customizer/context/collection_customization_context.rb
+++ b/packages/forest_admin_datasource_customizer/lib/forest_admin_datasource_customizer/context/collection_customization_context.rb
@@ -2,6 +2,7 @@ module ForestAdminDatasourceCustomizer
   module Context
     class CollectionCustomizationContext < AgentCustomizationContext
       include ForestAdminDatasourceCustomizer::Context::RelaxedWrappers
+
       def initialize(collection, caller)
         super(collection.datasource, caller)
         @real_collection = collection

--- a/packages/forest_admin_datasource_customizer/lib/forest_admin_datasource_customizer/datasource_customizer.rb
+++ b/packages/forest_admin_datasource_customizer/lib/forest_admin_datasource_customizer/datasource_customizer.rb
@@ -1,6 +1,7 @@
 module ForestAdminDatasourceCustomizer
   class DatasourceCustomizer
     include DSL::DatasourceHelpers
+
     attr_reader :stack, :composite_datasource
 
     def initialize(_db_config = {})

--- a/packages/forest_admin_datasource_customizer/lib/forest_admin_datasource_customizer/decorators/action/widget_field.rb
+++ b/packages/forest_admin_datasource_customizer/lib/forest_admin_datasource_customizer/decorators/action/widget_field.rb
@@ -3,6 +3,7 @@ module ForestAdminDatasourceCustomizer
     module Action
       module WidgetField
         include Types
+
         def self.validate_arg(options, attribute, rule)
           case rule[attribute]
           when 'contains'

--- a/packages/forest_admin_datasource_customizer/lib/forest_admin_datasource_customizer/decorators/computed/utils/flattener.rb
+++ b/packages/forest_admin_datasource_customizer/lib/forest_admin_datasource_customizer/decorators/computed/utils/flattener.rb
@@ -53,10 +53,10 @@ module ForestAdminDatasourceCustomizer
                 end
 
                 # for markers, the value tells us which fields are null so that we can set them.
-                if parts[parts.length - 1] == MARKER_NAME
+                if parts[-1] == MARKER_NAME
                   value.nil? ? nil : Undefined.new
-                elsif value&.key?(parts[parts.length - 1])
-                  value[parts[parts.length - 1]]
+                elsif value&.key?(parts[-1])
+                  value[parts[-1]]
                 else
                   Undefined.new
                 end

--- a/packages/forest_admin_datasource_customizer/lib/forest_admin_datasource_customizer/decorators/decorators_stack.rb
+++ b/packages/forest_admin_datasource_customizer/lib/forest_admin_datasource_customizer/decorators/decorators_stack.rb
@@ -88,8 +88,8 @@ module ForestAdminDatasourceCustomizer
       end
 
       def backup_stack
-        instance_variables.each_with_object({}) do |var, hash|
-          hash[var] = instance_variable_get(var)
+        instance_variables.to_h do |var|
+          [var, instance_variable_get(var)]
         end
       end
 

--- a/packages/forest_admin_datasource_customizer/lib/forest_admin_datasource_customizer/decorators/hook/context/hook_context.rb
+++ b/packages/forest_admin_datasource_customizer/lib/forest_admin_datasource_customizer/decorators/hook/context/hook_context.rb
@@ -4,6 +4,7 @@ module ForestAdminDatasourceCustomizer
       module Context
         class HookContext < ForestAdminDatasourceCustomizer::Context::CollectionCustomizationContext
           include ForestAdminAgent::Http::Exceptions
+
           def raise_validation_error(message)
             raise ValidationError, message
           end

--- a/packages/forest_admin_datasource_customizer/lib/forest_admin_datasource_customizer/decorators/override/override_collection_decorator.rb
+++ b/packages/forest_admin_datasource_customizer/lib/forest_admin_datasource_customizer/decorators/override/override_collection_decorator.rb
@@ -3,6 +3,7 @@ module ForestAdminDatasourceCustomizer
     module Override
       class OverrideCollectionDecorator < ForestAdminDatasourceToolkit::Decorators::CollectionDecorator
         include Context
+
         attr_reader :create_handler, :update_handler, :delete_handler
 
         def create(caller, data)

--- a/packages/forest_admin_datasource_customizer/lib/forest_admin_datasource_customizer/decorators/publication/publication_collection_decorator.rb
+++ b/packages/forest_admin_datasource_customizer/lib/forest_admin_datasource_customizer/decorators/publication/publication_collection_decorator.rb
@@ -3,6 +3,7 @@ module ForestAdminDatasourceCustomizer
     module Publication
       class PublicationCollectionDecorator < ForestAdminDatasourceToolkit::Decorators::CollectionDecorator
         include ForestAdminDatasourceToolkit::Exceptions
+
         attr_reader :blacklist
 
         def initialize(child_collection, datasource)

--- a/packages/forest_admin_datasource_customizer/lib/forest_admin_datasource_customizer/decorators/publication/publication_datasource_decorator.rb
+++ b/packages/forest_admin_datasource_customizer/lib/forest_admin_datasource_customizer/decorators/publication/publication_datasource_decorator.rb
@@ -3,6 +3,7 @@ module ForestAdminDatasourceCustomizer
     module Publication
       class PublicationDatasourceDecorator < ForestAdminDatasourceToolkit::Decorators::DatasourceDecorator
         include ForestAdminDatasourceToolkit::Exceptions
+
         attr_reader :blacklist
 
         def initialize(child_datasource)

--- a/packages/forest_admin_datasource_customizer/lib/forest_admin_datasource_customizer/decorators/validation/validation_collection_decorator.rb
+++ b/packages/forest_admin_datasource_customizer/lib/forest_admin_datasource_customizer/decorators/validation/validation_collection_decorator.rb
@@ -5,6 +5,7 @@ module ForestAdminDatasourceCustomizer
         include ForestAdminDatasourceToolkit::Validations
         include ForestAdminDatasourceToolkit::Components::Query::ConditionTree
         include ForestAdminDatasourceToolkit::Exceptions
+
         attr_reader :validation
 
         def initialize(child_collection, datasource)

--- a/packages/forest_admin_datasource_customizer/lib/forest_admin_datasource_customizer/decorators/write/create_relations/create_relations_collection_decorator.rb
+++ b/packages/forest_admin_datasource_customizer/lib/forest_admin_datasource_customizer/decorators/write/create_relations/create_relations_collection_decorator.rb
@@ -6,6 +6,7 @@ module ForestAdminDatasourceCustomizer
           include ForestAdminDatasourceToolkit::Components::Query
           include ForestAdminDatasourceToolkit::Components::Query::ConditionTree
           include ForestAdminDatasourceToolkit::Components::Query::ConditionTree::Nodes
+
           def create(caller, data)
             # Step 1: Remove all relations from records, and store them in a map
             # Note: the extractRelations method modifies the records array in place!

--- a/packages/forest_admin_datasource_customizer/lib/forest_admin_datasource_customizer/decorators/write/write_datasource_decorator.rb
+++ b/packages/forest_admin_datasource_customizer/lib/forest_admin_datasource_customizer/decorators/write/write_datasource_decorator.rb
@@ -3,6 +3,7 @@ module ForestAdminDatasourceCustomizer
     module Write
       class WriteDatasourceDecorator < ForestAdminDatasourceToolkit::Decorators::DatasourceDecorator
         include ForestAdminDatasourceToolkit::Decorators
+
         def initialize(child_datasource)
           create = DatasourceDecorator.new(child_datasource, CreateRelations::CreateRelationsCollectionDecorator)
           update = DatasourceDecorator.new(create, UpdateRelations::UpdateRelationsCollectionDecorator)

--- a/packages/forest_admin_datasource_customizer/lib/forest_admin_datasource_customizer/decorators/write/write_replace/write_replace_collection_decorator.rb
+++ b/packages/forest_admin_datasource_customizer/lib/forest_admin_datasource_customizer/decorators/write/write_replace/write_replace_collection_decorator.rb
@@ -5,6 +5,7 @@ module ForestAdminDatasourceCustomizer
         class WriteReplaceCollectionDecorator < ForestAdminDatasourceToolkit::Decorators::CollectionDecorator
           include ForestAdminDatasourceToolkit::Exceptions
           include ForestAdminDatasourceToolkit::Validations
+
           attr_reader :handlers
 
           def initialize(child_collection, datasource)

--- a/packages/forest_admin_datasource_customizer/spec/lib/forest_admin_datasource_customizer/collection_customizer_spec.rb
+++ b/packages/forest_admin_datasource_customizer/spec/lib/forest_admin_datasource_customizer/collection_customizer_spec.rb
@@ -7,6 +7,7 @@ module ForestAdminDatasourceCustomizer
   include ForestAdminDatasourceCustomizer::Decorators::Computed
   include ForestAdminDatasourceCustomizer::Decorators::Action
   include ForestAdminDatasourceCustomizer::Context
+
   describe CollectionCustomizer do
     include_context 'with caller'
     before do
@@ -307,7 +308,7 @@ module ForestAdminDatasourceCustomizer
         customizer.add_external_relation(
           'tags',
           {
-            schema: ['etag' => 'String', 'selfLink' => 'String'],
+            schema: [{ 'etag' => 'String', 'selfLink' => 'String' }],
             listRecords: proc {
               [
                 { 'etag' => 'OTD2tB19qn4', 'selfLink' => 'https://www.googleapis.com/books/v1/volumes/_ojXNuzgHRcC' },

--- a/packages/forest_admin_datasource_customizer/spec/lib/forest_admin_datasource_customizer/decorators/action/context/action_context_spec.rb
+++ b/packages/forest_admin_datasource_customizer/spec/lib/forest_admin_datasource_customizer/decorators/action/context/action_context_spec.rb
@@ -8,6 +8,7 @@ module ForestAdminDatasourceCustomizer
         include ForestAdminDatasourceToolkit::Decorators
         include ForestAdminDatasourceToolkit::Schema
         include ForestAdminDatasourceToolkit::Components::Query
+
         describe ActionContext do
           include_context 'with caller'
           before do

--- a/packages/forest_admin_datasource_customizer/spec/lib/forest_admin_datasource_customizer/decorators/chart/chart_context_spec.rb
+++ b/packages/forest_admin_datasource_customizer/spec/lib/forest_admin_datasource_customizer/decorators/chart/chart_context_spec.rb
@@ -7,6 +7,7 @@ module ForestAdminDatasourceCustomizer
       include ForestAdminDatasourceToolkit::Decorators
       include ForestAdminDatasourceToolkit::Schema
       include ForestAdminDatasourceToolkit::Components::Query
+
       describe ChartContext do
         include_context 'with caller'
         before do

--- a/packages/forest_admin_datasource_customizer/spec/lib/forest_admin_datasource_customizer/decorators/chart/result_builder_spec.rb
+++ b/packages/forest_admin_datasource_customizer/spec/lib/forest_admin_datasource_customizer/decorators/chart/result_builder_spec.rb
@@ -7,6 +7,7 @@ module ForestAdminDatasourceCustomizer
       include ForestAdminDatasourceToolkit::Decorators
       include ForestAdminDatasourceToolkit::Schema
       include ForestAdminDatasourceToolkit::Components::Query
+
       describe ResultBuilder do
         let(:builder) { described_class.new }
 

--- a/packages/forest_admin_datasource_customizer/spec/lib/forest_admin_datasource_customizer/decorators/computed/utils/flattener_spec.rb
+++ b/packages/forest_admin_datasource_customizer/spec/lib/forest_admin_datasource_customizer/decorators/computed/utils/flattener_spec.rb
@@ -5,6 +5,7 @@ module ForestAdminDatasourceCustomizer
     module Computed
       module Utils
         include ForestAdminDatasourceToolkit::Components::Query
+
         describe Flattener do
           it 'unflatten() should work with simple case' do
             flat_list = [

--- a/packages/forest_admin_datasource_mongoid/Gemfile
+++ b/packages/forest_admin_datasource_mongoid/Gemfile
@@ -7,7 +7,9 @@ gem 'mongoid', '~> 9.0'
 
 gem 'forest_admin_datasource_toolkit', path: '../forest_admin_datasource_toolkit'
 gem 'rake', '~> 13.0'
-gem 'rubocop', '~> 1.21'
+gem 'rubocop', '1.86.1'
+gem 'rubocop-performance', '1.26.1'
+gem 'rubocop-rspec', '3.9.0'
 
 group :development, :test do
   gem 'mongoid-rspec', '~> 4.0'

--- a/packages/forest_admin_datasource_mongoid/Gemfile-test
+++ b/packages/forest_admin_datasource_mongoid/Gemfile-test
@@ -4,7 +4,9 @@ source "https://rubygems.org"
 gemspec
 
 gem 'rake', '~> 13.0'
-gem 'rubocop', '~> 1.21'
+gem 'rubocop', '1.86.1'
+gem 'rubocop-performance', '1.26.1'
+gem 'rubocop-rspec', '3.9.0'
 gem 'mongoid', '~> 9.0'
 
 group :development, :test do

--- a/packages/forest_admin_datasource_mongoid/lib/forest_admin_datasource_mongoid/collection.rb
+++ b/packages/forest_admin_datasource_mongoid/lib/forest_admin_datasource_mongoid/collection.rb
@@ -13,7 +13,7 @@ module ForestAdminDatasourceMongoid
     attr_reader :model, :stack
 
     def initialize(datasource, model, stack)
-      prefix = stack[stack.length - 1][:prefix]
+      prefix = stack[-1][:prefix]
 
       @model = model
       @stack = stack

--- a/packages/forest_admin_datasource_mongoid/lib/forest_admin_datasource_mongoid/parser/validation.rb
+++ b/packages/forest_admin_datasource_mongoid/lib/forest_admin_datasource_mongoid/parser/validation.rb
@@ -2,6 +2,7 @@ module ForestAdminDatasourceMongoid
   module Parser
     module Validation
       include ForestAdminDatasourceToolkit::Components::Query::ConditionTree
+
       def get_validations(model, column)
         return [] if column.is_a?(Hash)
         return [] if before_validation_callback?(model)

--- a/packages/forest_admin_datasource_mongoid/lib/forest_admin_datasource_mongoid/utils/pipeline/group_generator.rb
+++ b/packages/forest_admin_datasource_mongoid/lib/forest_admin_datasource_mongoid/utils/pipeline/group_generator.rb
@@ -75,8 +75,8 @@ module ForestAdminDatasourceMongoid
           def compute_groups_projection(groups)
             return { '$literal' => {} } if groups.nil? || groups.empty?
 
-            groups.each_with_object({}) do |group, memo|
-              memo[group[:field]] = "$_id.#{group[:field]}"
+            groups.to_h do |group|
+              [group[:field], "$_id.#{group[:field]}"]
             end
           end
         end

--- a/packages/forest_admin_datasource_mongoid/lib/forest_admin_datasource_mongoid/utils/schema/fields_generator.rb
+++ b/packages/forest_admin_datasource_mongoid/lib/forest_admin_datasource_mongoid/utils/schema/fields_generator.rb
@@ -38,7 +38,7 @@ module ForestAdminDatasourceMongoid
 
           return our_schema unless stack.length > 1
 
-          parent_prefix = stack[stack.length - 2][:prefix]
+          parent_prefix = stack[-2][:prefix]
 
           our_schema['_id'] = build_virtual_primary_key
           parent_id = child_schema.fields['parent']['_id']

--- a/packages/forest_admin_datasource_mongoid/lib/forest_admin_datasource_mongoid/utils/schema/mongoid_schema.rb
+++ b/packages/forest_admin_datasource_mongoid/lib/forest_admin_datasource_mongoid/utils/schema/mongoid_schema.rb
@@ -4,6 +4,7 @@ module ForestAdminDatasourceMongoid
       class MongoidSchema
         include ForestAdminDatasourceToolkit::Exceptions
         include Utils::Helpers
+
         attr_reader :is_array, :is_leaf, :fields, :models
 
         def initialize(model, fields, is_array, is_leaf)

--- a/packages/forest_admin_datasource_mongoid/lib/forest_admin_datasource_mongoid/utils/schema/relation_generator.rb
+++ b/packages/forest_admin_datasource_mongoid/lib/forest_admin_datasource_mongoid/utils/schema/relation_generator.rb
@@ -23,14 +23,14 @@ module ForestAdminDatasourceMongoid
             # Create inverse of 'parent' relationship so that the relation name matches the actual name
             # of the data which is stored in the database.
             stack = collection.stack
-            prefix = stack[stack.length - 1][:prefix]
+            prefix = stack[-1][:prefix]
             is_array = MongoidSchema.from_model(collection.model).apply_stack(stack).is_array
 
             type = is_array ? OneToManySchema : OneToOneSchema
             inverse_name = escape(prefix)
 
             if stack.length > 2
-              previous_length = stack[stack.length - 2][:prefix].length + 1
+              previous_length = stack[-2][:prefix].length + 1
               inverse_name = prefix[previous_length..]
             end
           else

--- a/packages/forest_admin_datasource_mongoid/spec/lib/forest_admin_datasource_mongoid/collection_spec.rb
+++ b/packages/forest_admin_datasource_mongoid/spec/lib/forest_admin_datasource_mongoid/collection_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 module ForestAdminDatasourceMongoid
   include ForestAdminDatasourceToolkit::Components::Query
+
   describe Collection do
     before do
       logger = instance_double(Logger, log: nil)
@@ -45,6 +46,7 @@ module ForestAdminDatasourceMongoid
     it 'escapes collection names' do
       model = Class.new do
         include Mongoid::Document
+
         field :content, type: String
       end
 

--- a/packages/forest_admin_datasource_mongoid/spec/lib/forest_admin_datasource_mongoid/datasource_spec.rb
+++ b/packages/forest_admin_datasource_mongoid/spec/lib/forest_admin_datasource_mongoid/datasource_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 module ForestAdminDatasourceMongoid
   include ForestAdminDatasourceToolkit::Exceptions
+
   describe Datasource do
     let(:datasource) { described_class.new }
 
@@ -54,10 +55,12 @@ module ForestAdminDatasourceMongoid
       it 'accept both dots and colons as separator in options' do
         class_book = Class.new do
           include Mongoid::Document
+
           embeds_one :author, class_name: 'Dummy::Author'
         end
         class_author = Class.new do
           include Mongoid::Document
+
           field :first_name, type: String
           field :last_name, type: String
         end
@@ -77,6 +80,7 @@ module ForestAdminDatasourceMongoid
       it 'raise an error' do
         class_book = Class.new do
           include Mongoid::Document
+
           embeds_one :author
         end
         stub_const('Dummy::Book', class_book)

--- a/packages/forest_admin_datasource_mongoid/spec/lib/forest_admin_datasource_mongoid/parser/column_spec.rb
+++ b/packages/forest_admin_datasource_mongoid/spec/lib/forest_admin_datasource_mongoid/parser/column_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 module ForestAdminDatasourceMongoid
   module Parser
     include ForestAdminDatasourceToolkit::Components::Query::ConditionTree
+
     describe Column do
       let(:dummy_class) { Class.new { extend Column } }
 
@@ -75,6 +76,7 @@ module ForestAdminDatasourceMongoid
         it 'returns embedded fields for a model' do
           model = Class.new do
             include Mongoid::Document
+
             embeds_many :embedded_items
           end
 
@@ -85,6 +87,7 @@ module ForestAdminDatasourceMongoid
         it 'returns an empty hash when no embedded fields are present' do
           model = Class.new do
             include Mongoid::Document
+
             field :simple_field, type: String
           end
 

--- a/packages/forest_admin_datasource_mongoid/spec/lib/forest_admin_datasource_mongoid/parser/relation_spec.rb
+++ b/packages/forest_admin_datasource_mongoid/spec/lib/forest_admin_datasource_mongoid/parser/relation_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 module ForestAdminDatasourceMongoid
   module Parser
     include ForestAdminDatasourceToolkit::Components::Query::ConditionTree
+
     describe Validation do
       before do
         logger = instance_double(Logger, log: nil)

--- a/packages/forest_admin_datasource_mongoid/spec/lib/forest_admin_datasource_mongoid/parser/validation_spec.rb
+++ b/packages/forest_admin_datasource_mongoid/spec/lib/forest_admin_datasource_mongoid/parser/validation_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 module ForestAdminDatasourceMongoid
   module Parser
     include ForestAdminDatasourceToolkit::Components::Query::ConditionTree
+
     describe Validation do
       before do
         logger = instance_double(Logger, log: nil)
@@ -16,6 +17,7 @@ module ForestAdminDatasourceMongoid
         let(:model) do
           model_class = Class.new do
             include Mongoid::Document
+
             before_validation :some_before_validation_callback
             validates :email, presence: true
 
@@ -37,6 +39,7 @@ module ForestAdminDatasourceMongoid
         let(:model) do
           model_class = Class.new do
             include Mongoid::Document
+
             field :email, type: String
             validates :email, presence: true
           end
@@ -100,6 +103,7 @@ module ForestAdminDatasourceMongoid
           let(:model) do
             model_class = Class.new do
               include Mongoid::Document
+
               field :title, type: String
               validates :title, length: { minimum: 5 }
             end
@@ -120,6 +124,7 @@ module ForestAdminDatasourceMongoid
           let(:model) do
             model_class = Class.new do
               include Mongoid::Document
+
               field :title, type: String
               validates :title, length: { maximum: 10 }
             end
@@ -140,6 +145,7 @@ module ForestAdminDatasourceMongoid
           let(:model) do
             model_class = Class.new do
               include Mongoid::Document
+
               field :title, type: String
               validates :title, length: { is: 8 }
             end
@@ -163,6 +169,7 @@ module ForestAdminDatasourceMongoid
           let(:model) do
             model_class = Class.new do
               include Mongoid::Document
+
               field :email, type: String
               validates :email, format: { with: URI::MailTo::EMAIL_REGEXP }
             end
@@ -188,6 +195,7 @@ module ForestAdminDatasourceMongoid
           let(:model) do
             model_class = Class.new do
               include Mongoid::Document
+
               field :username, type: String
               validates :username, format: { with: /\A[a-zA-Z0-9_]+\z/, message: 'only allows letters, numbers, and underscores' }
             end

--- a/packages/forest_admin_datasource_mongoid/spec/lib/forest_admin_datasource_mongoid/utils/mongoid_serializer_spec.rb
+++ b/packages/forest_admin_datasource_mongoid/spec/lib/forest_admin_datasource_mongoid/utils/mongoid_serializer_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 module ForestAdminDatasourceMongoid
   module Utils
     include ForestAdminDatasourceToolkit::Components::Query
+
     describe MongoidSerializer do
       describe '#to_hash' do
         describe 'without relations' do

--- a/packages/forest_admin_datasource_mongoid/spec/lib/forest_admin_datasource_mongoid/utils/pipeline/filter_generator_spec.rb
+++ b/packages/forest_admin_datasource_mongoid/spec/lib/forest_admin_datasource_mongoid/utils/pipeline/filter_generator_spec.rb
@@ -4,6 +4,7 @@ module ForestAdminDatasourceMongoid
   module Utils
     module Pipeline
       include ForestAdminDatasourceToolkit::Components::Query
+
       describe FilterGenerator do
         before do
           logger = instance_double(Logger, log: nil)

--- a/packages/forest_admin_datasource_mongoid/spec/lib/forest_admin_datasource_mongoid/utils/pipeline/group_generator_spec.rb
+++ b/packages/forest_admin_datasource_mongoid/spec/lib/forest_admin_datasource_mongoid/utils/pipeline/group_generator_spec.rb
@@ -4,6 +4,7 @@ module ForestAdminDatasourceMongoid
   module Utils
     module Pipeline
       include ForestAdminDatasourceToolkit::Components::Query
+
       describe GroupGenerator do
         it 'creates a pipeline for sum (w/o field nor group)' do
           aggregation = Aggregation.new(operation: 'Sum', field: 'price')

--- a/packages/forest_admin_datasource_mongoid/spec/lib/forest_admin_datasource_mongoid/utils/pipeline/lookup_generator_spec.rb
+++ b/packages/forest_admin_datasource_mongoid/spec/lib/forest_admin_datasource_mongoid/utils/pipeline/lookup_generator_spec.rb
@@ -4,6 +4,7 @@ module ForestAdminDatasourceMongoid
   module Utils
     module Pipeline
       include ForestAdminDatasourceToolkit::Components::Query
+
       describe LookupGenerator do
         describe 'with the root collection' do
           let(:stack) { [{ prefix: nil, as_fields: [], as_models: [] }] }

--- a/packages/forest_admin_datasource_mongoid/spec/lib/forest_admin_datasource_mongoid/utils/pipeline/projection_generator_spec.rb
+++ b/packages/forest_admin_datasource_mongoid/spec/lib/forest_admin_datasource_mongoid/utils/pipeline/projection_generator_spec.rb
@@ -4,6 +4,7 @@ module ForestAdminDatasourceMongoid
   module Utils
     module Pipeline
       include ForestAdminDatasourceToolkit::Components::Query
+
       describe ProjectionGenerator do
         it 'generates a $replaceRoot stage when no fields are provided' do
           pipeline = described_class.project(Projection.new)

--- a/packages/forest_admin_datasource_mongoid/spec/lib/forest_admin_datasource_mongoid/utils/pipeline/reparent_generator_spec.rb
+++ b/packages/forest_admin_datasource_mongoid/spec/lib/forest_admin_datasource_mongoid/utils/pipeline/reparent_generator_spec.rb
@@ -5,6 +5,7 @@ module ForestAdminDatasourceMongoid
   module Utils
     module Pipeline
       include ForestAdminDatasourceToolkit::Components::Query
+
       describe ReparentGenerator do
         let(:author_model) do
           Class.new do

--- a/packages/forest_admin_datasource_mongoid/spec/lib/forest_admin_datasource_mongoid/utils/schema/field_simple_spec.rb
+++ b/packages/forest_admin_datasource_mongoid/spec/lib/forest_admin_datasource_mongoid/utils/schema/field_simple_spec.rb
@@ -12,6 +12,7 @@ module ForestAdminDatasourceMongoid
           let(:model) do
             Class.new do
               include Mongoid::Document
+
               field :a_field, type: Integer
               validates :a_field, presence: true
             end
@@ -28,6 +29,7 @@ module ForestAdminDatasourceMongoid
           let(:model) do
             Class.new do
               include Mongoid::Document
+
               field :a_field, type: Integer
             end
           end
@@ -43,6 +45,7 @@ module ForestAdminDatasourceMongoid
           let(:model) do
             Class.new do
               include Mongoid::Document
+
               field :a_field, type: String, default: 'default_value'
             end
           end
@@ -66,6 +69,7 @@ module ForestAdminDatasourceMongoid
           it 'builds the field schema with is_read_only as true' do
             class ImmutableFieldModel
               include Mongoid::Document
+
               field :a_field, type: Date
               attr_readonly :a_field
             end
@@ -83,6 +87,7 @@ module ForestAdminDatasourceMongoid
           let(:model) do
             Class.new do
               include Mongoid::Document
+
               field :a_field, type: Integer
               validates :a_field, inclusion: { in: [1, 2] }
             end
@@ -100,6 +105,7 @@ module ForestAdminDatasourceMongoid
             let(:model) do
               Class.new do
                 include Mongoid::Document
+
                 field :a_field, type: Array
               end
             end
@@ -115,11 +121,13 @@ module ForestAdminDatasourceMongoid
             it 'builds the right schema' do
               class ObjectArrayModel
                 include Mongoid::Document
+
                 embeds_many :nested_objects, class_name: 'NestedObject'
               end
 
               class NestedObject
                 include Mongoid::Document
+
                 field :level, type: Integer
               end
 
@@ -134,11 +142,13 @@ module ForestAdminDatasourceMongoid
           it 'adds a relation _manyToOne in the fields schema' do
             class ManyToOneModel
               include Mongoid::Document
+
               belongs_to :company, class_name: 'Company'
             end
 
             class Company
               include Mongoid::Document
+
               field :name, type: String
             end
 

--- a/packages/forest_admin_datasource_rpc/Gemfile
+++ b/packages/forest_admin_datasource_rpc/Gemfile
@@ -8,7 +8,9 @@ gem 'forest_admin_datasource_customizer', path: '../forest_admin_datasource_cust
 gem 'forest_admin_datasource_toolkit', path: '../forest_admin_datasource_toolkit'
 gem 'forest_admin_rpc_agent', path: '../forest_admin_rpc_agent'
 gem 'rake', '~> 13.0'
-gem 'rubocop', '~> 1.21'
+gem 'rubocop', '1.86.1'
+gem 'rubocop-performance', '1.26.1'
+gem 'rubocop-rspec', '3.9.0'
 
 group :development, :test do
   gem 'forest_admin_test_toolkit', path: '../forest_admin_test_toolkit'

--- a/packages/forest_admin_datasource_rpc/Gemfile-test
+++ b/packages/forest_admin_datasource_rpc/Gemfile-test
@@ -4,7 +4,9 @@ source "https://rubygems.org"
 gemspec
 
 gem 'rake', '~> 13.0'
-gem 'rubocop', '~> 1.21'
+gem 'rubocop', '1.86.1'
+gem 'rubocop-performance', '1.26.1'
+gem 'rubocop-rspec', '3.9.0'
 
 group :development, :test do
   gem 'forest_admin_test_toolkit', path: '../forest_admin_test_toolkit'

--- a/packages/forest_admin_datasource_rpc/spec/forest_admin_datasource_rpc_spec.rb
+++ b/packages/forest_admin_datasource_rpc/spec/forest_admin_datasource_rpc_spec.rb
@@ -14,7 +14,7 @@ module ForestAdminDatasourceRpc
         allow(ForestAdminAgent::Facades::Container).to receive_messages(logger: logger, cache: 'secret')
       end
 
-      include_examples 'with introspection'
+      include_context 'with introspection'
 
       context 'with unknown options' do
         let(:schema_polling_client) { instance_double(Utils::SchemaPollingClient, start?: true, stop: nil, current_schema: introspection) }

--- a/packages/forest_admin_datasource_rpc/spec/lib/forest_admin_datasource_rpc/collection_spec.rb
+++ b/packages/forest_admin_datasource_rpc/spec/lib/forest_admin_datasource_rpc/collection_spec.rb
@@ -18,7 +18,7 @@ module ForestAdminDatasourceRpc
     let(:collection) { datasource.get_collection('Product') }
     let(:caller) { build_caller }
 
-    include_examples 'with introspection'
+    include_context 'with introspection'
 
     context 'when initialized' do
       it 'uses the datasource shared RPC client' do

--- a/packages/forest_admin_datasource_rpc/spec/lib/forest_admin_datasource_rpc/datasource_spec.rb
+++ b/packages/forest_admin_datasource_rpc/spec/lib/forest_admin_datasource_rpc/datasource_spec.rb
@@ -17,7 +17,7 @@ module ForestAdminDatasourceRpc
     let(:datasource) { described_class.new({ uri: 'http://localhost' }, introspection) }
     let(:caller) { build_caller }
 
-    include_examples 'with introspection'
+    include_context 'with introspection'
 
     context 'when initialize the datasource' do
       it 'add collections' do

--- a/packages/forest_admin_datasource_toolkit/Gemfile
+++ b/packages/forest_admin_datasource_toolkit/Gemfile
@@ -4,7 +4,9 @@ source "https://rubygems.org"
 gemspec
 
 gem 'rake', '~> 13.0'
-gem 'rubocop', '~> 1.21'
+gem 'rubocop', '1.86.1'
+gem 'rubocop-performance', '1.26.1'
+gem 'rubocop-rspec', '3.9.0'
 
 group :development, :test do
   gem 'forest_admin_test_toolkit', path: '../forest_admin_test_toolkit'

--- a/packages/forest_admin_datasource_toolkit/Gemfile-test
+++ b/packages/forest_admin_datasource_toolkit/Gemfile-test
@@ -4,7 +4,9 @@ source "https://rubygems.org"
 gemspec
 
 gem 'rake', '~> 13.0'
-gem 'rubocop', '~> 1.21'
+gem 'rubocop', '1.86.1'
+gem 'rubocop-performance', '1.26.1'
+gem 'rubocop-rspec', '3.9.0'
 
 group :development, :test do
   gem 'forest_admin_test_toolkit', path: '../forest_admin_test_toolkit'

--- a/packages/forest_admin_datasource_toolkit/lib/forest_admin_datasource_toolkit/components/query/aggregation.rb
+++ b/packages/forest_admin_datasource_toolkit/lib/forest_admin_datasource_toolkit/components/query/aggregation.rb
@@ -6,6 +6,7 @@ module ForestAdminDatasourceToolkit
     module Query
       class Aggregation
         include ForestAdminDatasourceToolkit::Exceptions
+
         attr_reader :operation
         attr_accessor :groups, :field
 

--- a/packages/forest_admin_datasource_toolkit/lib/forest_admin_datasource_toolkit/components/query/condition_tree/transforms/pattern.rb
+++ b/packages/forest_admin_datasource_toolkit/lib/forest_admin_datasource_toolkit/components/query/condition_tree/transforms/pattern.rb
@@ -19,7 +19,7 @@ module ForestAdminDatasourceToolkit
                 depends_on: [Operators::MATCH],
                 for_types: ['String'],
                 replacer: proc { |leaf|
-                  regex = leaf.value.gsub(/([\.\\\+\*\?\[\^\]\$\(\)\{\}\=\!\<\>\|\:\-])/, '\\\\\1')
+                  regex = leaf.value.gsub(/([.\\+*?\[\^\]$(){}=!<>|:-])/, '\\\\\1')
                   regex.gsub!('%', '.*')
                   regex.tr!('_', '.')
 

--- a/packages/forest_admin_datasource_toolkit/lib/forest_admin_datasource_toolkit/components/query/projection.rb
+++ b/packages/forest_admin_datasource_toolkit/lib/forest_admin_datasource_toolkit/components/query/projection.rb
@@ -3,6 +3,7 @@ module ForestAdminDatasourceToolkit
     module Query
       class Projection < Array
         include ForestAdminDatasourceToolkit::Utils
+
         def with_pks(collection)
           ForestAdminDatasourceToolkit::Utils::Schema.primary_keys(collection).each do |key|
             push(key) unless include?(key)

--- a/packages/forest_admin_datasource_toolkit/lib/forest_admin_datasource_toolkit/components/query/projection_factory.rb
+++ b/packages/forest_admin_datasource_toolkit/lib/forest_admin_datasource_toolkit/components/query/projection_factory.rb
@@ -3,6 +3,7 @@ module ForestAdminDatasourceToolkit
     module Query
       class ProjectionFactory
         include ForestAdminDatasourceToolkit::Utils
+
         def self.all(collection)
           projection_fields = collection.schema[:fields].reduce([]) do |memo, path|
             column_name = path[0]

--- a/packages/forest_admin_datasource_toolkit/lib/forest_admin_datasource_toolkit/validations/type_getter.rb
+++ b/packages/forest_admin_datasource_toolkit/lib/forest_admin_datasource_toolkit/validations/type_getter.rb
@@ -6,6 +6,7 @@ module ForestAdminDatasourceToolkit
   module Validations
     class TypeGetter
       include ForestAdminDatasourceToolkit::Schema::Concerns
+
       def self.get(value, type_context)
         return PrimitiveTypes::JSON if type_context == PrimitiveTypes::JSON
 
@@ -30,6 +31,7 @@ module ForestAdminDatasourceToolkit
 
       class << self
         include ForestAdminDatasourceToolkit::Schema::Concerns
+
         def get_date_type(value)
           return PrimitiveTypes::DATE_ONLY if date?(value) && Date.parse(value).iso8601 == value
 

--- a/packages/forest_admin_datasource_toolkit/spec/lib/forest_admin_datasource_toolkit/components/contracts/collection_contract_spec.rb
+++ b/packages/forest_admin_datasource_toolkit/spec/lib/forest_admin_datasource_toolkit/components/contracts/collection_contract_spec.rb
@@ -4,6 +4,7 @@ module ForestAdminDatasourceToolkit
   module Components
     module Contracts
       include ForestAdminDatasourceToolkit::Components::Query
+
       describe CollectionContract do
         subject(:collection) { described_class.new }
 

--- a/packages/forest_admin_datasource_toolkit/spec/lib/forest_admin_datasource_toolkit/components/query/aggregation_spec.rb
+++ b/packages/forest_admin_datasource_toolkit/spec/lib/forest_admin_datasource_toolkit/components/query/aggregation_spec.rb
@@ -4,6 +4,7 @@ module ForestAdminDatasourceToolkit
   module Components
     module Query
       include ForestAdminDatasourceToolkit::Schema
+
       describe Aggregation do
         it 'raise if the operation is invalid' do
           expect do

--- a/packages/forest_admin_datasource_toolkit/spec/lib/forest_admin_datasource_toolkit/components/query/projection_factory_spec.rb
+++ b/packages/forest_admin_datasource_toolkit/spec/lib/forest_admin_datasource_toolkit/components/query/projection_factory_spec.rb
@@ -5,6 +5,7 @@ module ForestAdminDatasourceToolkit
     module Query
       include ForestAdminDatasourceToolkit::Schema
       include ForestAdminDatasourceToolkit::Schema::Relations
+
       describe ProjectionFactory do
         describe 'with one to one and many to one relations' do
           before do

--- a/packages/forest_admin_datasource_toolkit/spec/lib/forest_admin_datasource_toolkit/components/query/projection_spec.rb
+++ b/packages/forest_admin_datasource_toolkit/spec/lib/forest_admin_datasource_toolkit/components/query/projection_spec.rb
@@ -4,6 +4,7 @@ module ForestAdminDatasourceToolkit
   module Components
     module Query
       include ForestAdminDatasourceToolkit::Schema
+
       describe Projection do
         let(:collection) do
           collection = Collection.new(Datasource.new, '__collection__')

--- a/packages/forest_admin_datasource_toolkit/spec/lib/forest_admin_datasource_toolkit/components/query/sort_spec.rb
+++ b/packages/forest_admin_datasource_toolkit/spec/lib/forest_admin_datasource_toolkit/components/query/sort_spec.rb
@@ -6,6 +6,7 @@ module ForestAdminDatasourceToolkit
       include ForestAdminDatasourceToolkit
       include ForestAdminDatasourceToolkit::Schema
       include ForestAdminDatasourceToolkit::Components::Query::SortUtils
+
       describe Sort do
         let(:sort) { described_class.new([{ field: 'column1', ascending: true }, { field: 'column2', ascending: false }]) }
 

--- a/packages/forest_admin_datasource_toolkit/spec/lib/forest_admin_datasource_toolkit/components/query/sort_utils/sort_factory_spec.rb
+++ b/packages/forest_admin_datasource_toolkit/spec/lib/forest_admin_datasource_toolkit/components/query/sort_utils/sort_factory_spec.rb
@@ -7,6 +7,7 @@ module ForestAdminDatasourceToolkit
         include ForestAdminDatasourceToolkit
         include ForestAdminDatasourceToolkit::Schema
         include ForestAdminDatasourceToolkit::Components::Query::SortUtils
+
         describe SortFactory do
           it 'returns a sort instance sorted by primary keys' do
             collection_with_composite_id = Collection.new(Datasource.new, 'Book')

--- a/packages/forest_admin_datasource_toolkit/spec/lib/forest_admin_datasource_toolkit/utils/schema_spec.rb
+++ b/packages/forest_admin_datasource_toolkit/spec/lib/forest_admin_datasource_toolkit/utils/schema_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 module ForestAdminDatasourceToolkit
   module Utils
     include ForestAdminDatasourceToolkit::Schema
+
     describe Schema do
       let(:collection) do
         collection = ForestAdminDatasourceToolkit::Collection.new(Datasource.new, '__collection__')

--- a/packages/forest_admin_datasource_toolkit/spec/lib/forest_admin_datasource_toolkit/validations/condition_tree_validator/boolean_spec.rb
+++ b/packages/forest_admin_datasource_toolkit/spec/lib/forest_admin_datasource_toolkit/validations/condition_tree_validator/boolean_spec.rb
@@ -6,6 +6,7 @@ module ForestAdminDatasourceToolkit
     include ForestAdminDatasourceToolkit::Exceptions
     include ForestAdminDatasourceToolkit::Components::Query::ConditionTree
     include ForestAdminDatasourceToolkit::Components::Query::ConditionTree::Nodes
+
     describe ConditionTreeValidator do
       describe 'when the field is a boolean' do
         it 'not raise an error when it using the In operator with an empty array' do

--- a/packages/forest_admin_datasource_toolkit/spec/lib/forest_admin_datasource_toolkit/validations/condition_tree_validator/condition_tree_validator_spec.rb
+++ b/packages/forest_admin_datasource_toolkit/spec/lib/forest_admin_datasource_toolkit/validations/condition_tree_validator/condition_tree_validator_spec.rb
@@ -6,6 +6,7 @@ module ForestAdminDatasourceToolkit
     include ForestAdminDatasourceToolkit::Exceptions
     include ForestAdminDatasourceToolkit::Components::Query::ConditionTree
     include ForestAdminDatasourceToolkit::Components::Query::ConditionTree::Nodes
+
     describe ConditionTreeValidator do
       describe 'validate' do
         context 'with an invalid type' do

--- a/packages/forest_admin_datasource_toolkit/spec/lib/forest_admin_datasource_toolkit/validations/condition_tree_validator/date_spec.rb
+++ b/packages/forest_admin_datasource_toolkit/spec/lib/forest_admin_datasource_toolkit/validations/condition_tree_validator/date_spec.rb
@@ -6,6 +6,7 @@ module ForestAdminDatasourceToolkit
     include ForestAdminDatasourceToolkit::Exceptions
     include ForestAdminDatasourceToolkit::Components::Query::ConditionTree
     include ForestAdminDatasourceToolkit::Components::Query::ConditionTree::Nodes
+
     describe ConditionTreeValidator do
       describe 'when the field is a date' do
         it 'not raise an error when it using the BeforeXHoursAgo operator' do

--- a/packages/forest_admin_datasource_toolkit/spec/lib/forest_admin_datasource_toolkit/validations/condition_tree_validator/enum_spec.rb
+++ b/packages/forest_admin_datasource_toolkit/spec/lib/forest_admin_datasource_toolkit/validations/condition_tree_validator/enum_spec.rb
@@ -6,6 +6,7 @@ module ForestAdminDatasourceToolkit
     include ForestAdminDatasourceToolkit::Exceptions
     include ForestAdminDatasourceToolkit::Components::Query::ConditionTree
     include ForestAdminDatasourceToolkit::Components::Query::ConditionTree::Nodes
+
     describe ConditionTreeValidator do
       describe 'when the field is an enum' do
         it 'raise an error when the field value is not a valid enum' do

--- a/packages/forest_admin_datasource_toolkit/spec/lib/forest_admin_datasource_toolkit/validations/condition_tree_validator/json_spec.rb
+++ b/packages/forest_admin_datasource_toolkit/spec/lib/forest_admin_datasource_toolkit/validations/condition_tree_validator/json_spec.rb
@@ -6,6 +6,7 @@ module ForestAdminDatasourceToolkit
     include ForestAdminDatasourceToolkit::Exceptions
     include ForestAdminDatasourceToolkit::Components::Query::ConditionTree
     include ForestAdminDatasourceToolkit::Components::Query::ConditionTree::Nodes
+
     describe ConditionTreeValidator do
       describe 'when the field is a JSON' do
         let(:collection) do

--- a/packages/forest_admin_datasource_toolkit/spec/lib/forest_admin_datasource_toolkit/validations/condition_tree_validator/number_spec.rb
+++ b/packages/forest_admin_datasource_toolkit/spec/lib/forest_admin_datasource_toolkit/validations/condition_tree_validator/number_spec.rb
@@ -6,6 +6,7 @@ module ForestAdminDatasourceToolkit
     include ForestAdminDatasourceToolkit::Exceptions
     include ForestAdminDatasourceToolkit::Components::Query::ConditionTree
     include ForestAdminDatasourceToolkit::Components::Query::ConditionTree::Nodes
+
     describe ConditionTreeValidator do
       describe 'when the field is a number' do
         let(:collection) do

--- a/packages/forest_admin_datasource_toolkit/spec/lib/forest_admin_datasource_toolkit/validations/condition_tree_validator/point_spec.rb
+++ b/packages/forest_admin_datasource_toolkit/spec/lib/forest_admin_datasource_toolkit/validations/condition_tree_validator/point_spec.rb
@@ -6,6 +6,7 @@ module ForestAdminDatasourceToolkit
     include ForestAdminDatasourceToolkit::Exceptions
     include ForestAdminDatasourceToolkit::Components::Query::ConditionTree
     include ForestAdminDatasourceToolkit::Components::Query::ConditionTree::Nodes
+
     describe ConditionTreeValidator do
       describe 'when the field is a Point' do
         let(:collection) do

--- a/packages/forest_admin_datasource_toolkit/spec/lib/forest_admin_datasource_toolkit/validations/condition_tree_validator/string_spec.rb
+++ b/packages/forest_admin_datasource_toolkit/spec/lib/forest_admin_datasource_toolkit/validations/condition_tree_validator/string_spec.rb
@@ -6,6 +6,7 @@ module ForestAdminDatasourceToolkit
     include ForestAdminDatasourceToolkit::Exceptions
     include ForestAdminDatasourceToolkit::Components::Query::ConditionTree
     include ForestAdminDatasourceToolkit::Components::Query::ConditionTree::Nodes
+
     describe ConditionTreeValidator do
       describe 'when the field is a string' do
         it 'not raise an error when it using the ShorterThan operator' do

--- a/packages/forest_admin_datasource_toolkit/spec/lib/forest_admin_datasource_toolkit/validations/condition_tree_validator/uuid_spec.rb
+++ b/packages/forest_admin_datasource_toolkit/spec/lib/forest_admin_datasource_toolkit/validations/condition_tree_validator/uuid_spec.rb
@@ -6,6 +6,7 @@ module ForestAdminDatasourceToolkit
     include ForestAdminDatasourceToolkit::Exceptions
     include ForestAdminDatasourceToolkit::Components::Query::ConditionTree
     include ForestAdminDatasourceToolkit::Components::Query::ConditionTree::Nodes
+
     describe ConditionTreeValidator do
       describe 'when the field is an UUID' do
         let(:collection) do

--- a/packages/forest_admin_datasource_toolkit/spec/lib/forest_admin_datasource_toolkit/validations/field_validator_spec.rb
+++ b/packages/forest_admin_datasource_toolkit/spec/lib/forest_admin_datasource_toolkit/validations/field_validator_spec.rb
@@ -5,6 +5,7 @@ module ForestAdminDatasourceToolkit
     include ForestAdminDatasourceToolkit::Schema
     include ForestAdminDatasourceToolkit::Exceptions
     include ForestAdminDatasourceToolkit::Components::Query::ConditionTree
+
     describe FieldValidator do
       before do
         @datasource = Datasource.new

--- a/packages/forest_admin_datasource_toolkit/spec/lib/forest_admin_datasource_toolkit/validations/sort_validator_spec.rb
+++ b/packages/forest_admin_datasource_toolkit/spec/lib/forest_admin_datasource_toolkit/validations/sort_validator_spec.rb
@@ -5,6 +5,7 @@ module ForestAdminDatasourceToolkit
     include ForestAdminDatasourceToolkit
     include ForestAdminDatasourceToolkit::Schema
     include ForestAdminDatasourceToolkit::Components::Query
+
     describe SortValidator do
       let(:collection_user) do
         datasource = Datasource.new

--- a/packages/forest_admin_datasource_toolkit/spec/lib/forest_admin_datasource_toolkit/validations/type_getter_spec.rb
+++ b/packages/forest_admin_datasource_toolkit/spec/lib/forest_admin_datasource_toolkit/validations/type_getter_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 module ForestAdminDatasourceToolkit
   module Validations
     include ForestAdminDatasourceToolkit::Schema::Concerns
+
     describe TypeGetter do
       context 'when get is called' do
         context 'when the value is a number' do

--- a/packages/forest_admin_datasource_zendesk/Gemfile
+++ b/packages/forest_admin_datasource_zendesk/Gemfile
@@ -4,7 +4,9 @@ gemspec
 
 gem 'forest_admin_datasource_toolkit'
 gem 'rake', '~> 13.0'
-gem 'rubocop', '~> 1.21'
+gem 'rubocop', '1.86.1'
+gem 'rubocop-performance', '1.26.1'
+gem 'rubocop-rspec', '3.9.0'
 
 group :development, :test do
   gem 'rspec', '~> 3.0'

--- a/packages/forest_admin_datasource_zendesk/Gemfile-test
+++ b/packages/forest_admin_datasource_zendesk/Gemfile-test
@@ -4,7 +4,9 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'rake', '~> 13.0'
-gem 'rubocop', '~> 1.21'
+gem 'rubocop', '1.86.1'
+gem 'rubocop-performance', '1.26.1'
+gem 'rubocop-rspec', '3.9.0'
 
 group :development, :test do
   gem 'forest_admin_datasource_toolkit', path: '../forest_admin_datasource_toolkit'

--- a/packages/forest_admin_rails/Gemfile
+++ b/packages/forest_admin_rails/Gemfile
@@ -8,6 +8,9 @@ gem 'forest_admin_datasource_active_record', path: '../forest_admin_datasource_a
 
 group :development, :test do
   gem 'rspec-rails', '~> 6.0.0'
+  gem 'rubocop', '1.86.1'
+  gem 'rubocop-performance', '1.26.1'
+  gem 'rubocop-rspec', '3.9.0'
   gem 'simplecov', "~> 0.22", require: false
   gem 'simplecov_json_formatter', "~> 0.1.4"
 end

--- a/packages/forest_admin_rails/Gemfile-test
+++ b/packages/forest_admin_rails/Gemfile-test
@@ -8,6 +8,9 @@ group :development, :test do
   gem 'forest_admin_datasource_customizer', path: '../forest_admin_datasource_customizer'
   gem 'forest_admin_datasource_active_record', path: '../forest_admin_datasource_active_record'
   gem 'rspec-rails', '~> 6.0.0'
+  gem 'rubocop', '1.86.1'
+  gem 'rubocop-performance', '1.26.1'
+  gem 'rubocop-rspec', '3.9.0'
   gem 'simplecov', "~> 0.22", require: false
   gem 'simplecov_json_formatter', "~> 0.1.4"
 end

--- a/packages/forest_admin_rails/config/routes.rb
+++ b/packages/forest_admin_rails/config/routes.rb
@@ -13,7 +13,7 @@ ForestAdminRails::Engine.routes.draw do
             via: agent_route[:method],
             as: name,
             route_alias: name,
-            constraints: { id: /[a-zA-Z0-9\.\-]*+/ }
+            constraints: { id: /[a-zA-Z0-9.-]*+/ }
     end
   rescue StandardError => e
     if defined?(Rails) && Rails.logger

--- a/packages/forest_admin_rpc_agent/Gemfile
+++ b/packages/forest_admin_rpc_agent/Gemfile
@@ -7,7 +7,9 @@ gem 'forest_admin_agent', path: '../forest_admin_agent'
 gem 'forest_admin_datasource_toolkit', path: '../forest_admin_datasource_toolkit'
 gem 'forest_admin_test_toolkit', path: '../forest_admin_test_toolkit'
 gem 'rake', '~> 13.0'
-gem 'rubocop', '~> 1.21'
+gem 'rubocop', '1.86.1'
+gem 'rubocop-performance', '1.26.1'
+gem 'rubocop-rspec', '3.9.0'
 
 group :development, :test do
   gem 'rspec-rails', '~> 3.0'

--- a/packages/forest_admin_rpc_agent/Gemfile-test
+++ b/packages/forest_admin_rpc_agent/Gemfile-test
@@ -4,7 +4,9 @@ source "https://rubygems.org"
 gemspec
 
 gem 'rake', '~> 13.0'
-gem 'rubocop', '~> 1.21'
+gem 'rubocop', '1.86.1'
+gem 'rubocop-performance', '1.26.1'
+gem 'rubocop-rspec', '3.9.0'
 
 group :development, :test do
   gem 'forest_admin_datasource_toolkit', path: '../forest_admin_datasource_toolkit'

--- a/packages/forest_admin_rpc_agent/lib/forest_admin_rpc_agent/thor/install.rb
+++ b/packages/forest_admin_rpc_agent/lib/forest_admin_rpc_agent/thor/install.rb
@@ -5,6 +5,7 @@ module ForestAdminRpcAgent
   module Thor
     class Install < ::Thor
       include ::Thor::Actions
+
       # Run the command:
       # for a rails app : forest_admin_rpc_agent install AUTH_SECRET_FROM_YOUR_FOREST_APP
       # for a sinatra app : forest_admin_rpc_agent install AUTH_SECRET_FROM_YOUR_FOREST_APP --app_file=app.rb

--- a/packages/forest_admin_rpc_agent/spec/lib/forest_admin_rpc_agent/routes/action_execute_spec.rb
+++ b/packages/forest_admin_rpc_agent/spec/lib/forest_admin_rpc_agent/routes/action_execute_spec.rb
@@ -6,6 +6,7 @@ module ForestAdminRpcAgent
     include ForestAdminDatasourceRpc
     include ForestAdminDatasourceToolkit::Components::Query
     include ForestAdminDatasourceToolkit::Components::Query::ConditionTree
+
     describe ActionExecute do
       include_context 'with caller'
       subject(:route) { described_class.new }

--- a/packages/forest_admin_rpc_agent/spec/lib/forest_admin_rpc_agent/routes/action_form_spec.rb
+++ b/packages/forest_admin_rpc_agent/spec/lib/forest_admin_rpc_agent/routes/action_form_spec.rb
@@ -6,6 +6,7 @@ module ForestAdminRpcAgent
   module Routes
     include ForestAdminDatasourceRpc
     include ForestAdminDatasourceToolkit::Components::Query
+
     describe ActionForm do
       include_context 'with caller'
       subject(:route) { described_class.new }

--- a/packages/forest_admin_rpc_agent/spec/lib/forest_admin_rpc_agent/routes/aggregate_spec.rb
+++ b/packages/forest_admin_rpc_agent/spec/lib/forest_admin_rpc_agent/routes/aggregate_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 module ForestAdminRpcAgent
   module Routes
     include ForestAdminDatasourceRpc
+
     describe Aggregate do
       include_context 'with caller'
 

--- a/packages/forest_admin_rpc_agent/spec/lib/forest_admin_rpc_agent/routes/chart_spec.rb
+++ b/packages/forest_admin_rpc_agent/spec/lib/forest_admin_rpc_agent/routes/chart_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 module ForestAdminRpcAgent
   module Routes
     include ForestAdminDatasourceRpc
+
     describe Chart do
       include_context 'with caller'
 

--- a/packages/forest_admin_rpc_agent/spec/lib/forest_admin_rpc_agent/routes/create_spec.rb
+++ b/packages/forest_admin_rpc_agent/spec/lib/forest_admin_rpc_agent/routes/create_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 module ForestAdminRpcAgent
   module Routes
     include ForestAdminDatasourceRpc
+
     describe Create do
       include_context 'with caller'
 

--- a/packages/forest_admin_rpc_agent/spec/lib/forest_admin_rpc_agent/routes/datasource_chart_spec.rb
+++ b/packages/forest_admin_rpc_agent/spec/lib/forest_admin_rpc_agent/routes/datasource_chart_spec.rb
@@ -4,6 +4,7 @@ require 'faraday'
 module ForestAdminRpcAgent
   module Routes
     include ForestAdminDatasourceRpc
+
     describe DatasourceChart do
       include_context 'with caller'
 

--- a/packages/forest_admin_rpc_agent/spec/lib/forest_admin_rpc_agent/routes/delete_spec.rb
+++ b/packages/forest_admin_rpc_agent/spec/lib/forest_admin_rpc_agent/routes/delete_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 module ForestAdminRpcAgent
   module Routes
     include ForestAdminDatasourceRpc
+
     describe Delete do
       include_context 'with caller'
 

--- a/packages/forest_admin_rpc_agent/spec/lib/forest_admin_rpc_agent/routes/list_spec.rb
+++ b/packages/forest_admin_rpc_agent/spec/lib/forest_admin_rpc_agent/routes/list_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 module ForestAdminRpcAgent
   module Routes
     include ForestAdminDatasourceRpc
+
     describe List do
       include_context 'with caller'
 

--- a/packages/forest_admin_rpc_agent/spec/lib/forest_admin_rpc_agent/routes/schema_spec.rb
+++ b/packages/forest_admin_rpc_agent/spec/lib/forest_admin_rpc_agent/routes/schema_spec.rb
@@ -4,6 +4,7 @@ require 'rack'
 module ForestAdminRpcAgent
   module Routes
     include ForestAdminDatasourceRpc
+
     describe Schema do
       let(:route) { described_class.new }
       let(:agent) { instance_double(ForestAdminRpcAgent::Agent) }

--- a/packages/forest_admin_rpc_agent/spec/lib/forest_admin_rpc_agent/routes/update_spec.rb
+++ b/packages/forest_admin_rpc_agent/spec/lib/forest_admin_rpc_agent/routes/update_spec.rb
@@ -5,6 +5,7 @@ module ForestAdminRpcAgent
     include ForestAdminDatasourceRpc
     include ForestAdminDatasourceToolkit::Schema
     include ForestAdminDatasourceToolkit::Components::Query::ConditionTree
+
     describe Update do
       include_context 'with caller'
 

--- a/packages/forest_admin_test_toolkit/Gemfile
+++ b/packages/forest_admin_test_toolkit/Gemfile
@@ -4,7 +4,9 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'rake', '~> 13.0'
-gem 'rubocop', '~> 1.21'
+gem 'rubocop', '1.86.1'
+gem 'rubocop-performance', '1.26.1'
+gem 'rubocop-rspec', '3.9.0'
 
 gem 'forest_admin_datasource_toolkit', path: '../forest_admin_datasource_toolkit'
 


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Align rubocop, rubocop-performance, and rubocop-rspec versions across all packages
Updates all package `Gemfile` and `Gemfile-test` files to use `rubocop` 1.86.1, `rubocop-performance` 1.26.1, and `rubocop-rspec` 3.9.0. Fixes linting violations introduced by the new versions, including replacing `each_with_object` with `to_h`, using negative array indices (`-1`, `-2`) instead of `length - n`, switching `include_examples` to `include_context` in RSpec shared contexts, and cleaning up unnecessary regex escapes.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized a3f7083.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->