### PR TITLE
fix(mambu_payments): disable rubygems mfa requirement

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -40,6 +40,7 @@ Gemspec/RequireMFA:
     - 'packages/forest_admin_datasource_active_record/forest_admin_datasource_active_record.gemspec'
     - 'packages/forest_admin_datasource_zendesk/forest_admin_datasource_zendesk.gemspec'
     - 'packages/forest_admin_datasource_snowflake/forest_admin_datasource_snowflake.gemspec'
+    - 'packages/forest_admin_datasource_mambu_payments/forest_admin_datasource_mambu_payments.gemspec'
 
 # Offense count: 1
 # This cop supports unsafe autocorrection (--autocorrect-all).

--- a/packages/forest_admin_datasource_mambu_payments/forest_admin_datasource_mambu_payments.gemspec
+++ b/packages/forest_admin_datasource_mambu_payments/forest_admin_datasource_mambu_payments.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.metadata['homepage_uri']    = spec.homepage
   spec.metadata['source_code_uri'] = 'https://github.com/ForestAdmin/agent-ruby'
   spec.metadata['changelog_uri']   = 'https://github.com/ForestAdmin/agent-ruby/blob/main/CHANGELOG.md'
-  spec.metadata['rubygems_mfa_required'] = 'true'
+  spec.metadata['rubygems_mfa_required'] = 'false'
 
   spec.files = Dir.chdir(__dir__) do
     `git ls-files -z`.split("\x0").reject do |f|


### PR DESCRIPTION
## Summary
- Set `rubygems_mfa_required` to `false` in the Mambu Payments gemspec, aligning it with every other package in the repo.
- Added the gemspec to the `Gemspec/RequireMFA` RuboCop exclude list (same as zendesk/snowflake) so linting passes.

## Why
The datasource was the only package still requiring MFA, which blocks automated publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Disable RubyGems MFA requirement for `forest_admin_datasource_mambu_payments`
> Sets `rubygems_mfa_required` to `false` in [forest_admin_datasource_mambu_payments.gemspec](https://github.com/ForestAdmin/agent-ruby/pull/318/files#diff-01dd2ba3faf8632cf8fc6919cbe10a81b72184f3967805b2e5e8b92f0e85d6f5) and excludes the gemspec from the RuboCop `Gemspec/RequireMFA` cop in [.rubocop.yml](https://github.com/ForestAdmin/agent-ruby/pull/318/files#diff-4f894049af3375c2bd4e608f546f8d4a0eed95464efcdea850993200db9fef5c).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0f2a0af.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->