### PR TITLE
fix(rpc datasource): handle correctly simple action response

### DIFF
--- a/packages/forest_admin_datasource_rpc/lib/forest_admin_datasource_rpc/collection.rb
+++ b/packages/forest_admin_datasource_rpc/lib/forest_admin_datasource_rpc/collection.rb
@@ -127,7 +127,7 @@ module ForestAdminDatasourceRpc
         "Forwarding '#{@name}' action #{name} call to the Rpc agent on #{url}."
       )
 
-      @client.call_rpc(url, caller: caller, method: :post, payload: params)
+      @client.call_rpc(url, caller: caller, method: :post, payload: params, symbolize_keys: true)
     end
 
     def get_form(caller, name, data = nil, filter = nil, metas = nil)

--- a/packages/forest_admin_datasource_rpc/spec/lib/forest_admin_datasource_rpc/collection_spec.rb
+++ b/packages/forest_admin_datasource_rpc/spec/lib/forest_admin_datasource_rpc/collection_spec.rb
@@ -233,6 +233,30 @@ module ForestAdminDatasourceRpc
           )
         end
       end
+
+      it 'asks the RPC client to symbolize response keys so ActionResult.parse sees :type' do
+        collection.execute(caller, 'my_action', {})
+
+        expect(rpc_client).to have_received(:call_rpc) do |_url, options|
+          expect(options[:symbolize_keys]).to be(true)
+        end
+      end
+
+      it 'returns the action result as-is so :type and other keys reach ActionResult.parse' do
+        success_result = {
+          type: 'Success',
+          message: 'ok',
+          invalidated: ['books'],
+          html: nil,
+          response_headers: {}
+        }
+        allow(rpc_client).to receive(:call_rpc).and_return(success_result)
+
+        result = collection.execute(caller, 'my_action', {})
+
+        expect(result).to eq(success_result)
+        expect(result[:type]).to eq('Success')
+      end
     end
 
     context 'when call get_form' do


### PR DESCRIPTION
## Definition of Done

### General

- [ ] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [ ] Test manually the implemented changes
- [ ] Validate the code quality (indentation, syntax, style, simplicity, readability)

### Security

- [ ] Consider the security impact of the changes made


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `execute` in RPC datasource collection to symbolize keys in action responses
> Adds `symbolize_keys: true` to the `@client.call_rpc` call in `Collection#execute` so that action responses are returned with symbol keys (including `:type`) instead of string keys. Two new specs in [collection_spec.rb](https://github.com/ForestAdmin/agent-ruby/pull/306/files#diff-80251b67b6731a1c79eed179305869ba0c9801ba50f43e511c21a17c744170ef) verify that the option is passed and that the result is returned unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9508918.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->