### PR TITLE
chore(security): patch 0 Dependabot alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "semantic-release-slack-bot": "4.0.2"
   },
   "resolutions": {
-    "semantic-release-slack-bot/**/micromatch": "^4.0.8",
-    "ip-address": "^10.1.1"
+    "semantic-release-slack-bot/**/micromatch": "^4.0.8"
   }
 }


### PR DESCRIPTION
## Summary

0 fixed, 0 ignored, 0 deferred, 0 resolutions added, 1 resolutions removed. | label: :lock: security applied

No open Dependabot alerts at this run. Sweeping the existing `resolutions` block surfaced one redundant entry — shipping the cleanup on its own as instructed.

## Fixed

_None — no open alerts._

## Ignored

_None._

## Deferred

_None._

## Resolutions added

_None._

## Resolutions removed

| File | Pinned package | Why removal is safe |
|---|---|---|
| `package.json` | `ip-address: ^10.1.1` | **Redundant.** Only caller in the tree is `socks@2.8.9`, which itself requests `ip-address@^10.1.1`. Removed the resolution, ran `yarn install`, confirmed `yarn why ip-address` still reports `10.2.0` and `yarn.lock` is byte-identical. The natural resolution from `socks` already satisfies the original pin. |

The other resolution (`semantic-release-slack-bot/**/micromatch: ^4.0.8`) was probed and kept: removing it causes `semantic-release-slack-bot@4.0.2`'s exact pin `micromatch "4.0.2"` to reintroduce `micromatch@4.0.2` (vulnerable to ReDoS GHSA-952p-6rrq-rcjv). Confirmed via fresh install + `yarn why micromatch`.

## Risks

No behavior change. `yarn.lock` is byte-identical to baseline after the resolution removal — the resolved tree is unaffected, only the (now-unnecessary) override is gone.

## Manual testing

Covered by CI.

## Validation

✅ CI green

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove `ip-address` override from package.json to patch Dependabot alert
> Removes the `ip-address` resolution entry from [package.json](https://github.com/ForestAdmin/agent-ruby/pull/308/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) as part of a Dependabot security patch.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6f1918e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->