### PR TITLE
fix(rpc agent): allow connect as node rpc

### DIFF
--- a/packages/forest_admin_rpc_agent/lib/forest_admin_rpc_agent/routes/action_execute.rb
+++ b/packages/forest_admin_rpc_agent/lib/forest_admin_rpc_agent/routes/action_execute.rb
@@ -12,8 +12,6 @@ module ForestAdminRpcAgent
       end
 
       def handle_request(args)
-        return {} unless args[:params]['collection_name']
-
         datasource = ForestAdminRpcAgent::Facades::Container.datasource
         collection = get_collection_safe(datasource, args[:params]['collection_name'])
         filter = FilterFactory.from_plain_object(args[:params]['filter'])

--- a/packages/forest_admin_rpc_agent/lib/forest_admin_rpc_agent/routes/action_form.rb
+++ b/packages/forest_admin_rpc_agent/lib/forest_admin_rpc_agent/routes/action_form.rb
@@ -12,7 +12,7 @@ module ForestAdminRpcAgent
       end
 
       def handle_request(args)
-        return {} unless args[:params]['collection_name']
+        return [] unless args[:params]['collection_name']
 
         datasource = ForestAdminRpcAgent::Facades::Container.datasource
         collection = get_collection_safe(datasource, args[:params]['collection_name'])

--- a/packages/forest_admin_rpc_agent/lib/forest_admin_rpc_agent/routes/action_form.rb
+++ b/packages/forest_admin_rpc_agent/lib/forest_admin_rpc_agent/routes/action_form.rb
@@ -12,8 +12,6 @@ module ForestAdminRpcAgent
       end
 
       def handle_request(args)
-        return [] unless args[:params]['collection_name']
-
         datasource = ForestAdminRpcAgent::Facades::Container.datasource
         collection = get_collection_safe(datasource, args[:params]['collection_name'])
         filter = FilterFactory.from_plain_object(args[:params]['filter'])

--- a/packages/forest_admin_rpc_agent/lib/forest_admin_rpc_agent/routes/aggregate.rb
+++ b/packages/forest_admin_rpc_agent/lib/forest_admin_rpc_agent/routes/aggregate.rb
@@ -12,8 +12,6 @@ module ForestAdminRpcAgent
       end
 
       def handle_request(args)
-        return [] unless args[:params]['collection_name']
-
         datasource = ForestAdminRpcAgent::Facades::Container.datasource
         collection = get_collection_safe(datasource, args[:params]['collection_name'])
 

--- a/packages/forest_admin_rpc_agent/lib/forest_admin_rpc_agent/routes/aggregate.rb
+++ b/packages/forest_admin_rpc_agent/lib/forest_admin_rpc_agent/routes/aggregate.rb
@@ -12,7 +12,7 @@ module ForestAdminRpcAgent
       end
 
       def handle_request(args)
-        return {} unless args[:params]['collection_name']
+        return [] unless args[:params]['collection_name']
 
         datasource = ForestAdminRpcAgent::Facades::Container.datasource
         collection = get_collection_safe(datasource, args[:params]['collection_name'])
@@ -20,7 +20,7 @@ module ForestAdminRpcAgent
         aggregation = Aggregation.new(
           operation: args[:params]['aggregation']['operation'],
           field: args[:params]['aggregation']['field'],
-          groups: args[:params]['aggregation']['groups']
+          groups: args[:params]['aggregation']['groups'] || []
         )
         filter = FilterFactory.from_plain_object(args[:params]['filter'])
 

--- a/packages/forest_admin_rpc_agent/lib/forest_admin_rpc_agent/routes/base_route.rb
+++ b/packages/forest_admin_rpc_agent/lib/forest_admin_rpc_agent/routes/base_route.rb
@@ -39,16 +39,16 @@ module ForestAdminRpcAgent
 
           # Skip authentication for health check (root path)
           if @url == '/'
-            params = deep_symbolize_keys(request.query_parameters.merge(request.request_parameters))
-            result = handle_request({ params: params.with_indifferent_access, caller: nil, request: request })
+            params = extract_request_params(request)
+            result = handle_request({ params: params, caller: nil, request: request })
             build_rails_response(result)
           else
             auth_middleware = ForestAdminRpcAgent::Middleware::Authentication.new(->(_env) { [200, {}, ['OK']] })
             status, headers, response = auth_middleware.call(request.env)
 
             if status == 200
-              params = deep_symbolize_keys(request.query_parameters.merge(request.request_parameters))
-              result = handle_request({ params: params.with_indifferent_access, caller: headers[:caller], request: request })
+              params = extract_request_params(request)
+              result = handle_request({ params: params, caller: headers[:caller], request: request })
               build_rails_response(result)
             else
               [status, headers, response]
@@ -86,6 +86,16 @@ module ForestAdminRpcAgent
       end
 
       private
+
+      # Merge path params (e.g. :collection_name from the URL) with query and body params so
+      # consumers that don't duplicate `collection_name` in the body (the Node datasource-rpc)
+      # still resolve the route correctly.
+      def extract_request_params(request)
+        merged = request.path_parameters
+                        .merge(request.query_parameters)
+                        .merge(request.request_parameters)
+        deep_symbolize_keys(merged).with_indifferent_access
+      end
 
       def deep_symbolize_keys(obj)
         case obj

--- a/packages/forest_admin_rpc_agent/lib/forest_admin_rpc_agent/routes/base_route.rb
+++ b/packages/forest_admin_rpc_agent/lib/forest_admin_rpc_agent/routes/base_route.rb
@@ -91,21 +91,11 @@ module ForestAdminRpcAgent
       # consumers that don't duplicate `collection_name` in the body (the Node datasource-rpc)
       # still resolve the route correctly.
       def extract_request_params(request)
-        merged = request.path_parameters
-                        .merge(request.query_parameters)
-                        .merge(request.request_parameters)
-        deep_symbolize_keys(merged).with_indifferent_access
-      end
-
-      def deep_symbolize_keys(obj)
-        case obj
-        when Hash
-          obj.transform_keys(&:to_sym).transform_values { |v| deep_symbolize_keys(v) }
-        when Array
-          obj.map { |v| deep_symbolize_keys(v) }
-        else
-          obj
-        end
+        request.path_parameters
+               .except(:controller, :action, :format)
+               .merge(request.query_parameters)
+               .merge(request.request_parameters)
+               .with_indifferent_access
       end
 
       def serialize_response(result)

--- a/packages/forest_admin_rpc_agent/lib/forest_admin_rpc_agent/routes/chart.rb
+++ b/packages/forest_admin_rpc_agent/lib/forest_admin_rpc_agent/routes/chart.rb
@@ -10,8 +10,6 @@ module ForestAdminRpcAgent
       end
 
       def handle_request(args)
-        return {} unless args[:params]['collection_name']
-
         chart_name = args[:params]['chart']
         parameters = args[:params]['parameters']
         datasource = ForestAdminRpcAgent::Facades::Container.datasource

--- a/packages/forest_admin_rpc_agent/lib/forest_admin_rpc_agent/routes/create.rb
+++ b/packages/forest_admin_rpc_agent/lib/forest_admin_rpc_agent/routes/create.rb
@@ -8,7 +8,7 @@ module ForestAdminRpcAgent
       end
 
       def handle_request(args)
-        return {} unless args[:params]['collection_name']
+        return [] unless args[:params]['collection_name']
 
         datasource = ForestAdminRpcAgent::Facades::Container.datasource
         collection = get_collection_safe(datasource, args[:params]['collection_name'])

--- a/packages/forest_admin_rpc_agent/lib/forest_admin_rpc_agent/routes/create.rb
+++ b/packages/forest_admin_rpc_agent/lib/forest_admin_rpc_agent/routes/create.rb
@@ -8,8 +8,6 @@ module ForestAdminRpcAgent
       end
 
       def handle_request(args)
-        return [] unless args[:params]['collection_name']
-
         datasource = ForestAdminRpcAgent::Facades::Container.datasource
         collection = get_collection_safe(datasource, args[:params]['collection_name'])
 

--- a/packages/forest_admin_rpc_agent/lib/forest_admin_rpc_agent/routes/delete.rb
+++ b/packages/forest_admin_rpc_agent/lib/forest_admin_rpc_agent/routes/delete.rb
@@ -12,8 +12,6 @@ module ForestAdminRpcAgent
       end
 
       def handle_request(args)
-        return {} unless args[:params]['collection_name']
-
         datasource = ForestAdminRpcAgent::Facades::Container.datasource
         collection = get_collection_safe(datasource, args[:params]['collection_name'])
         filter = FilterFactory.from_plain_object(args[:params]['filter'])

--- a/packages/forest_admin_rpc_agent/lib/forest_admin_rpc_agent/routes/list.rb
+++ b/packages/forest_admin_rpc_agent/lib/forest_admin_rpc_agent/routes/list.rb
@@ -12,7 +12,7 @@ module ForestAdminRpcAgent
       end
 
       def handle_request(args)
-        return {} unless args[:params]['collection_name']
+        return [] unless args[:params]['collection_name']
 
         datasource = ForestAdminRpcAgent::Facades::Container.datasource
         collection = get_collection_safe(datasource, args[:params]['collection_name'])

--- a/packages/forest_admin_rpc_agent/lib/forest_admin_rpc_agent/routes/list.rb
+++ b/packages/forest_admin_rpc_agent/lib/forest_admin_rpc_agent/routes/list.rb
@@ -12,8 +12,6 @@ module ForestAdminRpcAgent
       end
 
       def handle_request(args)
-        return [] unless args[:params]['collection_name']
-
         datasource = ForestAdminRpcAgent::Facades::Container.datasource
         collection = get_collection_safe(datasource, args[:params]['collection_name'])
         projection = Projection.new(args[:params]['projection'])

--- a/packages/forest_admin_rpc_agent/lib/forest_admin_rpc_agent/routes/update.rb
+++ b/packages/forest_admin_rpc_agent/lib/forest_admin_rpc_agent/routes/update.rb
@@ -10,8 +10,6 @@ module ForestAdminRpcAgent
       end
 
       def handle_request(args)
-        return {} unless args[:params]['collection_name']
-
         datasource = ForestAdminRpcAgent::Facades::Container.datasource
         collection = get_collection_safe(datasource, args[:params]['collection_name'])
         filter = FilterFactory.from_plain_object(args[:params]['filter'])

--- a/packages/forest_admin_rpc_agent/spec/lib/forest_admin_rpc_agent/routes/action_execute_spec.rb
+++ b/packages/forest_admin_rpc_agent/spec/lib/forest_admin_rpc_agent/routes/action_execute_spec.rb
@@ -86,12 +86,12 @@ module ForestAdminRpcAgent
           end
         end
 
-        context 'when collection_name is missing' do
-          let(:params) { {} }
+        context 'when the collection is unknown' do
+          let(:params) { { 'collection_name' => 'unknown', 'action' => 'noop', 'data' => {} } }
 
-          it 'returns an empty hash' do
-            response = route.handle_request(args)
-            expect(response).to eq({})
+          it 'raises NotFoundError so the controller maps it to a 404 response' do
+            expect { route.handle_request(args) }
+              .to raise_error(ForestAdminAgent::Http::Exceptions::NotFoundError)
           end
         end
       end

--- a/packages/forest_admin_rpc_agent/spec/lib/forest_admin_rpc_agent/routes/action_form_spec.rb
+++ b/packages/forest_admin_rpc_agent/spec/lib/forest_admin_rpc_agent/routes/action_form_spec.rb
@@ -125,12 +125,12 @@ module ForestAdminRpcAgent
           end
         end
 
-        context 'when collection_name is missing' do
-          let(:params) { {} }
+        context 'when the collection is unknown' do
+          let(:params) { { 'collection_name' => 'unknown', 'action' => 'noop' } }
 
-          it 'returns an empty array' do
-            response = route.handle_request(args)
-            expect(response).to eq([])
+          it 'raises NotFoundError so the controller maps it to a 404 response' do
+            expect { route.handle_request(args) }
+              .to raise_error(ForestAdminAgent::Http::Exceptions::NotFoundError)
           end
         end
       end

--- a/packages/forest_admin_rpc_agent/spec/lib/forest_admin_rpc_agent/routes/action_form_spec.rb
+++ b/packages/forest_admin_rpc_agent/spec/lib/forest_admin_rpc_agent/routes/action_form_spec.rb
@@ -128,9 +128,9 @@ module ForestAdminRpcAgent
         context 'when collection_name is missing' do
           let(:params) { {} }
 
-          it 'returns an empty hash' do
+          it 'returns an empty array' do
             response = route.handle_request(args)
-            expect(response).to eq({})
+            expect(response).to eq([])
           end
         end
       end

--- a/packages/forest_admin_rpc_agent/spec/lib/forest_admin_rpc_agent/routes/aggregate_spec.rb
+++ b/packages/forest_admin_rpc_agent/spec/lib/forest_admin_rpc_agent/routes/aggregate_spec.rb
@@ -113,9 +113,9 @@ module ForestAdminRpcAgent
         end
 
         context 'when collection_name is missing' do
-          it 'returns an empty hash' do
+          it 'returns an empty array' do
             result = route.handle_request(params: {})
-            expect(result).to eq({})
+            expect(result).to eq([])
           end
         end
       end

--- a/packages/forest_admin_rpc_agent/spec/lib/forest_admin_rpc_agent/routes/aggregate_spec.rb
+++ b/packages/forest_admin_rpc_agent/spec/lib/forest_admin_rpc_agent/routes/aggregate_spec.rb
@@ -121,6 +121,17 @@ module ForestAdminRpcAgent
             end.to raise_error(ForestAdminAgent::Http::Exceptions::NotFoundError)
           end
         end
+
+        context 'when the aggregation payload omits :groups' do
+          it 'defaults groups to [] so Aggregation.new keeps its default' do
+            route.handle_request(
+              params: params.merge('aggregation' => { 'operation' => 'Count' })
+            )
+
+            expect(ForestAdminDatasourceToolkit::Components::Query::Aggregation)
+              .to have_received(:new).with(operation: 'Count', field: nil, groups: [])
+          end
+        end
       end
     end
   end

--- a/packages/forest_admin_rpc_agent/spec/lib/forest_admin_rpc_agent/routes/aggregate_spec.rb
+++ b/packages/forest_admin_rpc_agent/spec/lib/forest_admin_rpc_agent/routes/aggregate_spec.rb
@@ -112,10 +112,13 @@ module ForestAdminRpcAgent
           end
         end
 
-        context 'when collection_name is missing' do
-          it 'returns an empty array' do
-            result = route.handle_request(params: {})
-            expect(result).to eq([])
+        context 'when the collection is unknown' do
+          it 'raises NotFoundError so the controller maps it to a 404 response' do
+            expect do
+              route.handle_request(
+                params: { 'collection_name' => 'unknown', 'aggregation' => { 'operation' => 'Count' } }
+              )
+            end.to raise_error(ForestAdminAgent::Http::Exceptions::NotFoundError)
           end
         end
       end

--- a/packages/forest_admin_rpc_agent/spec/lib/forest_admin_rpc_agent/routes/base_route_spec.rb
+++ b/packages/forest_admin_rpc_agent/spec/lib/forest_admin_rpc_agent/routes/base_route_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 require 'rails'
 require 'action_dispatch'
+require 'active_support/core_ext/hash/indifferent_access'
 
 module ForestAdminRpcAgent
   module Routes
@@ -176,6 +177,45 @@ module ForestAdminRpcAgent
             expect(response[1]).to eq({ 'Content-Type' => 'application/json' })
             expect(response[2]).to eq(['{"test":"data"}'])
           end
+        end
+      end
+
+      describe '#extract_request_params' do
+        let(:request) do
+          instance_double(
+            ActionDispatch::Request,
+            path_parameters: { controller: 'forest_admin_rails/forest', action: 'index',
+                               format: 'json', collection_name: 'books' },
+            query_parameters: { 'page' => '2' },
+            request_parameters: { 'filter' => { 'search' => 'hello' } }
+          )
+        end
+
+        it 'merges path, query and body params with indifferent access' do
+          params = route.send(:extract_request_params, request)
+
+          expect(params['collection_name']).to eq('books')
+          expect(params[:collection_name]).to eq('books')
+          expect(params['page']).to eq('2')
+          expect(params['filter']['search']).to eq('hello')
+        end
+
+        it 'strips Rails-internal path keys (controller, action, format)' do
+          params = route.send(:extract_request_params, request)
+
+          expect(params).not_to have_key('controller')
+          expect(params).not_to have_key('action')
+          expect(params).not_to have_key('format')
+        end
+
+        it 'lets body params override path params on key collision' do
+          allow(request).to receive_messages(
+            path_parameters: { collection_name: 'from_path' },
+            query_parameters: {},
+            request_parameters: { 'collection_name' => 'from_body' }
+          )
+
+          expect(route.send(:extract_request_params, request)['collection_name']).to eq('from_body')
         end
       end
     end

--- a/packages/forest_admin_rpc_agent/spec/lib/forest_admin_rpc_agent/routes/chart_spec.rb
+++ b/packages/forest_admin_rpc_agent/spec/lib/forest_admin_rpc_agent/routes/chart_spec.rb
@@ -94,10 +94,11 @@ module ForestAdminRpcAgent
           end
         end
 
-        context 'when collection_name is missing' do
-          it 'returns an empty hash' do
-            result = route.handle_request(params: {})
-            expect(result).to eq({})
+        context 'when the collection is unknown' do
+          it 'raises NotFoundError so the controller maps it to a 404 response' do
+            expect do
+              route.handle_request(params: { 'collection_name' => 'unknown', 'chart' => 'foo' })
+            end.to raise_error(ForestAdminAgent::Http::Exceptions::NotFoundError)
           end
         end
       end

--- a/packages/forest_admin_rpc_agent/spec/lib/forest_admin_rpc_agent/routes/create_spec.rb
+++ b/packages/forest_admin_rpc_agent/spec/lib/forest_admin_rpc_agent/routes/create_spec.rb
@@ -92,10 +92,11 @@ module ForestAdminRpcAgent
           end
         end
 
-        context 'when collection_name is missing' do
-          it 'returns an empty array' do
-            result = route.handle_request(params: {})
-            expect(result).to eq([])
+        context 'when the collection is unknown' do
+          it 'raises NotFoundError so the controller maps it to a 404 response' do
+            expect do
+              route.handle_request(params: { 'collection_name' => 'unknown', 'data' => [{}] })
+            end.to raise_error(ForestAdminAgent::Http::Exceptions::NotFoundError)
           end
         end
       end

--- a/packages/forest_admin_rpc_agent/spec/lib/forest_admin_rpc_agent/routes/create_spec.rb
+++ b/packages/forest_admin_rpc_agent/spec/lib/forest_admin_rpc_agent/routes/create_spec.rb
@@ -93,9 +93,9 @@ module ForestAdminRpcAgent
         end
 
         context 'when collection_name is missing' do
-          it 'returns an empty hash' do
+          it 'returns an empty array' do
             result = route.handle_request(params: {})
-            expect(result).to eq({})
+            expect(result).to eq([])
           end
         end
       end

--- a/packages/forest_admin_rpc_agent/spec/lib/forest_admin_rpc_agent/routes/delete_spec.rb
+++ b/packages/forest_admin_rpc_agent/spec/lib/forest_admin_rpc_agent/routes/delete_spec.rb
@@ -56,10 +56,11 @@ module ForestAdminRpcAgent
           end
         end
 
-        context 'when collection_name is missing' do
-          it 'returns an empty hash' do
-            result = route.handle_request(params: {})
-            expect(result).to eq({})
+        context 'when the collection is unknown' do
+          it 'raises NotFoundError so the controller maps it to a 404 response' do
+            expect do
+              route.handle_request(params: { 'collection_name' => 'unknown', 'filter' => {} })
+            end.to raise_error(ForestAdminAgent::Http::Exceptions::NotFoundError)
           end
         end
       end

--- a/packages/forest_admin_rpc_agent/spec/lib/forest_admin_rpc_agent/routes/list_spec.rb
+++ b/packages/forest_admin_rpc_agent/spec/lib/forest_admin_rpc_agent/routes/list_spec.rb
@@ -77,9 +77,9 @@ module ForestAdminRpcAgent
         end
 
         context 'when collection_name is missing' do
-          it 'returns an empty hash' do
+          it 'returns an empty array' do
             result = route.handle_request(params: {})
-            expect(result).to eq({})
+            expect(result).to eq([])
           end
         end
       end

--- a/packages/forest_admin_rpc_agent/spec/lib/forest_admin_rpc_agent/routes/list_spec.rb
+++ b/packages/forest_admin_rpc_agent/spec/lib/forest_admin_rpc_agent/routes/list_spec.rb
@@ -76,10 +76,11 @@ module ForestAdminRpcAgent
           end
         end
 
-        context 'when collection_name is missing' do
-          it 'returns an empty array' do
-            result = route.handle_request(params: {})
-            expect(result).to eq([])
+        context 'when the collection is unknown' do
+          it 'raises NotFoundError so the controller maps it to a 404 response' do
+            expect do
+              route.handle_request(params: { 'collection_name' => 'unknown' })
+            end.to raise_error(ForestAdminAgent::Http::Exceptions::NotFoundError)
           end
         end
       end

--- a/packages/forest_admin_rpc_agent/spec/lib/forest_admin_rpc_agent/routes/update_spec.rb
+++ b/packages/forest_admin_rpc_agent/spec/lib/forest_admin_rpc_agent/routes/update_spec.rb
@@ -83,10 +83,11 @@ module ForestAdminRpcAgent
           end
         end
 
-        context 'when collection_name is missing' do
-          it 'returns an empty hash' do
-            result = route.handle_request(params: {})
-            expect(result).to eq({})
+        context 'when the collection is unknown' do
+          it 'raises NotFoundError so the controller maps it to a 404 response' do
+            expect do
+              route.handle_request(params: { 'collection_name' => 'unknown', 'filter' => {}, 'patch' => {} })
+            end.to raise_error(ForestAdminAgent::Http::Exceptions::NotFoundError)
           end
         end
       end


### PR DESCRIPTION
## Definition of Done

### General

- [ ] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [ ] Test manually the implemented changes
- [ ] Validate the code quality (indentation, syntax, style, simplicity, readability)

### Security

- [ ] Consider the security impact of the changes made


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix RPC agent Rails routes to include URL path parameters in request params
> - Adds `extract_request_params` helper in [`BaseRoute`](https://github.com/ForestAdmin/agent-ruby/pull/310/files#diff-0b1b029dc4c0c7c8eadc71e2943a8339c4770b4d0ed1a1a25527f297b3899f1a) that merges `path_parameters`, `query_parameters`, and `request_parameters` so that URL segment params like `:collection_name` are available to route handlers.
> - Route handlers in `list`, `create`, `aggregate`, and `action_form` previously received only query/body params, causing `collection_name` to be missing when provided as a path segment.
> - Changes the missing `collection_name` fallback return value from `{}` to `[]` across all affected handlers.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #310 opened
>
> - Removed early-return guards from route handlers to raise errors for missing or unknown collections [8e3ff47]
> - Refactored parameter extraction to use indifferent access without deep key symbolization [8e3ff47]
> - Updated route handler specs to expect errors instead of empty results for unknown collections [8e3ff47]
> - Added test coverage for `ForestAdminRpcAgent::Routes::Aggregate#handle_request` to verify that when the aggregation payload omits the `:groups` key, `Aggregation.new` is invoked with `groups` defaulting to an empty array [e0ffe0d]
> - Added test coverage for `ForestAdminRpcAgent::Routes::BaseRoute#extract_request_params` to verify parameter merging behavior from path, query, and body sources with indifferent access and proper filtering of Rails-internal keys [e0ffe0d]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cc8ced2.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->