### PR TITLE
chore(agent): bump rack-cors to ~> 3.0

### DIFF
--- a/packages/forest_admin_agent/forest_admin_agent.gemspec
+++ b/packages/forest_admin_agent/forest_admin_agent.gemspec
@@ -53,6 +53,6 @@ admin work on any Ruby application."
   spec.add_dependency "mono_logger", "~> 1.1"
   spec.add_dependency "openid_connect", "~> 2.2"
   spec.add_dependency "rake", "~> 13.0"
-  spec.add_dependency "rack-cors", "~> 2.0"
+  spec.add_dependency "rack-cors", "~> 3.0"
   spec.add_dependency "zeitwerk", "~> 2.3"
 end


### PR DESCRIPTION
## What

Bumps the `rack-cors` runtime dependency of `forest_admin_agent` from `~> 2.0` (resolved 2.0.2) to `~> 3.0` (resolved 3.0.0).

## Why it's safe

rack-cors 3.0.0 is the only release after 2.0.2, and its breaking changes are purely environmental — **no config DSL changes**:

| 3.0.0 requirement | This repo | OK? |
|---|---|---|
| Rack `>= 3.0.14` | resolves rack **3.2.6** | ✅ |
| Drops Ruby 2.3 | gemspec requires `>= 3.0.0` | ✅ |
| Adds `logger` runtime dep | already in the tree | ✅ |

The CORS config DSL (`allow`/`origins`/`resource`) used in `forest_admin_rails/lib/forest_admin_rails/engine.rb` is unchanged in 3.0.0.

## Testing

- CORS middleware-loading specs (`engine_spec.rb`) — pass
- `forest_controller_spec.rb` "exposes Content-Disposition via CORS" — pass
- Verified the bump introduces **zero new failures**: the few failures in the full rails suite (a production-logging mock expectation and `routes_spec` `AgentFactory` stubbing) reproduce identically on rack-cors 2.0.2 / pass in isolation, so they are pre-existing test-isolation issues unrelated to this change.

Note: package `Gemfile.lock` files are gitignored, so only the gemspec constraint is committed.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump `rack-cors` dependency to `~> 3.0` in forest_admin_agent
> Updates the `rack-cors` constraint in [forest_admin_agent.gemspec](https://github.com/ForestAdmin/agent-ruby/pull/315/files#diff-fb029f357c9e92eeb1623e6193e12a58a1faf99e5049ead27432497110547d28) from `~> 2.0` to `~> 3.0`. Risk: projects depending on this gem must now have `rack-cors` 3.x available.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 48fae14.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->