### PR TITLE
fix(rails): load create_agent.rb explicitly instead of autoloading the whole lib/

### DIFF
--- a/packages/forest_admin_rails/lib/forest_admin_rails/engine.rb
+++ b/packages/forest_admin_rails/lib/forest_admin_rails/engine.rb
@@ -24,11 +24,6 @@ module ForestAdminRails
 
     extend ActiveSupport::Concern
 
-    initializer 'forest_admin_rails.add_autoload_paths', before: :set_autoload_paths do |app|
-      lib_path = Rails.root.join('lib')
-      app.config.autoload_paths << lib_path unless app.config.autoload_paths.frozen?
-    end
-
     initializer 'forest_admin_rails.error_subscribe' do
       Rails.error.subscribe(ForestAdminErrorSubscriber.new)
     end
@@ -49,16 +44,20 @@ module ForestAdminRails
       # force eager loading models
       Rails.application.eager_load!
 
+      require create_agent_path.to_s
+
       setup_agent_and_cache_routes
 
       sse = ForestAdminAgent::Services::SSECacheInvalidation
       sse.run if ForestAdminRails.config[:instant_cache_refresh]
     end
 
-    def create_agent_file_exists?
-      path = Rails.root.join('lib', 'forest_admin_rails', 'create_agent.rb')
+    def create_agent_path
+      Rails.root.join('lib', 'forest_admin_rails', 'create_agent.rb')
+    end
 
-      File.exist?(path)
+    def create_agent_file_exists?
+      File.exist?(create_agent_path)
     end
 
     def setup_agent_and_cache_routes

--- a/packages/forest_admin_rails/spec/lib/forest_admin_rails/engine_spec.rb
+++ b/packages/forest_admin_rails/spec/lib/forest_admin_rails/engine_spec.rb
@@ -271,4 +271,100 @@ module ForestAdminRails
       end
     end
   end
+
+  RSpec.describe 'Engine autoload behaviour' do
+    it 'does not register an initializer that adds the host lib/ to autoload_paths' do
+      initializer_names = ForestAdminRails::Engine.initializers.map(&:name)
+
+      expect(initializer_names).not_to include('forest_admin_rails.add_autoload_paths')
+    end
+  end
+
+  RSpec.describe 'Engine#create_agent_path' do
+    let(:engine_instance) { ForestAdminRails::Engine.allocate }
+
+    before do
+      allow(Rails).to receive(:root).and_return(Pathname.new('/app'))
+    end
+
+    it 'points to lib/forest_admin_rails/create_agent.rb under Rails.root' do
+      expect(engine_instance.create_agent_path.to_s).to eq('/app/lib/forest_admin_rails/create_agent.rb')
+    end
+  end
+
+  RSpec.describe 'Engine#create_agent_file_exists?' do
+    let(:engine_instance) { ForestAdminRails::Engine.allocate }
+
+    before do
+      allow(Rails).to receive(:root).and_return(Pathname.new('/app'))
+    end
+
+    it 'returns true when the host create_agent.rb exists' do
+      allow(File).to receive(:exist?).with(engine_instance.create_agent_path).and_return(true)
+
+      expect(engine_instance.create_agent_file_exists?).to be true
+    end
+
+    it 'returns false when the host create_agent.rb is absent' do
+      allow(File).to receive(:exist?).with(engine_instance.create_agent_path).and_return(false)
+
+      expect(engine_instance.create_agent_file_exists?).to be false
+    end
+  end
+
+  RSpec.describe 'Engine#load_configuration' do
+    let(:engine_instance) { ForestAdminRails::Engine.allocate }
+
+    before do
+      allow(Rails).to receive(:root).and_return(Pathname.new('/app'))
+      allow(engine_instance).to receive(:require)
+      allow(engine_instance).to receive(:setup_agent_and_cache_routes)
+    end
+
+    context 'when no web server is running' do
+      before { allow(engine_instance).to receive(:running_web_server?).and_return(false) }
+
+      it 'does not load the host create_agent.rb nor run the setup' do
+        engine_instance.load_configuration
+
+        expect(engine_instance).not_to have_received(:require)
+        expect(engine_instance).not_to have_received(:setup_agent_and_cache_routes)
+      end
+    end
+
+    context 'when the host create_agent.rb is absent' do
+      before do
+        allow(engine_instance).to receive_messages(running_web_server?: true, create_agent_file_exists?: false)
+      end
+
+      it 'does not load it nor run the setup' do
+        engine_instance.load_configuration
+
+        expect(engine_instance).not_to have_received(:require)
+        expect(engine_instance).not_to have_received(:setup_agent_and_cache_routes)
+      end
+    end
+
+    context 'when a web server is running and the host create_agent.rb exists' do
+      # rubocop:disable RSpec/VerifiedDoubles
+      let(:application) { double('application', eager_load!: nil) }
+      # rubocop:enable RSpec/VerifiedDoubles
+
+      before do
+        allow(engine_instance).to receive_messages(running_web_server?: true, create_agent_file_exists?: true)
+        allow(Rails).to receive(:application).and_return(application)
+        ForestAdminAgent::Services.const_set(:SSECacheInvalidation, Class.new)
+        without_partial_double_verification do
+          allow(ForestAdminRails).to receive(:config).and_return({})
+        end
+      end
+
+      it 'requires the host create_agent.rb explicitly, then runs the setup' do
+        engine_instance.load_configuration
+
+        expect(engine_instance).to have_received(:require).with('/app/lib/forest_admin_rails/create_agent.rb')
+        expect(engine_instance).to have_received(:setup_agent_and_cache_routes)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Problem

A customer migrating to `forest_admin_rails` reported that the gem breaks their boot: their entire `lib/` directory ends up managed by Zeitwerk autoloading, conflicting with their explicit loading strategy (explicit `require`/`include`).

Root cause: the engine added the host app's **whole** `lib/` directory to Zeitwerk `autoload_paths`, via this initializer:

```ruby
initializer 'forest_admin_rails.add_autoload_paths', before: :set_autoload_paths do |app|
  lib_path = Rails.root.join('lib')
  app.config.autoload_paths << lib_path unless app.config.autoload_paths.frozen?
end
```

The **only** reason this existed was to resolve the constant `ForestAdminRails::CreateAgent` from the host's `lib/forest_admin_rails/create_agent.rb`. But since Rails 6, `lib/` is intentionally kept out of `autoload_paths` precisely because it often contains files that aren't Zeitwerk-compatible or are loaded explicitly. Forcing the host's entire `lib/` into autoload is intrusive and is what breaks these apps.

## Fix

- Remove the `add_autoload_paths` initializer.
- Load only the file we actually need, explicitly, during `load_configuration` — right after the existing `create_agent_file_exists?` guard:

```ruby
require create_agent_path.to_s
```

Since `lib/` is no longer in autoload_paths, a plain `require` is safe (no Zeitwerk conflict), and the host's `lib/` is left entirely under the app's own control. The path is centralized in a `create_agent_path` helper reused by `create_agent_file_exists?`.

## Tests

Added to `engine_spec.rb`:
- **Regression test**: the engine no longer registers the `forest_admin_rails.add_autoload_paths` initializer.
- `create_agent_path` points to the expected location under `Rails.root`.
- `create_agent_file_exists?` (present / absent).
- `load_configuration`: skips when no web server / file absent; `require`s the host file explicitly then runs setup when both conditions hold.

All `engine_spec.rb` examples pass (28, 0 failures) and RuboCop is clean.