### PR TITLE
fix(zendesk): warn on custom-field name collisions

### DIFF
--- a/packages/forest_admin_datasource_zendesk/lib/forest_admin_datasource_zendesk/collections/base_collection.rb
+++ b/packages/forest_admin_datasource_zendesk/lib/forest_admin_datasource_zendesk/collections/base_collection.rb
@@ -95,6 +95,26 @@ module ForestAdminDatasourceZendesk
         [translated, filter.search].compact.reject(&:empty?).join(' ')
       end
 
+      # Adds custom fields, skipping any whose column name collides with a
+      # field already declared on the collection (native column or relation).
+      # Returns the list of fields actually added so callers can keep their
+      # serializer in sync with the schema.
+      def add_custom_fields(custom_fields)
+        custom_fields.reject do |cf|
+          name = cf[:column_name]
+          if schema[:fields].key?(name)
+            ForestAdminDatasourceZendesk.logger.warn(
+              "[forest_admin_datasource_zendesk] Custom field '#{name}' on collection " \
+              "'#{self.name}' conflicts with an existing field; skipping."
+            )
+            true
+          else
+            add_field(name, cf[:schema])
+            false
+          end
+        end
+      end
+
       private
 
       def sort_field_and_direction(entry)

--- a/packages/forest_admin_datasource_zendesk/lib/forest_admin_datasource_zendesk/collections/base_collection.rb
+++ b/packages/forest_admin_datasource_zendesk/lib/forest_admin_datasource_zendesk/collections/base_collection.rb
@@ -101,15 +101,15 @@ module ForestAdminDatasourceZendesk
       # serializer in sync with the schema.
       def add_custom_fields(custom_fields)
         custom_fields.reject do |cf|
-          name = cf[:column_name]
-          if schema[:fields].key?(name)
+          column_name = cf[:column_name]
+          if schema[:fields].key?(column_name)
             ForestAdminDatasourceZendesk.logger.warn(
-              "[forest_admin_datasource_zendesk] Custom field '#{name}' on collection " \
-              "'#{self.name}' conflicts with an existing field; skipping."
+              "[forest_admin_datasource_zendesk] Custom field '#{column_name}' on collection " \
+              "'#{name}' conflicts with an existing field; skipping."
             )
             true
           else
-            add_field(name, cf[:schema])
+            add_field(column_name, cf[:schema])
             false
           end
         end

--- a/packages/forest_admin_datasource_zendesk/lib/forest_admin_datasource_zendesk/collections/organization.rb
+++ b/packages/forest_admin_datasource_zendesk/lib/forest_admin_datasource_zendesk/collections/organization.rb
@@ -3,6 +3,8 @@ module ForestAdminDatasourceZendesk
     class Organization < BaseCollection
       include Searchable
 
+      attr_reader :custom_fields
+
       OneToManySchema = ForestAdminDatasourceToolkit::Schema::Relations::OneToManySchema
 
       ZENDESK_SORTABLE = {
@@ -13,9 +15,9 @@ module ForestAdminDatasourceZendesk
 
       def initialize(datasource, custom_fields: [])
         super(datasource, 'ZendeskOrganization')
-        @custom_fields = custom_fields
         define_schema
         define_relations
+        @custom_fields = add_custom_fields(custom_fields)
         enable_search
         enable_count
       end
@@ -79,8 +81,6 @@ module ForestAdminDatasourceZendesk
                                                  is_read_only: true, is_sortable: true))
         add_field('updated_at', ColumnSchema.new(column_type: 'Date', filter_operators: DATE_OPS,
                                                  is_read_only: true, is_sortable: true))
-
-        @custom_fields.each { |cf| add_field(cf[:column_name], cf[:schema]) }
       end
 
       def define_relations

--- a/packages/forest_admin_datasource_zendesk/lib/forest_admin_datasource_zendesk/collections/ticket.rb
+++ b/packages/forest_admin_datasource_zendesk/lib/forest_admin_datasource_zendesk/collections/ticket.rb
@@ -6,6 +6,8 @@ module ForestAdminDatasourceZendesk
       include CommentsEmbedder
       include Serializer
 
+      attr_reader :custom_fields
+
       ManyToOneSchema = ForestAdminDatasourceToolkit::Schema::Relations::ManyToOneSchema
 
       ZENDESK_SORTABLE = {
@@ -28,9 +30,9 @@ module ForestAdminDatasourceZendesk
 
       def initialize(datasource, custom_fields: [])
         super(datasource, 'ZendeskTicket')
-        @custom_fields = custom_fields
         define_schema
         define_relations
+        @custom_fields = add_custom_fields(custom_fields)
         enable_search
         enable_count
       end

--- a/packages/forest_admin_datasource_zendesk/lib/forest_admin_datasource_zendesk/collections/ticket/schema_definition.rb
+++ b/packages/forest_admin_datasource_zendesk/lib/forest_admin_datasource_zendesk/collections/ticket/schema_definition.rb
@@ -46,8 +46,6 @@ module ForestAdminDatasourceZendesk
                                                    is_read_only: true, is_sortable: true))
           add_field('updated_at', ColumnSchema.new(column_type: 'Date', filter_operators: DATE_OPS,
                                                    is_read_only: true, is_sortable: true))
-
-          @custom_fields.each { |cf| add_field(cf[:column_name], cf[:schema]) }
         end
 
         def define_relations

--- a/packages/forest_admin_datasource_zendesk/lib/forest_admin_datasource_zendesk/collections/user.rb
+++ b/packages/forest_admin_datasource_zendesk/lib/forest_admin_datasource_zendesk/collections/user.rb
@@ -3,6 +3,8 @@ module ForestAdminDatasourceZendesk
     class User < BaseCollection
       include Searchable
 
+      attr_reader :custom_fields
+
       ManyToOneSchema = ForestAdminDatasourceToolkit::Schema::Relations::ManyToOneSchema
       OneToManySchema = ForestAdminDatasourceToolkit::Schema::Relations::OneToManySchema
       ENUM_ROLE       = %w[end-user agent admin].freeze
@@ -17,9 +19,9 @@ module ForestAdminDatasourceZendesk
 
       def initialize(datasource, custom_fields: [])
         super(datasource, 'ZendeskUser')
-        @custom_fields = custom_fields
         define_schema
         define_relations
+        @custom_fields = add_custom_fields(custom_fields)
         enable_search
         enable_count
       end
@@ -89,8 +91,6 @@ module ForestAdminDatasourceZendesk
                                                  is_read_only: true, is_sortable: true))
         add_field('updated_at', ColumnSchema.new(column_type: 'Date', filter_operators: DATE_OPS,
                                                  is_read_only: true, is_sortable: true))
-
-        @custom_fields.each { |cf| add_field(cf[:column_name], cf[:schema]) }
       end
 
       def define_relations

--- a/packages/forest_admin_datasource_zendesk/lib/forest_admin_datasource_zendesk/datasource.rb
+++ b/packages/forest_admin_datasource_zendesk/lib/forest_admin_datasource_zendesk/datasource.rb
@@ -16,15 +16,16 @@ module ForestAdminDatasourceZendesk
     def register_collections
       introspector = Schema::CustomFieldsIntrospector.new(@client)
 
-      ticket_cf = introspector.ticket_custom_fields
-      user_cf   = introspector.user_custom_fields
-      org_cf    = introspector.organization_custom_fields
+      ticket = Collections::Ticket.new(self, custom_fields: introspector.ticket_custom_fields)
+      user = Collections::User.new(self, custom_fields: introspector.user_custom_fields)
+      org = Collections::Organization.new(self, custom_fields: introspector.organization_custom_fields)
 
-      add_collection(Collections::Ticket.new(self, custom_fields: ticket_cf))
-      add_collection(Collections::User.new(self, custom_fields: user_cf))
-      add_collection(Collections::Organization.new(self, custom_fields: org_cf))
+      add_collection(ticket)
+      add_collection(user)
+      add_collection(org)
 
-      @custom_field_mapping = build_custom_field_mapping(ticket_cf, user_cf, org_cf)
+      @custom_field_mapping = build_custom_field_mapping(ticket.custom_fields,
+                                                         user.custom_fields, org.custom_fields)
     end
 
     # Forest column name -> Zendesk Search field name. Lives on the instance

--- a/packages/forest_admin_datasource_zendesk/spec/forest_admin_datasource_zendesk/collections/user_spec.rb
+++ b/packages/forest_admin_datasource_zendesk/spec/forest_admin_datasource_zendesk/collections/user_spec.rb
@@ -115,6 +115,37 @@ module ForestAdminDatasourceZendesk
         collection.create(nil, 'email' => 'a@b.com', 'tier' => 'gold')
         expect(client).to have_received(:create_user)
       end
+
+      context 'when a custom field collides with a native field' do
+        let(:cf) do
+          [{ column_name: 'role', zendesk_id: 42, zendesk_key: 'role',
+             schema: ForestAdminDatasourceToolkit::Schema::ColumnSchema.new(
+               column_type: 'String', filter_operators: [], is_read_only: false
+             ) }]
+        end
+
+        it 'logs a warning and skips the conflicting custom field instead of raising' do
+          logger = instance_double(Logger, warn: nil)
+          allow(ForestAdminDatasourceZendesk).to receive(:logger).and_return(logger)
+
+          expect { collection }.not_to raise_error
+          expect(logger).to have_received(:warn).with(/Custom field 'role'.*conflicts/)
+        end
+
+        it 'keeps the native role enum schema on the collection' do
+          allow(ForestAdminDatasourceZendesk).to receive(:logger).and_return(instance_double(Logger, warn: nil))
+          expect(collection.schema[:fields]['role'].column_type).to eq('Enum')
+        end
+
+        it 'does not overwrite the native role value when serializing' do
+          allow(ForestAdminDatasourceZendesk).to receive(:logger).and_return(instance_double(Logger, warn: nil))
+          user = zendesk_user('id' => 1, 'role' => 'admin', 'user_fields' => { 'role' => 'something-else' })
+          allow(client).to receive(:search).and_return([user])
+
+          result = collection.list(nil, Filter.new, nil).first
+          expect(result['role']).to eq('admin')
+        end
+      end
     end
 
     describe '#create' do


### PR DESCRIPTION
## Summary
- Zendesk custom fields whose key collides with a native column or relation (e.g. a user_field named `role`) used to crash agent setup with `Field role already defined in collection (RuntimeError)`.
- The conflicting field is now skipped with a warning via `ForestAdminDatasourceZendesk.logger`, so agent setup keeps going.
- The filtered list flows back into the datasource search mapping so schema and query translation stay in sync.

## Test plan
- [x] `bundle exec rspec` in `packages/forest_admin_datasource_zendesk` — 238 examples, 0 failures.
- [x] `bundle exec rubocop lib/ spec/` — clean.
- [x] New unit tests in `user_spec.rb` cover the `role` collision (warning emitted, native enum schema preserved, native value not overwritten by serializer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Warn and skip custom fields that collide with native field names in Zendesk collections
> - Adds `add_custom_fields` to [`BaseCollection`](https://github.com/ForestAdmin/agent-ruby/pull/312/files#diff-45edc1a6f679b29df3687bce7280b7eee72315e6308cf3790b1895e317ebb3a7) that checks each custom field against the existing schema, logs a warning on collision, and skips the conflicting field.
> - Updates `Ticket`, `User`, and `Organization` collections to use `add_custom_fields` instead of registering custom fields directly in `define_schema`, so `@custom_fields` only contains fields actually added.
> - Updates [`Datasource#build_custom_field_mapping`](https://github.com/ForestAdmin/agent-ruby/pull/312/files#diff-67a9d55669bb1902d2615a665cd5b900bf8b07764df57fe3d0441287becf7488) to derive the mapping from the filtered `@custom_fields` on each collection rather than raw introspection arrays.
> - Behavioral Change: native fields (e.g. `role` on `User`) can no longer be silently overwritten by a colliding custom field during serialization.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3810cf0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->