### PR TITLE
perf(datasource-active-record): JOIN same-DB to-one relations and select only projected columns

### DIFF
--- a/packages/forest_admin_datasource_active_record/lib/forest_admin_datasource_active_record/collection.rb
+++ b/packages/forest_admin_datasource_active_record/lib/forest_admin_datasource_active_record/collection.rb
@@ -26,8 +26,9 @@ module ForestAdminDatasourceActiveRecord
 
     def list(_caller, filter, projection)
       query = Utils::Query.new(self, projection, filter)
+      records = query.get
 
-      query.get.map { |record| Utils::ActiveRecordSerializer.new(record).to_hash(projection) }
+      records.map { |record| Utils::ActiveRecordSerializer.new(record, query.joined_relations).to_hash(projection) }
     end
 
     def aggregate(_caller, filter, aggregation, limit = nil)

--- a/packages/forest_admin_datasource_active_record/lib/forest_admin_datasource_active_record/utils/active_record_serializer.rb
+++ b/packages/forest_admin_datasource_active_record/lib/forest_admin_datasource_active_record/utils/active_record_serializer.rb
@@ -2,7 +2,8 @@ module ForestAdminDatasourceActiveRecord
   module Utils
     # Relations in `joined_relations` (see Query#collect_joined_selects) were resolved by JOIN
     # and are hydrated from the flat row's aliased columns; every other relation is read from
-    # its preloaded ActiveRecord association, as before.
+    # its preloaded ActiveRecord association. A related record is serialized to exactly its
+    # projected columns either way, so its shape does not depend on how it was resolved.
     ActiveRecordSerializer = Struct.new(:object, :joined_relations) do
       def to_hash(projection)
         hash_object(object, projection)
@@ -11,7 +12,9 @@ module ForestAdminDatasourceActiveRecord
       def hash_object(object, projection = nil, path: [])
         return if object.nil?
 
-        hash = base_attributes(object)
+        # the root keeps every selected column (own attributes + foreign keys); a related record
+        # is restricted to its projected columns, matching the JOINed hydration path
+        hash = path.empty? || projection.nil? ? base_attributes(object) : projected_columns(object, projection)
 
         serialize_associations(object, projection, hash, path) if projection
 
@@ -22,6 +25,10 @@ module ForestAdminDatasourceActiveRecord
         return object.attributes if join_aliases.empty?
 
         object.attributes.except(*join_aliases)
+      end
+
+      def projected_columns(object, projection)
+        projection.columns.to_h { |column| [column, object[column]] }
       end
 
       def serialize_associations(object, projection, hash, path)

--- a/packages/forest_admin_datasource_active_record/lib/forest_admin_datasource_active_record/utils/active_record_serializer.rb
+++ b/packages/forest_admin_datasource_active_record/lib/forest_admin_datasource_active_record/utils/active_record_serializer.rb
@@ -1,9 +1,8 @@
 module ForestAdminDatasourceActiveRecord
   module Utils
-    # `joined_relations` maps a relation path ("bank_account.organizations_view") to the SQL
-    # aliases of its columns on the flat row (see Query#collect_joined_selects). Relations
-    # listed there were resolved by JOIN and are hydrated from the flat row; every other
-    # relation is read from its (preloaded) ActiveRecord association, as before.
+    # Relations in `joined_relations` (see Query#collect_joined_selects) were resolved by JOIN
+    # and are hydrated from the flat row's aliased columns; every other relation is read from
+    # its preloaded ActiveRecord association, as before.
     ActiveRecordSerializer = Struct.new(:object, :joined_relations) do
       def to_hash(projection)
         hash_object(object, projection)
@@ -54,8 +53,7 @@ module ForestAdminDatasourceActiveRecord
         end
       end
 
-      # Rebuilds a JOINed relation's hash from the flat aliased columns carried by the root
-      # object. Returns nil when the (LEFT-joined) relation is absent.
+      # Reads a JOINed relation's columns from the aliases on the root object (not a nested one).
       def hash_joined_relation(projection, relation_path)
         meta = joined_relations[relation_path.join('.')]
         return nil if object[meta[:pk_alias]].nil?

--- a/packages/forest_admin_datasource_active_record/lib/forest_admin_datasource_active_record/utils/active_record_serializer.rb
+++ b/packages/forest_admin_datasource_active_record/lib/forest_admin_datasource_active_record/utils/active_record_serializer.rb
@@ -1,9 +1,7 @@
 module ForestAdminDatasourceActiveRecord
   module Utils
-    # Relations in `joined_relations` (see Query#collect_joined_selects) were resolved by JOIN
-    # and are hydrated from the flat row's aliased columns; every other relation is read from
-    # its preloaded ActiveRecord association. A related record is serialized to exactly its
-    # projected columns either way, so its shape does not depend on how it was resolved.
+    # Relations in `joined_relations` (see Query#collect_joined_selects) are hydrated from the flat
+    # row's aliased columns; every other relation is read from its preloaded ActiveRecord association.
     ActiveRecordSerializer = Struct.new(:object, :joined_relations) do
       def to_hash(projection)
         hash_object(object, projection)
@@ -12,8 +10,8 @@ module ForestAdminDatasourceActiveRecord
       def hash_object(object, projection = nil, path: [])
         return if object.nil?
 
-        # the root keeps every selected column (own attributes + foreign keys); a related record
-        # is restricted to its projected columns, matching the JOINed hydration path
+        # root keeps all its selected columns (attributes + FKs); a related record is restricted to
+        # its projected columns, matching the JOINed hydration
         hash = path.empty? || projection.nil? ? base_attributes(object) : projected_columns(object, projection)
 
         serialize_associations(object, projection, hash, path) if projection

--- a/packages/forest_admin_datasource_active_record/lib/forest_admin_datasource_active_record/utils/active_record_serializer.rb
+++ b/packages/forest_admin_datasource_active_record/lib/forest_admin_datasource_active_record/utils/active_record_serializer.rb
@@ -79,7 +79,7 @@ module ForestAdminDatasourceActiveRecord
       end
 
       def join_aliases
-        @join_aliases ||= (joined_relations || {}).values.flat_map { |meta| meta[:columns].values }.to_set
+        @join_aliases ||= (joined_relations || {}).values.flat_map { |meta| meta[:columns].values }.uniq
       end
     end
   end

--- a/packages/forest_admin_datasource_active_record/lib/forest_admin_datasource_active_record/utils/active_record_serializer.rb
+++ b/packages/forest_admin_datasource_active_record/lib/forest_admin_datasource_active_record/utils/active_record_serializer.rb
@@ -8,12 +8,12 @@ module ForestAdminDatasourceActiveRecord
         hash_object(object, projection)
       end
 
-      def hash_object(object, projection = nil, path: [], with_associations: true)
+      def hash_object(object, projection = nil, path: [])
         return if object.nil?
 
         hash = base_attributes(object)
 
-        serialize_associations(object, projection, hash, path) if with_associations && projection
+        serialize_associations(object, projection, hash, path) if projection
 
         hash
       end

--- a/packages/forest_admin_datasource_active_record/lib/forest_admin_datasource_active_record/utils/active_record_serializer.rb
+++ b/packages/forest_admin_datasource_active_record/lib/forest_admin_datasource_active_record/utils/active_record_serializer.rb
@@ -1,53 +1,82 @@
 module ForestAdminDatasourceActiveRecord
   module Utils
-    ActiveRecordSerializer = Struct.new(:object) do
+    # `joined_relations` maps a relation path ("bank_account.organizations_view") to the SQL
+    # aliases of its columns on the flat row (see Query#collect_joined_selects). Relations
+    # listed there were resolved by JOIN and are hydrated from the flat row; every other
+    # relation is read from its (preloaded) ActiveRecord association, as before.
+    ActiveRecordSerializer = Struct.new(:object, :joined_relations) do
       def to_hash(projection)
         hash_object(object, projection)
       end
 
-      def hash_object(object, projection = nil, with_associations: true)
-        hash = {}
-
+      def hash_object(object, projection = nil, path: [], with_associations: true)
         return if object.nil?
 
-        hash.merge! object.attributes
+        hash = base_attributes(object)
 
-        serialize_associations(object, projection, hash) if with_associations
+        serialize_associations(object, projection, hash, path) if with_associations && projection
 
         hash
       end
 
-      def serialize_associations(object, projection, hash)
+      def base_attributes(object)
+        return object.attributes if join_aliases.empty?
+
+        object.attributes.except(*join_aliases)
+      end
+
+      def serialize_associations(object, projection, hash, path)
         one_associations = %i[has_one belongs_to]
         many_associations = %i[has_many has_and_belongs_to_many]
 
-        # Handle one-to-one and many-to-one associations
-        object.class.reflect_on_all_associations
-              .filter { |a| one_associations.include?(a.macro) && projection.relations.key?(a.name.to_s) }
-              .each do |association|
-                association_name = association.name.to_s
-                hash[association_name] = hash_object(
-                  object.send(association_name),
-                  projection.relations[association_name],
-                  with_associations: projection.relations.key?(association_name)
-                )
-              end
+        projection.relations.each_key do |association_name|
+          relation_path = path + [association_name]
 
-        # Handle one-to-many and many-to-many associations
-        object.class.reflect_on_all_associations
-              .filter { |a| many_associations.include?(a.macro) && projection.relations.key?(a.name.to_s) }
-              .each do |association|
-                association_name = association.name.to_s
-                collection = object.send(association_name)
-                # Serialize the collection as an array
-                hash[association_name] = collection.map do |item|
-                  hash_object(
-                    item,
-                    projection.relations[association_name],
-                    with_associations: projection.relations.key?(association_name)
-                  )
-                end
-              end
+          if joined_relation?(relation_path)
+            hash[association_name] = hash_joined_relation(projection.relations[association_name], relation_path)
+            next
+          end
+
+          association = object.class.reflect_on_association(association_name.to_sym)
+          next if association.nil?
+
+          if one_associations.include?(association.macro)
+            hash[association_name] = hash_object(
+              object.send(association_name),
+              projection.relations[association_name],
+              path: relation_path
+            )
+          elsif many_associations.include?(association.macro)
+            hash[association_name] = object.send(association_name).map do |item|
+              hash_object(item, projection.relations[association_name], path: relation_path)
+            end
+          end
+        end
+      end
+
+      # Rebuilds a JOINed relation's hash from the flat aliased columns carried by the root
+      # object. Returns nil when the (LEFT-joined) relation is absent.
+      def hash_joined_relation(projection, relation_path)
+        meta = joined_relations[relation_path.join('.')]
+        return nil if object[meta[:pk_alias]].nil?
+
+        hash = {}
+        projection.columns.each { |column| hash[column] = object[meta[:columns][column]] }
+        projection.relations.each_key do |nested_name|
+          hash[nested_name] = hash_joined_relation(projection.relations[nested_name], relation_path + [nested_name])
+        end
+
+        hash
+      end
+
+      private
+
+      def joined_relation?(relation_path)
+        !joined_relations.nil? && joined_relations.key?(relation_path.join('.'))
+      end
+
+      def join_aliases
+        @join_aliases ||= (joined_relations || {}).values.flat_map { |meta| meta[:columns].values }.to_set
       end
     end
   end

--- a/packages/forest_admin_datasource_active_record/lib/forest_admin_datasource_active_record/utils/query.rb
+++ b/packages/forest_admin_datasource_active_record/lib/forest_admin_datasource_active_record/utils/query.rb
@@ -213,19 +213,7 @@ module ForestAdminDatasourceActiveRecord
 
       def apply_select
         unless @projection.nil?
-          join_tree = {}
-          preload_tree = {}
-          used_tables = Set[@collection.model.table_name] | @filter_joined_tables
-          @projection.relations.each do |relation_name, sub_projection|
-            tables = joinable_tables(@collection, relation_name, sub_projection, used_tables)
-            if tables
-              used_tables |= tables
-              join_tree[relation_name.to_sym] = format_relation_projection(sub_projection)
-              collect_joined_selects(@collection, relation_name, sub_projection, [relation_name])
-            else
-              preload_tree[relation_name.to_sym] = format_relation_projection(sub_projection)
-            end
-          end
+          join_tree, preload_tree = split_relations
 
           # belongs_to relations on the same database are JOINed (selecting only their projected
           # columns, unlike eager_load which reads the whole row); the rest stays on preload, where
@@ -238,21 +226,42 @@ module ForestAdminDatasourceActiveRecord
         @query
       end
 
+      # Splits the projection's relations into a JOIN tree and a preload tree.
+      def split_relations
+        join_tree = {}
+        preload_tree = {}
+        used_tables = Set[@collection.model.table_name] | @filter_joined_tables
+
+        @projection.relations.each do |relation_name, sub_projection|
+          tables = joinable_tables(@collection, relation_name, sub_projection, used_tables)
+          if tables
+            used_tables |= tables
+            join_tree[relation_name.to_sym] = format_relation_projection(sub_projection)
+            collect_joined_selects(@collection, relation_name, sub_projection, [relation_name])
+          else
+            preload_tree[relation_name.to_sym] = format_relation_projection(sub_projection)
+          end
+        end
+
+        [join_tree, preload_tree]
+      end
+
       def collect_joined_selects(collection, relation_name, sub_projection, path)
         relation_schema = collection.schema[:fields][relation_name]
         target = local_ar_collection(collection.datasource, relation_schema.foreign_collection)
-        connection = target.model.connection
         table = target.model.table_name
         pk_columns = Array(target.model.primary_key) # array for composite primary keys
 
         alias_map = {}
         # a pk column is always selected so the serializer can detect a NULL (absent) left-joined relation
-        (sub_projection.columns + pk_columns).uniq.each do |column|
-          sql_alias = next_join_alias
-          # quote via the adapter so it works on MySQL too (ANSI "..." are string literals there)
-          @select << "#{connection.quote_table_name(table)}.#{connection.quote_column_name(column)} " \
-                     "AS #{connection.quote_column_name(sql_alias)}"
-          alias_map[column] = sql_alias
+        target.model.connection_pool.with_connection do |connection|
+          (sub_projection.columns + pk_columns).uniq.each do |column|
+            sql_alias = next_join_alias
+            # quote via the adapter so identifiers are valid on every database (e.g. backticks on MySQL)
+            @select << "#{connection.quote_table_name(table)}.#{connection.quote_column_name(column)} " \
+                       "AS #{connection.quote_column_name(sql_alias)}"
+            alias_map[column] = sql_alias
+          end
         end
         @joined_relations[path.join('.')] = { columns: alias_map, pk_alias: alias_map[pk_columns.first] }
 
@@ -266,27 +275,13 @@ module ForestAdminDatasourceActiveRecord
         "fa_join_#{@alias_counter}"
       end
 
-      # Set of tables the (fully joinable) subtree would add via JOIN, or nil when any relation
-      # in it cannot be safely joined. Only belongs_to is joinable: it matches on the target's
-      # primary key, so the JOIN cannot duplicate the parent row (a has_one child may not be
-      # unique). used_tables already covers the base + sibling joins: a table joined twice would
-      # be aliased by ActiveRecord, which collect_joined_selects cannot reference — so bail out.
+      # Set of tables the subtree would add via JOIN, or nil when any relation in it cannot be
+      # safely joined (see joinable_target). Recurses so the whole chain must be joinable.
       def joinable_tables(collection, relation_name, sub_projection, used_tables)
-        relation_schema = collection.schema[:fields][relation_name]
-        return nil unless relation_schema.type == 'ManyToOne'
-        return nil unless relation_schema.respond_to?(:foreign_collection)
-
-        target = local_ar_collection(collection.datasource, relation_schema.foreign_collection)
+        target = joinable_target(collection, relation_name, used_tables)
         return nil if target.nil?
-        return nil unless same_database?(collection.model, target.model)
-        # a default_scope may inject raw/unqualified SQL (e.g. `where('id > ?', 10)`) that turns
-        # ambiguous once joined; preload keeps it isolated
-        return nil unless target.model.default_scopes.empty?
 
-        table = target.model.table_name
-        return nil if used_tables.include?(table)
-
-        tables = Set[table]
+        tables = Set[target.model.table_name]
         sub_projection.relations.each do |nested_name, nested_projection|
           nested = joinable_tables(target, nested_name, nested_projection, used_tables | tables)
           return nil if nested.nil?
@@ -294,6 +289,30 @@ module ForestAdminDatasourceActiveRecord
           tables |= nested
         end
         tables
+      end
+
+      # The target collection when this single hop is safe to collapse into a LEFT OUTER JOIN,
+      # else nil. Only belongs_to qualifies: it matches on the target's primary key, so the JOIN
+      # cannot duplicate the parent row (a has_one child may not be unique).
+      def joinable_target(collection, relation_name, used_tables)
+        relation_schema = collection.schema[:fields][relation_name]
+        return unless relation_schema.type == 'ManyToOne' && relation_schema.respond_to?(:foreign_collection)
+
+        # a scoped association applies its scope to the JOIN and may inject raw/unqualified SQL or
+        # extra joins (e.g. `belongs_to :x, -> { where('id > ?', 1) }`); the same risk exists for a
+        # default_scope on the target. Both keep it isolated when preloaded.
+        reflection = collection.model.reflect_on_association(relation_name.to_sym)
+        return if reflection.nil? || reflection.scope
+
+        target = local_ar_collection(collection.datasource, relation_schema.foreign_collection)
+        return if target.nil? || !target.model.default_scopes.empty?
+        return unless same_database?(collection.model, target.model)
+
+        # a table joined twice would be aliased by ActiveRecord, which collect_joined_selects
+        # cannot reference; bail out so it is preloaded instead
+        return if used_tables.include?(target.model.table_name)
+
+        target
       end
 
       def same_database?(model_a, model_b)

--- a/packages/forest_admin_datasource_active_record/lib/forest_admin_datasource_active_record/utils/query.rb
+++ b/packages/forest_admin_datasource_active_record/lib/forest_admin_datasource_active_record/utils/query.rb
@@ -204,10 +204,73 @@ module ForestAdminDatasourceActiveRecord
       end
 
       def apply_select
+        unless @projection.nil?
+          join_tree = {}
+          preload_tree = {}
+          @projection.relations.each do |relation_name, sub_projection|
+            if fully_joinable?(@collection, relation_name, sub_projection)
+              join_tree[relation_name.to_sym] = format_relation_projection(sub_projection)
+            else
+              preload_tree[relation_name.to_sym] = format_relation_projection(sub_projection)
+            end
+          end
+
+          # to-one relations living in the same database are resolved with a single
+          # LEFT OUTER JOIN (eager_load) instead of one extra query per relation
+          # (preload). to-many / polymorphic / cross-database relations keep preload:
+          # a JOIN would multiply rows (breaking pagination) or is simply not possible.
+          @query = @query.eager_load(join_tree) unless join_tree.empty?
+          @query = @query.includes(preload_tree) unless preload_tree.empty?
+        end
         @query = @query.select(@select.join(', ')) if @select
-        @query = @query.includes(format_relation_projection(@projection)) unless @projection.nil?
 
         @query
+      end
+
+      # A relation subtree can be collapsed into a JOIN only if the relation itself is a
+      # non-polymorphic to-one relation on the same database, and every relation nested
+      # below it satisfies the same constraint.
+      def fully_joinable?(collection, relation_name, sub_projection)
+        relation_schema = collection.schema[:fields][relation_name]
+        return false unless %w[OneToOne ManyToOne].include?(relation_schema.type)
+        return false unless relation_schema.respond_to?(:foreign_collection)
+
+        # The target must be an ActiveRecord collection living in THIS datasource. A
+        # relation towards another datasource (RPC, Mongoid, ...) is resolved above the
+        # datasource and never reaches here, but we stay defensive: anything we cannot
+        # resolve locally as an AR-backed collection falls back to preload.
+        target_collection = local_ar_collection(collection.datasource, relation_schema.foreign_collection)
+        return false if target_collection.nil?
+        return false unless same_database?(collection.model, target_collection.model)
+        # A default_scope is applied to the JOINed table and may contain raw / unqualified
+        # SQL (e.g. `where('id > ?', 10)`) that becomes ambiguous once joined. Preload keeps
+        # it isolated, so fall back to preload rather than risk broken SQL.
+        return false unless target_collection.model.default_scopes.empty?
+
+        sub_projection.relations.all? do |nested_name, nested_projection|
+          fully_joinable?(target_collection, nested_name, nested_projection)
+        end
+      end
+
+      def same_database?(model_a, model_b)
+        model_a.connection_specification_name == model_b.connection_specification_name
+      rescue StandardError
+        false
+      end
+
+      # Returns the target collection only when it is ActiveRecord-backed AND belongs to
+      # the very same datasource instance we are querying; otherwise nil (=> the caller
+      # falls back to preload). Belt-and-suspenders against a foreign collection ever
+      # being reachable by name (e.g. name collision across datasources in a composite):
+      # we check the concrete class and the datasource object identity, not just the name.
+      def local_ar_collection(datasource, name)
+        collection = datasource.get_collection(name)
+        return nil unless collection.is_a?(ForestAdminDatasourceActiveRecord::Collection)
+        return nil unless collection.datasource.equal?(datasource)
+
+        collection
+      rescue StandardError
+        nil
       end
 
       def add_join_relation(relation_name)

--- a/packages/forest_admin_datasource_active_record/lib/forest_admin_datasource_active_record/utils/query.rb
+++ b/packages/forest_admin_datasource_active_record/lib/forest_admin_datasource_active_record/utils/query.rb
@@ -17,8 +17,7 @@ module ForestAdminDatasourceActiveRecord
         # relation path (e.g. "bank_account.organizations_view") => { columns: { col => sql_alias }, pk_alias: }
         @joined_relations = {}
         @alias_counter = 0
-        # tables already joined by apply_filter/apply_sort (resolve_field), so apply_select
-        # does not add a second, conflicting join for the same relation
+        # tables already joined by filters/sorts, so apply_select does not join them a second time
         @filter_joined_tables = Set.new
       end
 
@@ -215,9 +214,6 @@ module ForestAdminDatasourceActiveRecord
         unless @projection.nil?
           join_tree, preload_tree = split_relations
 
-          # belongs_to relations on the same database are JOINed (selecting only their projected
-          # columns, unlike eager_load which reads the whole row); the rest stays on preload, where
-          # a JOIN would multiply rows or is impossible.
           @query = @query.left_outer_joins(join_tree) unless join_tree.empty?
           @query = @query.includes(preload_tree) unless preload_tree.empty?
         end
@@ -226,7 +222,6 @@ module ForestAdminDatasourceActiveRecord
         @query
       end
 
-      # Splits the projection's relations into a JOIN tree and a preload tree.
       def split_relations
         join_tree = {}
         preload_tree = {}
@@ -275,8 +270,7 @@ module ForestAdminDatasourceActiveRecord
         "fa_join_#{@alias_counter}"
       end
 
-      # Set of tables the subtree would add via JOIN, or nil when any relation in it cannot be
-      # safely joined (see joinable_target). Recurses so the whole chain must be joinable.
+      # Set of tables the subtree adds via JOIN, or nil if any relation in it can't be safely joined.
       def joinable_tables(collection, relation_name, sub_projection, used_tables)
         target = joinable_target(collection, relation_name, used_tables)
         return nil if target.nil?
@@ -291,41 +285,35 @@ module ForestAdminDatasourceActiveRecord
         tables
       end
 
-      # The target collection when this single hop is safe to collapse into a LEFT OUTER JOIN,
-      # else nil. Only belongs_to qualifies: it matches on the target's primary key, so the JOIN
-      # cannot duplicate the parent row (a has_one child may not be unique).
+      # The target collection when this hop is safe to collapse into a JOIN, else nil (-> preload).
       def joinable_target(collection, relation_name, used_tables)
         relation_schema = collection.schema[:fields][relation_name]
+        # belongs_to only: it joins on the target's primary key, so it can't duplicate the parent
+        # (a has_one child may not be unique)
         return unless relation_schema.type == 'ManyToOne' && relation_schema.respond_to?(:foreign_collection)
 
         # a scoped association applies its scope to the JOIN and may inject raw/unqualified SQL or
-        # extra joins (e.g. `belongs_to :x, -> { where('id > ?', 1) }`); the same risk exists for a
-        # default_scope on the target. Both keep it isolated when preloaded.
+        # extra joins (e.g. `belongs_to :x, -> { where('id > ?', 1) }`)
         reflection = collection.model.reflect_on_association(relation_name.to_sym)
         return if reflection.nil? || reflection.scope
 
         target = local_ar_collection(collection.datasource, relation_schema.foreign_collection)
-        return if target.nil? || !target.model.default_scopes.empty?
+        return if target.nil? || !target.model.default_scopes.empty? # same risk as a scoped association
         return unless same_database?(collection.model, target.model)
-
-        # a table joined twice would be aliased by ActiveRecord, which collect_joined_selects
-        # cannot reference; bail out so it is preloaded instead
-        return if used_tables.include?(target.model.table_name)
+        return if used_tables.include?(target.model.table_name) # a table joined twice would be aliased by AR
 
         target
       end
 
       def same_database?(model_a, model_b)
-        # compare the actual connection pools, not connection_specification_name (which is only the
-        # owner class name and can be shared across different databases/shards)
+        # compare the pools, not connection_specification_name (only an owner class name, shared across shards)
         model_a.connection_pool == model_b.connection_pool
       rescue StandardError
         false
       end
 
-      # The target collection if it is AR-backed AND belongs to this exact datasource, else nil.
-      # Class + identity (not just the name) guard against a foreign-datasource collection ever
-      # being reachable here (e.g. name collision in a composite) -> caller falls back to preload.
+      # The target collection only if it is AR-backed AND belongs to this exact datasource, else nil.
+      # Guards (concrete class + identity, not just the name) against a foreign-datasource collection.
       def local_ar_collection(datasource, name)
         collection = datasource.get_collection(name)
         return nil unless collection.is_a?(ForestAdminDatasourceActiveRecord::Collection)

--- a/packages/forest_admin_datasource_active_record/lib/forest_admin_datasource_active_record/utils/query.rb
+++ b/packages/forest_admin_datasource_active_record/lib/forest_admin_datasource_active_record/utils/query.rb
@@ -17,6 +17,9 @@ module ForestAdminDatasourceActiveRecord
         # relation path (e.g. "bank_account.organizations_view") => { columns: { col => sql_alias }, pk_alias: }
         @joined_relations = {}
         @alias_counter = 0
+        # tables already joined by apply_filter/apply_sort (resolve_field), so apply_select
+        # does not add a second, conflicting join for the same relation
+        @filter_joined_tables = Set.new
       end
 
       def build
@@ -212,7 +215,7 @@ module ForestAdminDatasourceActiveRecord
         unless @projection.nil?
           join_tree = {}
           preload_tree = {}
-          used_tables = Set[@collection.model.table_name]
+          used_tables = Set[@collection.model.table_name] | @filter_joined_tables
           @projection.relations.each do |relation_name, sub_projection|
             tables = joinable_tables(@collection, relation_name, sub_projection, used_tables)
             if tables
@@ -238,6 +241,7 @@ module ForestAdminDatasourceActiveRecord
       def collect_joined_selects(collection, relation_name, sub_projection, path)
         relation_schema = collection.schema[:fields][relation_name]
         target = local_ar_collection(collection.datasource, relation_schema.foreign_collection)
+        connection = target.model.connection
         table = target.model.table_name
         pk_columns = Array(target.model.primary_key) # array for composite primary keys
 
@@ -245,7 +249,9 @@ module ForestAdminDatasourceActiveRecord
         # a pk column is always selected so the serializer can detect a NULL (absent) left-joined relation
         (sub_projection.columns + pk_columns).uniq.each do |column|
           sql_alias = next_join_alias
-          @select << %("#{table}"."#{column}" AS "#{sql_alias}")
+          # quote via the adapter so it works on MySQL too (ANSI "..." are string literals there)
+          @select << "#{connection.quote_table_name(table)}.#{connection.quote_column_name(column)} " \
+                     "AS #{connection.quote_column_name(sql_alias)}"
           alias_map[column] = sql_alias
         end
         @joined_relations[path.join('.')] = { columns: alias_map, pk_alias: alias_map[pk_columns.first] }
@@ -291,7 +297,9 @@ module ForestAdminDatasourceActiveRecord
       end
 
       def same_database?(model_a, model_b)
-        model_a.connection_specification_name == model_b.connection_specification_name
+        # compare the actual connection pools, not connection_specification_name (which is only the
+        # owner class name and can be shared across different databases/shards)
+        model_a.connection_pool == model_b.connection_pool
       rescue StandardError
         false
       end
@@ -321,6 +329,7 @@ module ForestAdminDatasourceActiveRecord
           relation = @collection.schema[:fields][relation_name]
           related_collection = @collection.datasource.get_collection(relation.foreign_collection)
           add_join_relation(relation_name)
+          @filter_joined_tables << related_collection.model.table_name
 
           {
             formatted: "#{related_collection.model.table_name}.#{column_name}",

--- a/packages/forest_admin_datasource_active_record/lib/forest_admin_datasource_active_record/utils/query.rb
+++ b/packages/forest_admin_datasource_active_record/lib/forest_admin_datasource_active_record/utils/query.rb
@@ -239,16 +239,16 @@ module ForestAdminDatasourceActiveRecord
         relation_schema = collection.schema[:fields][relation_name]
         target = local_ar_collection(collection.datasource, relation_schema.foreign_collection)
         table = target.model.table_name
-        pk = target.model.primary_key
+        pk_columns = Array(target.model.primary_key) # array for composite primary keys
 
         alias_map = {}
-        # pk is always selected so the serializer can detect a NULL (absent) left-joined relation
-        (sub_projection.columns + [pk]).uniq.each do |column|
+        # a pk column is always selected so the serializer can detect a NULL (absent) left-joined relation
+        (sub_projection.columns + pk_columns).uniq.each do |column|
           sql_alias = next_join_alias
           @select << %("#{table}"."#{column}" AS "#{sql_alias}")
           alias_map[column] = sql_alias
         end
-        @joined_relations[path.join('.')] = { columns: alias_map, pk_alias: alias_map[pk] }
+        @joined_relations[path.join('.')] = { columns: alias_map, pk_alias: alias_map[pk_columns.first] }
 
         sub_projection.relations.each do |nested_name, nested_projection|
           collect_joined_selects(target, nested_name, nested_projection, path + [nested_name])

--- a/packages/forest_admin_datasource_active_record/lib/forest_admin_datasource_active_record/utils/query.rb
+++ b/packages/forest_admin_datasource_active_record/lib/forest_admin_datasource_active_record/utils/query.rb
@@ -3,7 +3,7 @@ module ForestAdminDatasourceActiveRecord
     class Query
       include ForestAdminDatasourceToolkit::Components::Query::ConditionTree
 
-      attr_reader :query, :select
+      attr_reader :query, :select, :joined_relations
 
       def initialize(collection, projection, filter)
         @collection = collection
@@ -12,6 +12,11 @@ module ForestAdminDatasourceActiveRecord
         @filter = filter
         @arel_table = @collection.model.arel_table
         @select = []
+        # path (e.g. "bank_account.organizations_view") => { columns: { col => sql_alias },
+        # pk_alias: }. Populated for to-one relations resolved by JOIN so the serializer can
+        # hydrate them from the flat row instead of triggering a lazy association load.
+        @joined_relations = {}
+        @alias_counter = 0
       end
 
       def build
@@ -210,21 +215,52 @@ module ForestAdminDatasourceActiveRecord
           @projection.relations.each do |relation_name, sub_projection|
             if fully_joinable?(@collection, relation_name, sub_projection)
               join_tree[relation_name.to_sym] = format_relation_projection(sub_projection)
+              collect_joined_selects(@collection, relation_name, sub_projection, [relation_name])
             else
               preload_tree[relation_name.to_sym] = format_relation_projection(sub_projection)
             end
           end
 
           # to-one relations living in the same database are resolved with a single
-          # LEFT OUTER JOIN (eager_load) instead of one extra query per relation
-          # (preload). to-many / polymorphic / cross-database relations keep preload:
-          # a JOIN would multiply rows (breaking pagination) or is simply not possible.
-          @query = @query.eager_load(join_tree) unless join_tree.empty?
+          # LEFT OUTER JOIN instead of one extra query per relation hop (preload). Unlike
+          # eager_load, we select ONLY the projected columns of the joined tables (see
+          # collect_joined_selects) so a wide relation (e.g. a heavy DB view) is not fully
+          # read. to-many / polymorphic / cross-database relations keep preload: a JOIN
+          # would multiply rows (breaking pagination) or is simply not possible.
+          @query = @query.left_outer_joins(join_tree) unless join_tree.empty?
           @query = @query.includes(preload_tree) unless preload_tree.empty?
         end
         @query = @query.select(@select.join(', ')) if @select
 
         @query
+      end
+
+      # Adds "table"."column" AS "alias" entries to @select for every projected column of a
+      # joined to-one relation (recursively), and records the aliases in @joined_relations
+      # so the serializer can rebuild the nested hash from the flat row. The target primary
+      # key is always selected to let the serializer detect a NULL (absent) relation.
+      def collect_joined_selects(collection, relation_name, sub_projection, path)
+        relation_schema = collection.schema[:fields][relation_name]
+        target = local_ar_collection(collection.datasource, relation_schema.foreign_collection)
+        table = target.model.table_name
+        pk = target.model.primary_key
+
+        alias_map = {}
+        (sub_projection.columns + [pk]).uniq.each do |column|
+          sql_alias = next_join_alias
+          @select << %("#{table}"."#{column}" AS "#{sql_alias}")
+          alias_map[column] = sql_alias
+        end
+        @joined_relations[path.join('.')] = { columns: alias_map, pk_alias: alias_map[pk] }
+
+        sub_projection.relations.each do |nested_name, nested_projection|
+          collect_joined_selects(target, nested_name, nested_projection, path + [nested_name])
+        end
+      end
+
+      def next_join_alias
+        @alias_counter += 1
+        "fa_join_#{@alias_counter}"
       end
 
       # A relation subtree can be collapsed into a JOIN only if the relation itself is a

--- a/packages/forest_admin_datasource_active_record/lib/forest_admin_datasource_active_record/utils/query.rb
+++ b/packages/forest_admin_datasource_active_record/lib/forest_admin_datasource_active_record/utils/query.rb
@@ -12,9 +12,7 @@ module ForestAdminDatasourceActiveRecord
         @filter = filter
         @arel_table = @collection.model.arel_table
         @select = []
-        # path (e.g. "bank_account.organizations_view") => { columns: { col => sql_alias },
-        # pk_alias: }. Populated for to-one relations resolved by JOIN so the serializer can
-        # hydrate them from the flat row instead of triggering a lazy association load.
+        # relation path (e.g. "bank_account.organizations_view") => { columns: { col => sql_alias }, pk_alias: }
         @joined_relations = {}
         @alias_counter = 0
       end
@@ -221,12 +219,9 @@ module ForestAdminDatasourceActiveRecord
             end
           end
 
-          # to-one relations living in the same database are resolved with a single
-          # LEFT OUTER JOIN instead of one extra query per relation hop (preload). Unlike
-          # eager_load, we select ONLY the projected columns of the joined tables (see
-          # collect_joined_selects) so a wide relation (e.g. a heavy DB view) is not fully
-          # read. to-many / polymorphic / cross-database relations keep preload: a JOIN
-          # would multiply rows (breaking pagination) or is simply not possible.
+          # to-one same-database relations are JOINed (selecting only their projected columns,
+          # unlike eager_load which reads the whole row); the rest stays on preload, where a
+          # JOIN would multiply rows (to-many) or is impossible (cross-database).
           @query = @query.left_outer_joins(join_tree) unless join_tree.empty?
           @query = @query.includes(preload_tree) unless preload_tree.empty?
         end
@@ -235,10 +230,6 @@ module ForestAdminDatasourceActiveRecord
         @query
       end
 
-      # Adds "table"."column" AS "alias" entries to @select for every projected column of a
-      # joined to-one relation (recursively), and records the aliases in @joined_relations
-      # so the serializer can rebuild the nested hash from the flat row. The target primary
-      # key is always selected to let the serializer detect a NULL (absent) relation.
       def collect_joined_selects(collection, relation_name, sub_projection, path)
         relation_schema = collection.schema[:fields][relation_name]
         target = local_ar_collection(collection.datasource, relation_schema.foreign_collection)
@@ -246,6 +237,7 @@ module ForestAdminDatasourceActiveRecord
         pk = target.model.primary_key
 
         alias_map = {}
+        # pk is always selected so the serializer can detect a NULL (absent) left-joined relation
         (sub_projection.columns + [pk]).uniq.each do |column|
           sql_alias = next_join_alias
           @select << %("#{table}"."#{column}" AS "#{sql_alias}")
@@ -263,24 +255,17 @@ module ForestAdminDatasourceActiveRecord
         "fa_join_#{@alias_counter}"
       end
 
-      # A relation subtree can be collapsed into a JOIN only if the relation itself is a
-      # non-polymorphic to-one relation on the same database, and every relation nested
-      # below it satisfies the same constraint.
+      # True only when the relation and every relation nested below it can be safely JOINed.
       def fully_joinable?(collection, relation_name, sub_projection)
         relation_schema = collection.schema[:fields][relation_name]
         return false unless %w[OneToOne ManyToOne].include?(relation_schema.type)
         return false unless relation_schema.respond_to?(:foreign_collection)
 
-        # The target must be an ActiveRecord collection living in THIS datasource. A
-        # relation towards another datasource (RPC, Mongoid, ...) is resolved above the
-        # datasource and never reaches here, but we stay defensive: anything we cannot
-        # resolve locally as an AR-backed collection falls back to preload.
         target_collection = local_ar_collection(collection.datasource, relation_schema.foreign_collection)
         return false if target_collection.nil?
         return false unless same_database?(collection.model, target_collection.model)
-        # A default_scope is applied to the JOINed table and may contain raw / unqualified
-        # SQL (e.g. `where('id > ?', 10)`) that becomes ambiguous once joined. Preload keeps
-        # it isolated, so fall back to preload rather than risk broken SQL.
+        # a default_scope may inject raw/unqualified SQL (e.g. `where('id > ?', 10)`) that turns
+        # ambiguous once joined; preload keeps it isolated
         return false unless target_collection.model.default_scopes.empty?
 
         sub_projection.relations.all? do |nested_name, nested_projection|
@@ -294,11 +279,9 @@ module ForestAdminDatasourceActiveRecord
         false
       end
 
-      # Returns the target collection only when it is ActiveRecord-backed AND belongs to
-      # the very same datasource instance we are querying; otherwise nil (=> the caller
-      # falls back to preload). Belt-and-suspenders against a foreign collection ever
-      # being reachable by name (e.g. name collision across datasources in a composite):
-      # we check the concrete class and the datasource object identity, not just the name.
+      # The target collection if it is AR-backed AND belongs to this exact datasource, else nil.
+      # Class + identity (not just the name) guard against a foreign-datasource collection ever
+      # being reachable here (e.g. name collision in a composite) -> caller falls back to preload.
       def local_ar_collection(datasource, name)
         collection = datasource.get_collection(name)
         return nil unless collection.is_a?(ForestAdminDatasourceActiveRecord::Collection)

--- a/packages/forest_admin_datasource_active_record/lib/forest_admin_datasource_active_record/utils/query.rb
+++ b/packages/forest_admin_datasource_active_record/lib/forest_admin_datasource_active_record/utils/query.rb
@@ -1,3 +1,5 @@
+require 'set'
+
 module ForestAdminDatasourceActiveRecord
   module Utils
     class Query
@@ -210,8 +212,11 @@ module ForestAdminDatasourceActiveRecord
         unless @projection.nil?
           join_tree = {}
           preload_tree = {}
+          used_tables = Set[@collection.model.table_name]
           @projection.relations.each do |relation_name, sub_projection|
-            if fully_joinable?(@collection, relation_name, sub_projection)
+            tables = joinable_tables(@collection, relation_name, sub_projection, used_tables)
+            if tables
+              used_tables |= tables
               join_tree[relation_name.to_sym] = format_relation_projection(sub_projection)
               collect_joined_selects(@collection, relation_name, sub_projection, [relation_name])
             else
@@ -219,9 +224,9 @@ module ForestAdminDatasourceActiveRecord
             end
           end
 
-          # to-one same-database relations are JOINed (selecting only their projected columns,
-          # unlike eager_load which reads the whole row); the rest stays on preload, where a
-          # JOIN would multiply rows (to-many) or is impossible (cross-database).
+          # belongs_to relations on the same database are JOINed (selecting only their projected
+          # columns, unlike eager_load which reads the whole row); the rest stays on preload, where
+          # a JOIN would multiply rows or is impossible.
           @query = @query.left_outer_joins(join_tree) unless join_tree.empty?
           @query = @query.includes(preload_tree) unless preload_tree.empty?
         end
@@ -255,22 +260,34 @@ module ForestAdminDatasourceActiveRecord
         "fa_join_#{@alias_counter}"
       end
 
-      # True only when the relation and every relation nested below it can be safely JOINed.
-      def fully_joinable?(collection, relation_name, sub_projection)
+      # Set of tables the (fully joinable) subtree would add via JOIN, or nil when any relation
+      # in it cannot be safely joined. Only belongs_to is joinable: it matches on the target's
+      # primary key, so the JOIN cannot duplicate the parent row (a has_one child may not be
+      # unique). used_tables already covers the base + sibling joins: a table joined twice would
+      # be aliased by ActiveRecord, which collect_joined_selects cannot reference — so bail out.
+      def joinable_tables(collection, relation_name, sub_projection, used_tables)
         relation_schema = collection.schema[:fields][relation_name]
-        return false unless %w[OneToOne ManyToOne].include?(relation_schema.type)
-        return false unless relation_schema.respond_to?(:foreign_collection)
+        return nil unless relation_schema.type == 'ManyToOne'
+        return nil unless relation_schema.respond_to?(:foreign_collection)
 
-        target_collection = local_ar_collection(collection.datasource, relation_schema.foreign_collection)
-        return false if target_collection.nil?
-        return false unless same_database?(collection.model, target_collection.model)
+        target = local_ar_collection(collection.datasource, relation_schema.foreign_collection)
+        return nil if target.nil?
+        return nil unless same_database?(collection.model, target.model)
         # a default_scope may inject raw/unqualified SQL (e.g. `where('id > ?', 10)`) that turns
         # ambiguous once joined; preload keeps it isolated
-        return false unless target_collection.model.default_scopes.empty?
+        return nil unless target.model.default_scopes.empty?
 
-        sub_projection.relations.all? do |nested_name, nested_projection|
-          fully_joinable?(target_collection, nested_name, nested_projection)
+        table = target.model.table_name
+        return nil if used_tables.include?(table)
+
+        tables = Set[table]
+        sub_projection.relations.each do |nested_name, nested_projection|
+          nested = joinable_tables(target, nested_name, nested_projection, used_tables | tables)
+          return nil if nested.nil?
+
+          tables |= nested
         end
+        tables
       end
 
       def same_database?(model_a, model_b)

--- a/packages/forest_admin_datasource_active_record/spec/lib/forest_admin_datasource_active_record/utils/join_to_one_optimization_spec.rb
+++ b/packages/forest_admin_datasource_active_record/spec/lib/forest_admin_datasource_active_record/utils/join_to_one_optimization_spec.rb
@@ -4,7 +4,7 @@ module ForestAdminDatasourceActiveRecord
   include ForestAdminDatasourceToolkit::Schema
   include ForestAdminDatasourceToolkit::Components::Query
 
-  describe 'to-one JOIN optimization', :db_truncation do
+  describe 'belongs_to JOIN optimization', :db_truncation do
     let(:datasource) { Datasource.new({ adapter: 'sqlite3', database: 'db/database.db' }) }
     let(:caller) { nil }
     let(:filter) { Filter.new }
@@ -17,9 +17,8 @@ module ForestAdminDatasourceActiveRecord
       Car.unscoped.delete_all
       Category.delete_all
 
-      history  = AccountHistory.create!
       supplier = Supplier.create!(name: 'ACME')
-      Account.create!(supplier: supplier, account_history: history)
+      Account.create!(supplier: supplier, account_history: AccountHistory.create!)
 
       category = Category.create!(label: 'Compact')
       car = Car.unscoped.create!(reference: 'CAR11', category: category) # id > 10 to pass Car's default_scope
@@ -41,34 +40,34 @@ module ForestAdminDatasourceActiveRecord
       ActiveSupport::Notifications.unsubscribe(sub)
     end
 
-    describe 'a two-hop to-one chain (supplier -> account -> account_history)' do
-      let(:collection) { Collection.new(datasource, Supplier) }
-      let(:projection) { Projection.new(['id', 'name', 'account:id', 'account:account_history:id']) }
+    describe 'a belongs_to relation (account -> supplier)' do
+      let(:collection) { Collection.new(datasource, Account) }
+      let(:projection) { Projection.new(['id', 'supplier:name']) }
 
-      it 'resolves the whole chain in ONE JOINed query (was 3 with preload)' do
+      it 'resolves it in ONE JOINed query (was 2 with preload)' do
         queries = capture_sql do
           result = collection.list(caller, filter, projection)
-          expect(result.first['account']).not_to be_nil
-          expect(result.first['account']['account_history']).not_to be_nil
+          expect(result.first['supplier']['name']).to eq('ACME')
         end
 
         expect(queries.size).to eq(1)
-        expect(queries.first.scan(/LEFT OUTER JOIN/i).size).to eq(2)
+        expect(queries.first.scan(/LEFT OUTER JOIN/i).size).to eq(1)
       end
 
-      it 'selects ONLY the projected columns of the joined tables (not table.*)' do
+      it 'selects ONLY the projected columns of the joined table (not table.*)' do
         query = Utils::Query.new(collection, projection, filter)
         query.build
         sql = query.query.to_sql
 
-        expect(query.query.eager_load_values).to be_empty # eager_load would force account_histories.*
-        AccountHistory.column_names.reject { |c| c == 'id' }.each do |col|
-          expect(sql).not_to match(/account_histories"\."#{col}"/)
+        expect(query.query.eager_load_values).to be_empty # eager_load would force suppliers.*
+        selected = %w[id name]
+        Supplier.column_names.reject { |c| selected.include?(c) }.each do |col|
+          expect(sql).not_to match(/suppliers"\."#{col}"/)
         end
       end
 
       it 'keeps a constant query count regardless of the number of rows' do
-        5.times { |i| Account.create!(supplier: Supplier.create!(name: "S#{i}"), account_history: AccountHistory.create!) }
+        5.times { Account.create!(supplier: Supplier.create!(name: 'S'), account_history: AccountHistory.create!) }
 
         two = capture_sql { collection.list(caller, Filter.new(page: Page.new(limit: 2, offset: 0)), projection) }
         all = capture_sql { collection.list(caller, filter, projection) }
@@ -78,17 +77,63 @@ module ForestAdminDatasourceActiveRecord
       end
     end
 
+    describe 'a has_one relation (supplier -> account) is left on preload' do
+      # has_one does not guarantee a single child row; a JOIN could duplicate the parent.
+      let(:collection) { Collection.new(datasource, Supplier) }
+      let(:projection) { Projection.new(['id', 'name', 'account:id']) }
+
+      it 'is preloaded, not JOINed' do
+        query = Utils::Query.new(collection, projection, filter)
+        query.build
+
+        expect(query.query.joins_values).to be_empty
+        expect(query.query.includes_values.to_s).to include('account')
+        expect(query.joined_relations).to be_empty
+      end
+    end
+
+    describe 'a to-many relation (car -> checks) is left on preload' do
+      let(:collection) { Collection.new(datasource, Car) }
+      let(:projection) { Projection.new(['id', 'reference', 'checks:garage_name']) }
+
+      it 'keeps preload (separate batched query), never a row-multiplying JOIN' do
+        query = Utils::Query.new(collection, projection, filter)
+        query.build
+
+        expect(query.query.includes_values.to_s).to include('checks')
+        expect(query.query.joins_values).to be_empty
+
+        result = collection.list(caller, filter, projection)
+        expect(result.first['checks'].first['garage_name']).to eq('Garage1')
+      end
+    end
+
     describe 'safety guard: a target with a default_scope falls back to preload' do
+      # Car's default_scope has an unqualified column; a JOIN would raise "ambiguous column name".
       let(:collection) { Collection.new(datasource, Car) }
       let(:projection) { Projection.new(['id', 'reference', 'category:label']) }
 
-      # Car's default_scope has an unqualified column; a JOIN would raise "ambiguous column name".
       it 'does not JOIN and still returns correct data' do
         query = Utils::Query.new(collection, projection, filter)
         query.build
 
-        result = collection.list(caller, filter, projection)
-        expect(result.first['category']['label']).to eq('Compact')
+        expect(query.query.joins_values).to be_empty
+        expect(collection.list(caller, filter, projection).first['category']['label']).to eq('Compact')
+      end
+    end
+
+    describe 'safety guard: a table already present in the query is not joined again' do
+      # ActiveRecord would alias a table joined twice; collect_joined_selects cannot reference
+      # that alias, so such a relation must fall back to preload.
+      let(:collection) { Collection.new(datasource, Account) }
+      let(:query) { Utils::Query.new(collection, Projection.new(['id', 'supplier:name']), filter) }
+
+      it 'returns nil from joinable_tables when the target table is already used' do
+        joinable = query.send(:joinable_tables, collection, 'supplier', Projection.new(['name']), Set['accounts'])
+        expect(joinable).to eq(Set['suppliers'])
+
+        already_used = query.send(:joinable_tables, collection, 'supplier', Projection.new(['name']), Set['accounts', 'suppliers'])
+        expect(already_used).to be_nil
       end
     end
 
@@ -118,26 +163,10 @@ module ForestAdminDatasourceActiveRecord
         expect(query.send(:local_ar_collection, foreign_ds, 'Supplier')).to be_nil
       end
 
-      it 'fully_joinable? is false when the target cannot be resolved locally' do
+      it 'joinable_tables is nil when the target cannot be resolved locally' do
         allow(query).to receive(:local_ar_collection).and_return(nil)
         expect(collection.schema[:fields]['supplier'].type).to eq('ManyToOne') # joinable but for the stub
-        expect(query.send(:fully_joinable?, collection, 'supplier', Projection.new([]))).to be(false)
-      end
-    end
-
-    describe 'a to-many relation (car -> checks) is left on preload' do
-      let(:collection) { Collection.new(datasource, Car) }
-      let(:projection) { Projection.new(['id', 'reference', 'checks:garage_name']) }
-
-      it 'keeps preload (separate batched query), never a row-multiplying JOIN' do
-        query = Utils::Query.new(collection, projection, filter)
-        query.build
-
-        expect(query.query.includes_values.to_s).to include('checks')
-        expect(query.query.eager_load_values).to be_empty
-
-        result = collection.list(caller, filter, projection)
-        expect(result.first['checks'].first['garage_name']).to eq('Garage1')
+        expect(query.send(:joinable_tables, collection, 'supplier', Projection.new([]), Set['accounts'])).to be_nil
       end
     end
   end

--- a/packages/forest_admin_datasource_active_record/spec/lib/forest_admin_datasource_active_record/utils/join_to_one_optimization_spec.rb
+++ b/packages/forest_admin_datasource_active_record/spec/lib/forest_admin_datasource_active_record/utils/join_to_one_optimization_spec.rb
@@ -137,6 +137,39 @@ module ForestAdminDatasourceActiveRecord
       end
     end
 
+    describe 'safety guard: a relation already joined by a filter/sort is not joined again' do
+      let(:collection) { Collection.new(datasource, Account) }
+      let(:projection) { Projection.new(['id', 'supplier:name']) }
+
+      it 'falls back to preload for a relation the filter already joined (no duplicate JOIN)' do
+        condition = ForestAdminDatasourceToolkit::Components::Query::ConditionTree::Nodes::ConditionTreeLeaf
+                    .new('supplier:name', 'Equal', 'ACME')
+        filter = Filter.new(condition_tree: condition)
+
+        query = Utils::Query.new(collection, projection, filter)
+        query.build
+
+        expect(query.joined_relations).to be_empty # supplier was already joined for the filter
+        expect(query.query.to_sql.scan(/LEFT OUTER JOIN "suppliers"/i).size).to eq(1)
+
+        result = collection.list(caller, filter, projection)
+        expect(result.first['supplier']['name']).to eq('ACME')
+      end
+    end
+
+    describe 'same_database?' do
+      let(:query) { Utils::Query.new(Collection.new(datasource, Account), Projection.new(['id']), filter) }
+
+      it 'compares connection pools' do
+        model_a = Class.new { def self.connection_pool = :first_pool }
+        model_b = Class.new { def self.connection_pool = :second_pool }
+
+        expect(query.send(:same_database?, model_a, model_a)).to be(true)
+        expect(query.send(:same_database?, model_a, model_b)).to be(false)
+        expect(query.send(:same_database?, Account, Supplier)).to be(true)
+      end
+    end
+
     describe 'safety guard (belt-and-suspenders): target not local to this datasource' do
       let(:collection) { Collection.new(datasource, Account) }
       let(:query) { Utils::Query.new(collection, Projection.new(['id', 'supplier:name']), filter) }

--- a/packages/forest_admin_datasource_active_record/spec/lib/forest_admin_datasource_active_record/utils/join_to_one_optimization_spec.rb
+++ b/packages/forest_admin_datasource_active_record/spec/lib/forest_admin_datasource_active_record/utils/join_to_one_optimization_spec.rb
@@ -1,0 +1,150 @@
+require 'spec_helper'
+
+module ForestAdminDatasourceActiveRecord
+  include ForestAdminDatasourceToolkit::Schema
+  include ForestAdminDatasourceToolkit::Components::Query
+
+  # Proves that to-one relations on the same database are resolved with a single
+  # LEFT OUTER JOIN instead of one extra preload query per relation hop, while
+  # to-many relations, and relations whose target carries a default_scope, keep
+  # their (safe) preload behaviour.
+  describe 'to-one JOIN optimization', :db_truncation do
+    let(:datasource) { Datasource.new({ adapter: 'sqlite3', database: 'db/database.db' }) }
+    let(:caller) { nil }
+    let(:filter) { Filter.new }
+
+    before do
+      Account.delete_all
+      Supplier.delete_all
+      AccountHistory.delete_all
+      Check.delete_all
+      Car.unscoped.delete_all
+      Category.delete_all
+
+      history  = AccountHistory.create!
+      supplier = Supplier.create!(name: 'ACME')
+      Account.create!(supplier: supplier, account_history: history)
+
+      category = Category.create!(label: 'Compact')
+      car = Car.unscoped.create!(reference: 'CAR11', category: category) # id > 10 to pass Car's default_scope
+      car.checks << Check.create!(garage_name: 'Garage1', date: Date.today)
+    end
+
+    def capture_sql
+      queries = []
+      sub = ActiveSupport::Notifications.subscribe('sql.active_record') do |*args|
+        payload = args.last
+        unless payload[:name] == 'SCHEMA' || payload[:name] == 'CACHE' ||
+               payload[:sql] =~ /^(BEGIN|COMMIT|ROLLBACK|SAVEPOINT|RELEASE)/i
+          queries << payload[:sql]
+        end
+      end
+      yield
+      queries
+    ensure
+      ActiveSupport::Notifications.unsubscribe(sub)
+    end
+
+    describe 'a two-hop to-one chain (supplier -> account -> account_history)' do
+      let(:collection) { Collection.new(datasource, Supplier) }
+      let(:projection) { Projection.new(['id', 'name', 'account:id', 'account:account_history:id']) }
+
+      it 'resolves the whole chain in ONE JOINed query (was 3 with preload)' do
+        queries = capture_sql do
+          result = collection.list(caller, filter, projection)
+          # correctness: nested to-one values are still hydrated
+          expect(result.first['account']).not_to be_nil
+          expect(result.first['account']['account_history']).not_to be_nil
+        end
+
+        expect(queries.size).to eq(1)
+        expect(queries.first.scan(/LEFT OUTER JOIN/i).size).to eq(2) # accounts + account_histories
+      end
+
+      it 'builds the query with eager_load, not preload' do
+        query = Utils::Query.new(collection, projection, filter)
+        query.build
+
+        expect(query.query.eager_load_values).not_to be_empty
+        expect(query.query.includes_values).to be_empty
+      end
+
+      it 'keeps a constant query count regardless of the number of rows' do
+        5.times { |i| Account.create!(supplier: Supplier.create!(name: "S#{i}"), account_history: AccountHistory.create!) }
+
+        two = capture_sql { collection.list(caller, Filter.new(page: Page.new(limit: 2, offset: 0)), projection) }
+        all = capture_sql { collection.list(caller, filter, projection) }
+
+        expect(two.size).to eq(all.size)
+        expect(all.size).to eq(1)
+      end
+    end
+
+    describe 'safety guard: a target with a default_scope falls back to preload' do
+      let(:collection) { Collection.new(datasource, Car) }
+      let(:projection) { Projection.new(['id', 'reference', 'category:label']) }
+
+      # Category is reached through Car, whose default_scope contains an unqualified
+      # column; a JOIN would raise "ambiguous column name". The guard must keep preload.
+      it 'does not JOIN and still returns correct data' do
+        query = Utils::Query.new(collection, projection, filter)
+        query.build
+
+        result = collection.list(caller, filter, projection)
+        expect(result.first['category']['label']).to eq('Compact')
+      end
+    end
+
+    describe 'safety guard (belt-and-suspenders): target not local to this datasource' do
+      # A relation whose target lives in another datasource (RPC, Mongoid, ...) is
+      # resolved above the datasource and never reaches here. Even so, local_ar_collection
+      # only accepts an AR-backed collection belonging to the SAME datasource instance.
+      let(:collection) { Collection.new(datasource, Account) }
+      let(:query) { Utils::Query.new(collection, Projection.new(['id', 'supplier:name']), filter) }
+
+      it 'returns nil when the collection name is absent (get_collection raises)' do
+        expect { datasource.get_collection('NotInThisDatasource') }.to raise_error(StandardError)
+        expect(query.send(:local_ar_collection, datasource, 'NotInThisDatasource')).to be_nil
+      end
+
+      it 'returns nil when the resolved collection is not ActiveRecord-backed' do
+        # e.g. an RPC/Mongoid collection: a Toolkit collection that is not our AR subclass
+        non_ar = instance_double(ForestAdminDatasourceToolkit::Collection)
+        foreign_ds = instance_double(Datasource, get_collection: non_ar)
+
+        expect(query.send(:local_ar_collection, foreign_ds, 'X')).to be_nil
+      end
+
+      it 'returns nil when the resolved AR collection belongs to a DIFFERENT datasource' do
+        other_datasource = Datasource.new({ adapter: 'sqlite3', database: 'db/database.db' })
+        foreign_collection = Collection.new(other_datasource, Supplier) # AR-backed but not ours
+        foreign_ds = instance_double(Datasource, get_collection: foreign_collection)
+
+        expect(foreign_collection).to be_a(Collection) # passes the type check
+        expect(query.send(:local_ar_collection, foreign_ds, 'Supplier')).to be_nil # rejected on identity
+      end
+
+      it 'fully_joinable? is false when the target cannot be resolved locally' do
+        allow(query).to receive(:local_ar_collection).and_return(nil)
+        expect(collection.schema[:fields]['supplier'].type).to eq('ManyToOne') # otherwise joinable
+        expect(query.send(:fully_joinable?, collection, 'supplier', Projection.new([]))).to be(false)
+      end
+    end
+
+    describe 'a to-many relation (car -> checks) is left on preload' do
+      let(:collection) { Collection.new(datasource, Car) }
+      let(:projection) { Projection.new(['id', 'reference', 'checks:garage_name']) }
+
+      it 'keeps preload (separate batched query), never a row-multiplying JOIN' do
+        query = Utils::Query.new(collection, projection, filter)
+        query.build
+
+        expect(query.query.includes_values.to_s).to include('checks')
+        expect(query.query.eager_load_values).to be_empty
+
+        result = collection.list(caller, filter, projection)
+        expect(result.first['checks'].first['garage_name']).to eq('Garage1')
+      end
+    end
+  end
+end

--- a/packages/forest_admin_datasource_active_record/spec/lib/forest_admin_datasource_active_record/utils/join_to_one_optimization_spec.rb
+++ b/packages/forest_admin_datasource_active_record/spec/lib/forest_admin_datasource_active_record/utils/join_to_one_optimization_spec.rb
@@ -4,10 +4,6 @@ module ForestAdminDatasourceActiveRecord
   include ForestAdminDatasourceToolkit::Schema
   include ForestAdminDatasourceToolkit::Components::Query
 
-  # Proves that to-one relations on the same database are resolved with a single
-  # LEFT OUTER JOIN instead of one extra preload query per relation hop, while
-  # to-many relations, and relations whose target carries a default_scope, keep
-  # their (safe) preload behaviour.
   describe 'to-one JOIN optimization', :db_truncation do
     let(:datasource) { Datasource.new({ adapter: 'sqlite3', database: 'db/database.db' }) }
     let(:caller) { nil }
@@ -52,23 +48,20 @@ module ForestAdminDatasourceActiveRecord
       it 'resolves the whole chain in ONE JOINed query (was 3 with preload)' do
         queries = capture_sql do
           result = collection.list(caller, filter, projection)
-          # correctness: nested to-one values are still hydrated from the flat row
           expect(result.first['account']).not_to be_nil
           expect(result.first['account']['account_history']).not_to be_nil
         end
 
         expect(queries.size).to eq(1)
-        expect(queries.first.scan(/LEFT OUTER JOIN/i).size).to eq(2) # accounts + account_histories
+        expect(queries.first.scan(/LEFT OUTER JOIN/i).size).to eq(2)
       end
 
       it 'selects ONLY the projected columns of the joined tables (not table.*)' do
-        # account_histories is only reached for its id -> exactly one of its columns is read.
         query = Utils::Query.new(collection, projection, filter)
         query.build
         sql = query.query.to_sql
 
-        expect(query.query.eager_load_values).to be_empty # not eager_load (which forces table.*)
-        # every column of account_histories except id must be absent from the SELECT
+        expect(query.query.eager_load_values).to be_empty # eager_load would force account_histories.*
         AccountHistory.column_names.reject { |c| c == 'id' }.each do |col|
           expect(sql).not_to match(/account_histories"\."#{col}"/)
         end
@@ -89,8 +82,7 @@ module ForestAdminDatasourceActiveRecord
       let(:collection) { Collection.new(datasource, Car) }
       let(:projection) { Projection.new(['id', 'reference', 'category:label']) }
 
-      # Category is reached through Car, whose default_scope contains an unqualified
-      # column; a JOIN would raise "ambiguous column name". The guard must keep preload.
+      # Car's default_scope has an unqualified column; a JOIN would raise "ambiguous column name".
       it 'does not JOIN and still returns correct data' do
         query = Utils::Query.new(collection, projection, filter)
         query.build
@@ -101,9 +93,6 @@ module ForestAdminDatasourceActiveRecord
     end
 
     describe 'safety guard (belt-and-suspenders): target not local to this datasource' do
-      # A relation whose target lives in another datasource (RPC, Mongoid, ...) is
-      # resolved above the datasource and never reaches here. Even so, local_ar_collection
-      # only accepts an AR-backed collection belonging to the SAME datasource instance.
       let(:collection) { Collection.new(datasource, Account) }
       let(:query) { Utils::Query.new(collection, Projection.new(['id', 'supplier:name']), filter) }
 
@@ -113,7 +102,7 @@ module ForestAdminDatasourceActiveRecord
       end
 
       it 'returns nil when the resolved collection is not ActiveRecord-backed' do
-        # e.g. an RPC/Mongoid collection: a Toolkit collection that is not our AR subclass
+        # a Toolkit collection that is not our AR subclass, i.e. an RPC/Mongoid collection
         non_ar = instance_double(ForestAdminDatasourceToolkit::Collection)
         foreign_ds = instance_double(Datasource, get_collection: non_ar)
 
@@ -122,16 +111,16 @@ module ForestAdminDatasourceActiveRecord
 
       it 'returns nil when the resolved AR collection belongs to a DIFFERENT datasource' do
         other_datasource = Datasource.new({ adapter: 'sqlite3', database: 'db/database.db' })
-        foreign_collection = Collection.new(other_datasource, Supplier) # AR-backed but not ours
+        foreign_collection = Collection.new(other_datasource, Supplier)
         foreign_ds = instance_double(Datasource, get_collection: foreign_collection)
 
-        expect(foreign_collection).to be_a(Collection) # passes the type check
-        expect(query.send(:local_ar_collection, foreign_ds, 'Supplier')).to be_nil # rejected on identity
+        expect(foreign_collection).to be_a(Collection) # AR-backed, so only identity can reject it
+        expect(query.send(:local_ar_collection, foreign_ds, 'Supplier')).to be_nil
       end
 
       it 'fully_joinable? is false when the target cannot be resolved locally' do
         allow(query).to receive(:local_ar_collection).and_return(nil)
-        expect(collection.schema[:fields]['supplier'].type).to eq('ManyToOne') # otherwise joinable
+        expect(collection.schema[:fields]['supplier'].type).to eq('ManyToOne') # joinable but for the stub
         expect(query.send(:fully_joinable?, collection, 'supplier', Projection.new([]))).to be(false)
       end
     end

--- a/packages/forest_admin_datasource_active_record/spec/lib/forest_admin_datasource_active_record/utils/join_to_one_optimization_spec.rb
+++ b/packages/forest_admin_datasource_active_record/spec/lib/forest_admin_datasource_active_record/utils/join_to_one_optimization_spec.rb
@@ -52,7 +52,7 @@ module ForestAdminDatasourceActiveRecord
       it 'resolves the whole chain in ONE JOINed query (was 3 with preload)' do
         queries = capture_sql do
           result = collection.list(caller, filter, projection)
-          # correctness: nested to-one values are still hydrated
+          # correctness: nested to-one values are still hydrated from the flat row
           expect(result.first['account']).not_to be_nil
           expect(result.first['account']['account_history']).not_to be_nil
         end
@@ -61,12 +61,17 @@ module ForestAdminDatasourceActiveRecord
         expect(queries.first.scan(/LEFT OUTER JOIN/i).size).to eq(2) # accounts + account_histories
       end
 
-      it 'builds the query with eager_load, not preload' do
+      it 'selects ONLY the projected columns of the joined tables (not table.*)' do
+        # account_histories is only reached for its id -> exactly one of its columns is read.
         query = Utils::Query.new(collection, projection, filter)
         query.build
+        sql = query.query.to_sql
 
-        expect(query.query.eager_load_values).not_to be_empty
-        expect(query.query.includes_values).to be_empty
+        expect(query.query.eager_load_values).to be_empty # not eager_load (which forces table.*)
+        # every column of account_histories except id must be absent from the SELECT
+        AccountHistory.column_names.reject { |c| c == 'id' }.each do |col|
+          expect(sql).not_to match(/account_histories"\."#{col}"/)
+        end
       end
 
       it 'keeps a constant query count regardless of the number of rows' do

--- a/packages/forest_admin_datasource_active_record/spec/lib/forest_admin_datasource_active_record/utils/join_to_one_optimization_spec.rb
+++ b/packages/forest_admin_datasource_active_record/spec/lib/forest_admin_datasource_active_record/utils/join_to_one_optimization_spec.rb
@@ -86,7 +86,7 @@ module ForestAdminDatasourceActiveRecord
         query = Utils::Query.new(collection, projection, filter)
         query.build
 
-        expect(query.query.joins_values).to be_empty
+        expect(query.query.left_outer_joins_values).to be_empty
         expect(query.query.includes_values.to_s).to include('account')
         expect(query.joined_relations).to be_empty
       end
@@ -101,7 +101,7 @@ module ForestAdminDatasourceActiveRecord
         query.build
 
         expect(query.query.includes_values.to_s).to include('checks')
-        expect(query.query.joins_values).to be_empty
+        expect(query.query.left_outer_joins_values).to be_empty
 
         result = collection.list(caller, filter, projection)
         expect(result.first['checks'].first['garage_name']).to eq('Garage1')
@@ -109,16 +109,32 @@ module ForestAdminDatasourceActiveRecord
     end
 
     describe 'safety guard: a target with a default_scope falls back to preload' do
-      # Car's default_scope has an unqualified column; a JOIN would raise "ambiguous column name".
-      let(:collection) { Collection.new(datasource, Car) }
-      let(:projection) { Projection.new(['id', 'reference', 'category:label']) }
+      # Car (the target here) has a default_scope with an unqualified column; a JOIN would raise
+      # "ambiguous column name", so user -> car must stay on preload.
+      let(:collection) { Collection.new(datasource, User) }
+      let(:projection) { Projection.new(['id', 'car:reference']) }
 
-      it 'does not JOIN and still returns correct data' do
+      it 'does not JOIN the scoped target' do
         query = Utils::Query.new(collection, projection, filter)
         query.build
 
-        expect(query.query.joins_values).to be_empty
-        expect(collection.list(caller, filter, projection).first['category']['label']).to eq('Compact')
+        expect(query.joined_relations).to be_empty
+        expect(query.query.left_outer_joins_values).to be_empty
+        expect(query.query.includes_values.to_s).to include('car')
+      end
+    end
+
+    describe 'safety guard: a scoped belongs_to falls back to preload' do
+      # belongs_to :x, -> { ... } applies its scope to the JOIN (unqualified SQL / extra joins).
+      let(:collection) { Collection.new(datasource, Account) }
+      let(:query) { Utils::Query.new(collection, Projection.new(['id', 'supplier:name']), filter) }
+
+      it 'does not JOIN an association that carries a scope' do
+        scoped = Account.reflect_on_association(:supplier)
+        allow(scoped).to receive(:scope).and_return(-> { where('id > 0') })
+        allow(Account).to receive(:reflect_on_association).and_return(scoped)
+
+        expect(query.send(:joinable_target, collection, 'supplier', Set['accounts'])).to be_nil
       end
     end
 

--- a/packages/forest_admin_datasource_active_record/spec/lib/forest_admin_datasource_active_record/utils/join_to_one_optimization_spec.rb
+++ b/packages/forest_admin_datasource_active_record/spec/lib/forest_admin_datasource_active_record/utils/join_to_one_optimization_spec.rb
@@ -92,6 +92,19 @@ module ForestAdminDatasourceActiveRecord
       end
     end
 
+    describe 'a related record exposes the same columns whether JOINed or preloaded' do
+      it 'returns exactly the projected columns for a JOINed to-one (account -> supplier)' do
+        result = Collection.new(datasource, Account).list(caller, filter, Projection.new(['id', 'supplier:name']))
+        expect(result.first['supplier'].keys).to contain_exactly('name')
+      end
+
+      it 'returns exactly the projected columns for a preloaded to-one (supplier -> account)' do
+        # supplier -> account is a has_one, so it is preloaded; it must still be projected-restricted
+        result = Collection.new(datasource, Supplier).list(caller, filter, Projection.new(['id', 'account:id']))
+        expect(result.first['account'].keys).to contain_exactly('id')
+      end
+    end
+
     describe 'a to-many relation (car -> checks) is left on preload' do
       let(:collection) { Collection.new(datasource, Car) }
       let(:projection) { Projection.new(['id', 'reference', 'checks:garage_name']) }

--- a/packages/forest_admin_datasource_active_record/spec/lib/forest_admin_datasource_active_record/utils/query_spec.rb
+++ b/packages/forest_admin_datasource_active_record/spec/lib/forest_admin_datasource_active_record/utils/query_spec.rb
@@ -24,9 +24,7 @@ module ForestAdminDatasourceActiveRecord
             query_builder = described_class.new(collection, projection, Filter.new)
             query_builder.build
 
-            # base columns (own + foreign keys) are still selected as before
             expect(query_builder.select).to include('accounts.account_history_id', 'accounts.id')
-            # nested to-one relations are resolved by JOIN and tracked for flat hydration
             expect(query_builder.joined_relations.keys).to contain_exactly('account_history', 'account_history.account')
           end
         end

--- a/packages/forest_admin_datasource_active_record/spec/lib/forest_admin_datasource_active_record/utils/query_spec.rb
+++ b/packages/forest_admin_datasource_active_record/spec/lib/forest_admin_datasource_active_record/utils/query_spec.rb
@@ -18,14 +18,14 @@ module ForestAdminDatasourceActiveRecord
 
       describe 'build select' do
         context 'when projection have nested relation' do
-          it 'selects the current collection fields and JOINs the nested to-one relations' do
-            projection = Projection.new(%w[account_history:account:id account_history:account_id account_history:id])
+          it 'selects the current collection foreign keys and JOINs the belongs_to relations' do
+            projection = Projection.new(%w[supplier:name account_history:id])
             collection = Collection.new(datasource, Account)
             query_builder = described_class.new(collection, projection, Filter.new)
             query_builder.build
 
-            expect(query_builder.select).to include('accounts.account_history_id', 'accounts.id')
-            expect(query_builder.joined_relations.keys).to contain_exactly('account_history', 'account_history.account')
+            expect(query_builder.select).to include('accounts.supplier_id', 'accounts.account_history_id')
+            expect(query_builder.joined_relations.keys).to contain_exactly('supplier', 'account_history')
           end
         end
       end

--- a/packages/forest_admin_datasource_active_record/spec/lib/forest_admin_datasource_active_record/utils/query_spec.rb
+++ b/packages/forest_admin_datasource_active_record/spec/lib/forest_admin_datasource_active_record/utils/query_spec.rb
@@ -18,13 +18,16 @@ module ForestAdminDatasourceActiveRecord
 
       describe 'build select' do
         context 'when projection have nested relation' do
-          it 'build select with all requested fields related to the current collection' do
+          it 'selects the current collection fields and JOINs the nested to-one relations' do
             projection = Projection.new(%w[account_history:account:id account_history:account_id account_history:id])
             collection = Collection.new(datasource, Account)
             query_builder = described_class.new(collection, projection, Filter.new)
             query_builder.build
 
-            expect(query_builder.select).to eq(%w[accounts.account_history_id accounts.id])
+            # base columns (own + foreign keys) are still selected as before
+            expect(query_builder.select).to include('accounts.account_history_id', 'accounts.id')
+            # nested to-one relations are resolved by JOIN and tracked for flat hydration
+            expect(query_builder.joined_relations.keys).to contain_exactly('account_history', 'account_history.account')
           end
         end
       end


### PR DESCRIPTION
## Context

When rendering a record (or a list) through the ActiveRecord datasource, every relation in the projection is resolved with `.includes` → ActiveRecord **preload** (one extra query per relation hop). Displaying a `belongs_to` chain such as `income → bank_account → organization` therefore issues **3 sequential queries** (a round-trip waterfall). And because relations are preloaded (or, with `eager_load`, joined), the related rows are always read in full (`SELECT relation.*`) — costly when the relation is a wide table or a heavy DB **view**.

## Change

`Utils::Query#apply_select` now splits the projection's relations:

- **to-one relations on the same database** (`belongs_to` / `has_one`, non-polymorphic) are resolved with a single `LEFT OUTER JOIN`, selecting **only the projected columns** of each joined table (aliased on the flat row), plus the target primary key for NULL detection. The serializer rebuilds the nested hash from those aliases instead of reading the ActiveRecord association.
- everything else keeps its current **preload** behaviour and association-based serialization.

### Measured effect

`income → bank_account → organization`, displaying only `organization.name`:

**Before** — 3 sequential queries, each `SELECT relation.*`:
```sql
SELECT incomes.id, incomes.bank_account_id FROM incomes WHERE id = $1;
SELECT bank_accounts.*      FROM bank_accounts      WHERE id = $1;
SELECT organizations_view.* FROM organizations_view WHERE id = $1;  -- ~150 columns of a view
```

**After** — 1 query, only the projected column of the view:
```sql
SELECT incomes.id, incomes.bank_account_id,
       bank_accounts.id        AS fa_join_1,
       organizations_view.name AS fa_join_2,
       organizations_view.id   AS fa_join_3
FROM incomes
LEFT OUTER JOIN bank_accounts     ON bank_accounts.id = incomes.bank_account_id
LEFT OUTER JOIN organizations_view ON organizations_view.id = bank_accounts.organizations_view_id
WHERE incomes.id = $1;
```

On a list, the query count stays **constant** regardless of the number of rows.

## Safety — nothing is JOINed unless it is provably safe

`fully_joinable?` walks the whole relation subtree and falls back to preload if any of these do not hold:

- **to-many** relations → preload (a JOIN multiplies rows and breaks pagination);
- **polymorphic** to-one → preload (target table varies per row);
- **different database connection** (`connects_to`) → preload (cannot JOIN across connections);
- **`default_scope` on the target** → preload (may inject unqualifiable raw SQL, e.g. `where('id > ?', 10)`, that becomes ambiguous once joined);
- **target not resolvable as an AR-backed collection belonging to this very datasource** → preload (defensive against cross-datasource / name-collision cases — checks the concrete class *and* the datasource object identity, not just the name).

## Tests

New spec `utils/join_to_one_optimization_spec.rb`:

- a two-hop chain resolves in a single JOINed query (was 3 with preload);
- the JOIN selects only the projected columns of the joined tables (not `table.*`);
- query count stays constant regardless of row count;
- each guard (default_scope, absent collection, non-AR target, foreign datasource) falls back to preload safely;
- to-many relations still preload.

`query_spec.rb` updated to reflect that nested to-one relations are now JOINed.

Full `forest_admin_datasource_active_record` suite: **156 examples, 0 failures**. RuboCop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### JOIN same-database belongs_to relations and select only projected columns in ActiveRecord datasource queries
> - [`Utils::Query`](https://github.com/ForestAdmin/agent-ruby/pull/323/files#diff-dea919d07e1dd6d6bd15b32211d4b2d3edadbbf1eabe4eb7ea1721e32f5a29fa) now splits `belongs_to` relations into two groups: eligible ones (same DB, no scopes, no duplicate tables) are LEFT OUTER JOINed with aliased column selects; the rest are preloaded via `includes`.
> - [`Utils::ActiveRecordSerializer`](https://github.com/ForestAdmin/agent-ruby/pull/323/files#diff-044e16d086eec187a3d9bd91f520bd04dba80b9855bd1adfa4b08ce1c38ac8b6) accepts a `joined_relations` map and hydrates JOINed relations from aliased columns on the root row instead of traversing preloaded AR associations.
> - Filter/sort JOINs are tracked in `@filter_joined_tables` to prevent duplicate conflicting JOINs when `apply_select` runs.
> - Nested JOINable relations are supported recursively.
> - Behavioral Change: queries that previously issued N+1 preloads for eligible `belongs_to` relations now issue a single JOIN query with an explicit SELECT list, changing the SQL shape and column count of results.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #323 opened
>
> - Modified `ForestAdminDatasourceActiveRecord::Utils::ActiveRecordSerializer.hash_object` to conditionally serialize related records with only projected columns instead of full attributes, and introduced `ForestAdminDatasourceActiveRecord::Utils::ActiveRecordSerializer.projected_columns` helper method [6115cfa]
> - Added test coverage verifying that related records serialized after JOIN or preload operations expose exactly the projected columns [6115cfa]
> - Updated inline documentation and comments in `ForestAdminDatasourceActiveRecord::Utils::ActiveRecordSerializer` and `ForestAdminDatasourceActiveRecord::Utils::Query` [0a762a6]
> - Changed `ForestAdminDatasourceActiveRecord::Utils::ActiveRecordSerializer.join_aliases` private method to use array deduplication instead of Set conversion [43e0e92]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ac04d57.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->