### PR TITLE
chore(snowflake): remove mfa requirement for rubygem [force release]

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -39,6 +39,7 @@ Gemspec/RequireMFA:
     - 'packages/forest_admin_datasource_customizer/forest_admin_datasource_customizer.gemspec'
     - 'packages/forest_admin_datasource_active_record/forest_admin_datasource_active_record.gemspec'
     - 'packages/forest_admin_datasource_zendesk/forest_admin_datasource_zendesk.gemspec'
+    - 'packages/forest_admin_datasource_snowflake/forest_admin_datasource_snowflake.gemspec'
 
 # Offense count: 1
 # This cop supports unsafe autocorrection (--autocorrect-all).

--- a/packages/forest_admin_datasource_snowflake/forest_admin_datasource_snowflake.gemspec
+++ b/packages/forest_admin_datasource_snowflake/forest_admin_datasource_snowflake.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.metadata['homepage_uri']         = spec.homepage
   spec.metadata['source_code_uri']      = 'https://github.com/ForestAdmin/agent-ruby'
   spec.metadata['changelog_uri']        = 'https://github.com/ForestAdmin/agent-ruby/blob/main/CHANGELOG.md'
-  spec.metadata['rubygems_mfa_required'] = 'true'
+  spec.metadata['rubygems_mfa_required'] = 'false'
 
   spec.files = Dir.chdir(__dir__) do
     `git ls-files -z`.split("\x0").reject do |f|


### PR DESCRIPTION
## Summary
- Set `rubygems_mfa_required` to `false` in the `forest_admin_datasource_snowflake` gemspec to unblock publishing.

## Test plan
- [ ] CI passes
- [ ] Gem publishes successfully without MFA

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove MFA requirement for the `forest_admin_datasource_snowflake` RubyGem
> Sets `rubygems_mfa_required` to `false` in the [gemspec](https://github.com/ForestAdmin/agent-ruby/pull/300/files#diff-34a028bef1177c1f22d178b6b760eef796c2314a0494f269cc65c36aa710b793) and excludes it from the `Gemspec/RequireMFA` RuboCop rule in [.rubocop.yml](https://github.com/ForestAdmin/agent-ruby/pull/300/files#diff-4f894049af3375c2bd4e608f546f8d4a0eed95464efcdea850993200db9fef5c).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dac2298.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->