### PR TITLE
refactor(zendesk): template-method init for collections

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -251,6 +251,7 @@ Naming/PredicatePrefix:
 
 Metrics/ParameterLists:
   Exclude:
+    - 'packages/forest_admin_datasource_zendesk/lib/forest_admin_datasource_zendesk/collections/base_collection.rb'
     - 'packages/forest_admin_datasource_snowflake/lib/forest_admin_datasource_snowflake/datasource.rb'
     - 'packages/forest_admin_agent/lib/forest_admin_agent/routes/query_handler.rb'
     - 'packages/forest_admin_agent/lib/forest_admin_agent/services/smart_action_checker.rb'
@@ -347,6 +348,7 @@ Metrics/BlockLength:
 
 Metrics/ClassLength:
   Exclude:
+    - 'packages/forest_admin_datasource_zendesk/lib/forest_admin_datasource_zendesk/collections/base_collection.rb'
     - 'packages/forest_admin_datasource_snowflake/lib/forest_admin_datasource_snowflake/collection.rb'
     - 'packages/forest_admin_datasource_snowflake/lib/forest_admin_datasource_snowflake/datasource.rb'
     - 'packages/forest_admin_datasource_snowflake/lib/forest_admin_datasource_snowflake/utils/query.rb'

--- a/packages/forest_admin_datasource_zendesk/lib/forest_admin_datasource_zendesk/collections/base_collection.rb
+++ b/packages/forest_admin_datasource_zendesk/lib/forest_admin_datasource_zendesk/collections/base_collection.rb
@@ -11,6 +11,23 @@ module ForestAdminDatasourceZendesk
       DATE_OPS    = [Operators::EQUAL, Operators::BEFORE, Operators::AFTER,
                      Operators::PRESENT, Operators::BLANK].freeze
 
+      attr_reader :custom_fields
+
+      # Template method: subclasses implement `define_schema` and
+      # `define_relations` as hooks; ordering between them, custom-field
+      # registration, and the search/count flags is owned here so collisions
+      # are always evaluated against the final native schema. A subclass can
+      # opt out of search/count by passing `searchable: false` / `countable:
+      # false` through `super`.
+      def initialize(datasource, name, custom_fields: [], searchable: true, countable: true, native_driver: nil)
+        super(datasource, name, native_driver)
+        define_schema
+        define_relations
+        @custom_fields = add_custom_fields(custom_fields)
+        enable_search if searchable
+        enable_count if countable
+      end
+
       def aggregate(caller, filter, aggregation, _limit = nil)
         unless aggregation.operation == 'Count' && aggregation.field.nil? && aggregation.groups.empty?
           raise ForestAdminDatasourceToolkit::Exceptions::ForestException,
@@ -97,7 +114,7 @@ module ForestAdminDatasourceZendesk
 
       # Adds custom fields, skipping any whose column name collides with a
       # field already declared on the collection (native column or relation).
-      # Returns the list of fields actually added so callers can keep their
+      # Returns the subset actually added so callers can keep their
       # serializer in sync with the schema.
       def add_custom_fields(custom_fields)
         custom_fields.reject do |cf|
@@ -116,6 +133,9 @@ module ForestAdminDatasourceZendesk
       end
 
       private
+
+      def define_schema    = raise(NotImplementedError, "#{self.class} did not implement define_schema")
+      def define_relations = raise(NotImplementedError, "#{self.class} did not implement define_relations")
 
       def sort_field_and_direction(entry)
         return [entry.field, entry.ascending] if entry.respond_to?(:field)

--- a/packages/forest_admin_datasource_zendesk/lib/forest_admin_datasource_zendesk/collections/organization.rb
+++ b/packages/forest_admin_datasource_zendesk/lib/forest_admin_datasource_zendesk/collections/organization.rb
@@ -3,8 +3,6 @@ module ForestAdminDatasourceZendesk
     class Organization < BaseCollection
       include Searchable
 
-      attr_reader :custom_fields
-
       OneToManySchema = ForestAdminDatasourceToolkit::Schema::Relations::OneToManySchema
 
       ZENDESK_SORTABLE = {
@@ -14,12 +12,7 @@ module ForestAdminDatasourceZendesk
       }.freeze
 
       def initialize(datasource, custom_fields: [])
-        super(datasource, 'ZendeskOrganization')
-        define_schema
-        define_relations
-        @custom_fields = add_custom_fields(custom_fields)
-        enable_search
-        enable_count
+        super(datasource, 'ZendeskOrganization', custom_fields: custom_fields)
       end
 
       def create(_caller, data)

--- a/packages/forest_admin_datasource_zendesk/lib/forest_admin_datasource_zendesk/collections/ticket.rb
+++ b/packages/forest_admin_datasource_zendesk/lib/forest_admin_datasource_zendesk/collections/ticket.rb
@@ -6,8 +6,6 @@ module ForestAdminDatasourceZendesk
       include CommentsEmbedder
       include Serializer
 
-      attr_reader :custom_fields
-
       ManyToOneSchema = ForestAdminDatasourceToolkit::Schema::Relations::ManyToOneSchema
 
       ZENDESK_SORTABLE = {
@@ -29,12 +27,7 @@ module ForestAdminDatasourceZendesk
       }.freeze
 
       def initialize(datasource, custom_fields: [])
-        super(datasource, 'ZendeskTicket')
-        define_schema
-        define_relations
-        @custom_fields = add_custom_fields(custom_fields)
-        enable_search
-        enable_count
+        super(datasource, 'ZendeskTicket', custom_fields: custom_fields)
       end
 
       def list(caller, filter, projection)

--- a/packages/forest_admin_datasource_zendesk/lib/forest_admin_datasource_zendesk/collections/user.rb
+++ b/packages/forest_admin_datasource_zendesk/lib/forest_admin_datasource_zendesk/collections/user.rb
@@ -3,8 +3,6 @@ module ForestAdminDatasourceZendesk
     class User < BaseCollection
       include Searchable
 
-      attr_reader :custom_fields
-
       ManyToOneSchema = ForestAdminDatasourceToolkit::Schema::Relations::ManyToOneSchema
       OneToManySchema = ForestAdminDatasourceToolkit::Schema::Relations::OneToManySchema
       ENUM_ROLE       = %w[end-user agent admin].freeze
@@ -18,12 +16,7 @@ module ForestAdminDatasourceZendesk
       }.freeze
 
       def initialize(datasource, custom_fields: [])
-        super(datasource, 'ZendeskUser')
-        define_schema
-        define_relations
-        @custom_fields = add_custom_fields(custom_fields)
-        enable_search
-        enable_count
+        super(datasource, 'ZendeskUser', custom_fields: custom_fields)
       end
 
       def create(_caller, data)

--- a/packages/forest_admin_datasource_zendesk/spec/forest_admin_datasource_zendesk/collections/base_collection_spec.rb
+++ b/packages/forest_admin_datasource_zendesk/spec/forest_admin_datasource_zendesk/collections/base_collection_spec.rb
@@ -1,0 +1,44 @@
+module ForestAdminDatasourceZendesk
+  RSpec.describe Collections::BaseCollection do
+    let(:datasource) do
+      instance_double(ForestAdminDatasourceZendesk::Datasource,
+                      client: instance_double(ForestAdminDatasourceZendesk::Client),
+                      custom_field_mapping: {})
+    end
+
+    describe 'subclass contract' do
+      it 'raises NotImplementedError naming define_schema when the hook is missing' do
+        subclass = Class.new(described_class)
+        expect { subclass.new(datasource, 'X') }
+          .to raise_error(NotImplementedError, /define_schema/)
+      end
+
+      it 'raises NotImplementedError naming define_relations when only define_schema is implemented' do
+        subclass = Class.new(described_class) { def define_schema; end }
+        expect { subclass.new(datasource, 'X') }
+          .to raise_error(NotImplementedError, /define_relations/)
+      end
+    end
+
+    describe 'search/count opt-out' do
+      let(:subclass) do
+        Class.new(described_class) do
+          def define_schema; end
+          def define_relations; end
+        end
+      end
+
+      it 'enables search and count by default' do
+        collection = subclass.new(datasource, 'X')
+        expect(collection.is_searchable?).to be(true)
+        expect(collection.is_countable?).to be(true)
+      end
+
+      it 'honours searchable: false / countable: false from super' do
+        collection = subclass.new(datasource, 'X', searchable: false, countable: false)
+        expect(collection.is_searchable?).to be(false)
+        expect(collection.is_countable?).to be(false)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Hoist the Zendesk collection setup (`define_schema → define_relations → add_custom_fields → enable_search → enable_count`) into `BaseCollection#initialize`. The ordering becomes an invariant of the base class instead of a discipline the subclass author has to remember — a follow-up to #312, where the custom-field collision check silently depended on schema+relations being added first.
- Subclass initializers shrink to one line: `super(datasource, 'ZendeskX', custom_fields: custom_fields)`.
- `define_schema` / `define_relations` now raise `NotImplementedError` with the subclass name when omitted — explicit contract instead of `NoMethodError`.
- `searchable:` / `countable:` kwargs (default `true`) let a future subclass opt out via `super(..., searchable: false)` without re-defining the whole initializer.
- `native_driver` is propagated to the toolkit `Collection` constructor.

## Test plan
- [x] `bundle exec rspec` — 242 examples, 0 failures (4 new specs in `base_collection_spec.rb` lock the NotImplementedError contract and the search/count opt-out).
- [x] `bundle exec rubocop lib/ spec/` — clean.
- [x] `.rubocop.yml`: `Metrics/ParameterLists` and `Metrics/ClassLength` exclude this file (same pattern as `forest_admin_datasource_snowflake/collection.rb`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refactor Zendesk collection init to use template-method pattern in `BaseCollection`
> - Moves the initialization lifecycle (schema definition, relations, custom fields, search/count flags) into `BaseCollection#initialize`, replacing repeated boilerplate in `Organization`, `Ticket`, and `User`.
> - Adds abstract `define_schema` and `define_relations` hook methods that raise `NotImplementedError` if not implemented by a subclass.
> - `searchable` and `countable` default to `true` and can be opted out via keyword arguments.
> - `attr_reader :custom_fields` is now provided by `BaseCollection` and removed from each subclass.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f17ae58.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->