### PR TITLE
feat(schema): expose foreign_key_type_field on polymorphic relation

### DIFF
--- a/packages/forest_admin_agent/lib/forest_admin_agent/utils/schema/generator_field.rb
+++ b/packages/forest_admin_agent/lib/forest_admin_agent/utils/schema/generator_field.rb
@@ -165,7 +165,8 @@ module ForestAdminAgent
                 isSortable: false,
                 validations: [],
                 reference: "#{base_schema[:field]}.id",
-                polymorphic_referenced_models: relation.foreign_collections
+                polymorphic_referenced_models: relation.foreign_collections,
+                foreign_key_type_field: relation.foreign_key_type_field
               }
             )
           end

--- a/packages/forest_admin_agent/spec/lib/forest_admin_agent/utils/schema/generator_field_polymorphic_spec.rb
+++ b/packages/forest_admin_agent/spec/lib/forest_admin_agent/utils/schema/generator_field_polymorphic_spec.rb
@@ -86,7 +86,8 @@ module ForestAdminAgent
                   isSortable: false,
                   isVirtual: false,
                   validations: [],
-                  polymorphic_referenced_models: %w[User Order]
+                  polymorphic_referenced_models: %w[User Order],
+                  foreign_key_type_field: 'addressable_type'
                 }
               )
             end


### PR DESCRIPTION
## Context

In the schema emitted for `PolymorphicManyToOne` relations (`belongs_to ..., polymorphic: true`), we already exposed the list of target models via `polymorphic_referenced_models`, but **not** the name of the discriminator column (the `_type`, e.g. `addressable_type`). As a result, the Forest query executor could not resolve which model a polymorphic record targets.

## Change

On the polymorphic relation field of the emitted schema, expose the discriminator column name as metadata, next to `polymorphic_referenced_models`:

```ruby
foreign_key_type_field: relation.foreign_key_type_field  # e.g. "addressable_type"
```

- Naming convention follows the neighbouring polymorphic key (`polymorphic_referenced_models`): snake_case `foreign_key_type_field`.
- No allowed-keys whitelist exists in agent-ruby (`SchemaEmitter` serializes the collection hash as-is), so nothing to add there.
- The raw `_id`/`_type` columns remain hidden from the frontend — only the **name** of the `_type` column is exposed as relation metadata; behaviour unchanged.

## Tests

- Updated `generator_field_polymorphic_spec.rb` to assert `foreign_key_type_field: 'addressable_type'`.
- Targeted suite: 3 examples, 0 failures. Full `utils/schema/` suite: 199 examples, 0 failures.

## Ref

- [PRD-493](https://linear.app/forest/issue/PRD-493)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Expose `foreign_key_type_field` in polymorphic relation field schema
> Adds `foreign_key_type_field` to the hash returned by `GeneratorField.build_column_schema` for polymorphic foreign key columns, populated from `relation.foreign_key_type_field`. The spec in [generator_field_polymorphic_spec.rb](https://github.com/ForestAdmin/agent-ruby/pull/316/files#diff-7515bf0b34803cd4ca7001d6542b0df841064dc52832d29f23613d771f61b562) is updated to assert the new field is present with the correct value.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2d13057.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->