### PR TITLE
fix(zendesk): raise ForestException past Zendesk Search 1000-result cap

### DIFF
--- a/packages/forest_admin_datasource_zendesk/lib/forest_admin_datasource_zendesk/client.rb
+++ b/packages/forest_admin_datasource_zendesk/lib/forest_admin_datasource_zendesk/client.rb
@@ -4,6 +4,7 @@ module ForestAdminDatasourceZendesk
     include Introspection
 
     MAX_PER_PAGE = 100
+    MAX_TOTAL_RESULTS = 1000
 
     def initialize(configuration)
       @configuration = configuration

--- a/packages/forest_admin_datasource_zendesk/lib/forest_admin_datasource_zendesk/collections/base_collection.rb
+++ b/packages/forest_admin_datasource_zendesk/lib/forest_admin_datasource_zendesk/collections/base_collection.rb
@@ -63,6 +63,12 @@ module ForestAdminDatasourceZendesk
 
         per_page = page.limit&.positive? ? [page.limit, Client::MAX_PER_PAGE].min : Client::MAX_PER_PAGE
         page_num = (page.offset.to_i / per_page) + 1
+        if page_num * per_page > Client::MAX_TOTAL_RESULTS
+          raise ForestAdminDatasourceToolkit::Exceptions::ForestException,
+                "Zendesk Search caps total results at #{Client::MAX_TOTAL_RESULTS}; " \
+                "page #{page_num} (offset=#{page.offset}, per_page=#{per_page}) exceeds this limit. " \
+                'Narrow the filter to fetch records past this point.'
+        end
         [page_num, per_page]
       end
 

--- a/packages/forest_admin_datasource_zendesk/spec/forest_admin_datasource_zendesk/collections/ticket_spec.rb
+++ b/packages/forest_admin_datasource_zendesk/spec/forest_admin_datasource_zendesk/collections/ticket_spec.rb
@@ -188,6 +188,22 @@ module ForestAdminDatasourceZendesk
           expect(client).to have_received(:search)
             .with('ticket', hash_including(per_page: ForestAdminDatasourceZendesk::Client::MAX_PER_PAGE))
         end
+
+        it 'sends the last allowed page (offset 900 / limit 100) without raising' do
+          allow(client).to receive(:search).and_return([])
+
+          filter = Filter.new(page: Page.new(offset: 900, limit: 100))
+          collection.list(nil, filter, ['id'])
+
+          expect(client).to have_received(:search).with('ticket', hash_including(page: 10, per_page: 100))
+        end
+
+        it 'raises a ForestException with an actionable message past the 1000-result cap' do
+          filter = Filter.new(page: Page.new(offset: 1000, limit: 100))
+          expect { collection.list(nil, filter, ['id']) }
+            .to raise_error(ForestAdminDatasourceToolkit::Exceptions::ForestException,
+                            /caps total results at 1000.*Narrow the filter/m)
+        end
       end
 
       describe 'requester_email enrichment' do


### PR DESCRIPTION
Zendesk Search caps total results at 1000 in addition to the per-page max of 100 already handled via Client::MAX_PER_PAGE. translate_page previously computed page numbers without bounds, so paginating past offset 1000 sent page=11 to Zendesk and surfaced an opaque APIError.

Add Client::MAX_TOTAL_RESULTS = 1000 and refuse the request before sending when (page_num * per_page) would exceed it. The exception points the user at the actionable next step (narrow the filter) instead of a generic 422 wrapper.

## Definition of Done

### General

- [ ] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [ ] Test manually the implemented changes
- [ ] Validate the code quality (indentation, syntax, style, simplicity, readability)

### Security

- [ ] Consider the security impact of the changes made


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Raise `ForestException` when Zendesk search pagination exceeds 1000-result cap
> Zendesk's Search API caps results at 1000. `BaseCollection#translate_page` now raises a `ForestException` with an actionable message advising the user to narrow their filter when the requested page offset would exceed this limit. A new `Client::MAX_TOTAL_RESULTS` constant (1000) centralizes the threshold.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3d008df.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->