### PR TITLE
test(agent): gzip passthrough regression for the executor proxy [PRD-567]

### DIFF
--- a/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/workflow/workflow_executor_proxy_spec.rb
+++ b/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/workflow/workflow_executor_proxy_spec.rb
@@ -1,5 +1,8 @@
 require 'spec_helper'
 require 'faraday'
+require 'zlib'
+require 'stringio'
+require 'socket'
 
 module ForestAdminAgent
   module Routes
@@ -269,6 +272,55 @@ module ForestAdminAgent
             expect do
               proxy.handle_request(method: 'GET', headers: headers, params: { 'path' => run_id })
             end.to raise_error(Http::Exceptions::ServiceUnavailableError, /request failed/)
+          end
+        end
+
+        # Real local server + real Faraday (no run_request stub) to exercise actual gzip decompression.
+        describe 'when the executor gzip-compresses the response (nginx in front)' do
+          let(:gz_body) do
+            io = StringIO.new
+            writer = Zlib::GzipWriter.new(io)
+            writer.write(JSON.generate('steps' => [{ 'stepId' => 'gz' }]))
+            writer.close
+            io.string
+          end
+
+          around do |example|
+            @gz_server = TCPServer.new('127.0.0.1', 0)
+            @gz_port = @gz_server.addr[1]
+            @gz_thread = Thread.new do
+              client = @gz_server.accept
+              client.readpartial(4096)
+              client.write(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n" \
+                "Content-Encoding: gzip\r\nContent-Length: #{gz_body.bytesize}\r\n" \
+                "Connection: close\r\n\r\n"
+              )
+              client.write(gz_body)
+              client.close
+            rescue IOError, Errno::ECONNRESET, Errno::EPIPE
+              nil
+            end
+
+            example.run
+
+            @gz_thread.kill
+            @gz_server.close
+          end
+
+          before do
+            # Runs after the outer `before`, so it wins: use the real Faraday client (no run_request
+            # stub) against the local gzip server.
+            override_config(workflow_executor_url: "http://127.0.0.1:#{@gz_port}")
+            allow(Faraday).to receive(:new).and_call_original
+          end
+
+          it 'decompresses the body and drops the stale content-encoding' do
+            result = proxy.handle_request(method: 'GET', headers: headers, params: { 'path' => 'runs/gz' })
+
+            expect(result[:status]).to eq(200)
+            expect(result[:content]).to eq('steps' => [{ 'stepId' => 'gz' }])
+            expect(result[:headers].keys.map(&:downcase)).not_to include('content-encoding')
           end
         end
 


### PR DESCRIPTION
## What

Follow-up test for the generic executor passthrough ([#321](https://github.com/ForestAdmin/agent-ruby/pull/321), merged). Locks in the gzip behaviour after the Node bug ([agent-nodejs#1716](https://github.com/ForestAdmin/agent-nodejs/pull/1716)): nginx in front of the executor gzips large responses.

A real local server + the **real Faraday client** (no `run_request` stub) confirm that a gzip-compressed executor response is:
- **decompressed** (Net::HTTP under Faraday handles it, since we don't forward the client's `Accept-Encoding`), and
- returned **without a stale `Content-Encoding`** (we drop it in `SKIPPED_HEADERS`).

So the agent never replays the ERR_CONTENT_DECODING_FAILED that hit the Node agent.

Test-only change. **25/25** + rubocop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add regression test for gzip passthrough in `WorkflowExecutorProxy`
> Adds a test covering the case where an nginx-fronted executor returns a gzip-compressed response, verifying the proxy correctly decompresses the body and strips the `Content-Encoding: gzip` header.
>
> - Spins up a real local `TCPServer` in an `around` hook that serves a minimal HTTP/1.1 200 response with a gzip-encoded JSON body.
> - Allows `Faraday.new` to call the original implementation so the real Faraday stack handles decompression, then asserts the returned status, parsed body, and absence of `Content-Encoding` in the response headers.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 28764bc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->