### PR TITLE
perf(agent): cache IP whitelist rules across requests

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -364,6 +364,7 @@ Metrics/ClassLength:
     - 'packages/forest_admin_agent/lib/forest_admin_agent/routes/resources/related/update_related.rb'
     - 'packages/forest_admin_agent/lib/forest_admin_agent/routes/workflow/workflow_executor_proxy.rb'
     - 'packages/forest_admin_agent/lib/forest_admin_agent/services/permissions.rb'
+    - 'packages/forest_admin_agent/lib/forest_admin_agent/services/ip_whitelist.rb'
     - 'packages/forest_admin_agent/lib/forest_admin_agent/services/smart_action_checker.rb'
     - 'packages/forest_admin_agent/lib/forest_admin_agent/utils/schema/frontend_validation_utils.rb'
     - 'packages/forest_admin_agent/lib/forest_admin_agent/utils/query_string_parser.rb'

--- a/packages/forest_admin_agent/lib/forest_admin_agent/services/ip_whitelist.rb
+++ b/packages/forest_admin_agent/lib/forest_admin_agent/services/ip_whitelist.rb
@@ -1,4 +1,6 @@
 require 'ipaddress'
+require 'filecache'
+require 'json'
 
 module ForestAdminAgent
   module Services
@@ -6,11 +8,26 @@ module ForestAdminAgent
       RULE_MATCH_IP = 0
       RULE_MATCH_RANGE = 1
       RULE_MATCH_SUBNET = 2
+      CACHE_KEY = 'forest.ip_whitelist'.freeze
 
-      attr_reader :forest_api
+      attr_reader :forest_api, :cache
 
       def initialize
         @forest_api = ForestAdminAgent::Http::ForestAdminApiRequester.new
+        @cache = FileCache.new(
+          'ip_whitelist',
+          Facades::Container.config_from_cache[:cache_dir].to_s,
+          Facades::Container.config_from_cache[:permission_expiration]
+        )
+      end
+
+      def self.invalidate_cache
+        cache = FileCache.new(
+          'ip_whitelist',
+          Facades::Container.config_from_cache[:cache_dir].to_s,
+          Facades::Container.config_from_cache[:permission_expiration]
+        )
+        cache.delete(CACHE_KEY) unless cache.get(CACHE_KEY).nil?
       end
 
       def use_ip_whitelist
@@ -85,6 +102,13 @@ module ForestAdminAgent
       private
 
       def fetch_rules
+        ip_whitelist_data = cache.get_or_set(CACHE_KEY) { fetch_ip_whitelist_from_api }
+
+        @use_ip_whitelist = ip_whitelist_data['use_ip_whitelist']
+        @rules = ip_whitelist_data['rules']
+      end
+
+      def fetch_ip_whitelist_from_api
         response = forest_api.get('/liana/v1/ip-whitelist-rules')
 
         unless response.status == 200
@@ -109,10 +133,7 @@ module ForestAdminAgent
                 ForestAdminAgent::Utils::ErrorMessages::UNEXPECTED
         end
 
-        ip_whitelist_data = body['data']['attributes']
-
-        @use_ip_whitelist = ip_whitelist_data['use_ip_whitelist']
-        @rules = ip_whitelist_data['rules']
+        body['data']['attributes']
       rescue StandardError => e
         ForestAdminAgent::Facades::Container.logger.log('Debug', {
                                                           error: e.message,

--- a/packages/forest_admin_agent/spec/lib/forest_admin_agent/services/ip_whitelist_spec.rb
+++ b/packages/forest_admin_agent/spec/lib/forest_admin_agent/services/ip_whitelist_spec.rb
@@ -10,6 +10,8 @@ module ForestAdminAgent
 
       let(:forest_api_requester) { instance_double(ForestAdminAgent::Http::ForestAdminApiRequester) }
 
+      before { described_class.invalidate_cache }
+
       context 'when there is no rule' do
         before do
           allow(forest_api_requester).to receive(:get).with('/liana/v1/ip-whitelist-rules').and_return(
@@ -284,6 +286,32 @@ module ForestAdminAgent
           expect do
             ip_whitelist.ip_matches_any_rule?(client_ip)
           end.to raise_error('Invalid rule type')
+        end
+      end
+
+      context 'when caching whitelist rules' do
+        before do
+          allow(forest_api_requester).to receive(:get).with('/liana/v1/ip-whitelist-rules').and_return(
+            instance_double(Faraday::Response,
+                            status: 200,
+                            body: {
+                              'data' => {
+                                'attributes' => {
+                                  'rules' => [],
+                                  'use_ip_whitelist' => false
+                                }
+                              }
+                            }.to_json)
+          )
+
+          allow(ForestAdminAgent::Http::ForestAdminApiRequester).to receive(:new).and_return(forest_api_requester)
+        end
+
+        it 'fetches the rules from the API only once across instances' do
+          described_class.new.use_ip_whitelist
+          described_class.new.use_ip_whitelist
+
+          expect(forest_api_requester).to have_received(:get).once
         end
       end
     end

--- a/packages/forest_admin_agent/spec/spec_helper.rb
+++ b/packages/forest_admin_agent/spec/spec_helper.rb
@@ -51,6 +51,7 @@ RSpec.configure do |config|
         forest_server_url: 'https://api.development.forestadmin.com',
         debug: true,
         prefix: 'forest',
+        permission_expiration: 100,
         customize_error_message: nil,
         append_schema_path: nil
       }


### PR DESCRIPTION
## Context

`ForestAdminAgent::Routes::AbstractAuthenticatedRoute` calls `Facades::Whitelist.check_ip` on **every authenticated request**, and `check_ip` builds a **fresh `IpWhitelist` instance** each time. `IpWhitelist` memoized its rules only in instance variables (`@rules` / `@use_ip_whitelist`), with no cross-request cache — so every request issued a new HTTPS call to `GET /liana/v1/ip-whitelist-rules`, opening a new TLS connection each time (no pooling).

Profiling a trivial endpoint (`.../relationships/transactions/count`) under load showed **~65% of request wall-time** in `TCPSocket#initialize` / `Net::HTTP#connect`, all originating from `IpWhitelist#fetch_rules`. On a mini benchmark this made cheap endpoints 3–6× slower than they should be (e.g. a count: ~33 ms with only ~1.7 ms of SQL).

By contrast, permissions are already cached (`FileCache`, `permission_expiration` TTL) — 0 permission fetches over the same burst.

## Change

`IpWhitelist` now caches the fetched configuration in a `FileCache('ip_whitelist', cache_dir, permission_expiration)` via `get_or_set`, mirroring `Permissions`:

- new instances read the cached rules instead of re-hitting the API;
- TTL = `permission_expiration` (same as permissions);
- the HTTP call is isolated in `fetch_ip_whitelist_from_api`, so failed fetches raise and are **not** cached.

## Measured effect

Same scenario, before → after (median of 7, warm):

| endpoint | before | after |
|---|---|---|
| related count | ~33 ms | ~7 ms |
| record show | ~45 ms | ~9 ms |
| related list (100) | ~155 ms | ~49 ms |

The per-request outbound HTTPS call to the Forest server is gone (first request warms the cache, subsequent ones read from `FileCache`).

## Tests

- `ip_whitelist_spec.rb`: added `before { described_class.invalidate_cache }` (the disk cache otherwise leaks between examples), plus a new test asserting the API is fetched **once** across two instances.
- `spec_helper.rb`: added `permission_expiration: 100` to the shared agent config (needed now that the service builds a `FileCache` with that TTL).
- `.rubocop.yml`: `ip_whitelist.rb` added to the `Metrics/ClassLength` exclude list, alongside `permissions.rb`.

Full `forest_admin_agent` suite: **719 examples, 0 failures**. RuboCop clean.

> Note: stacked on `perf/ar-datasource-join-to-one-same-db` (#323) since that is the branch it was validated against; the change is independent and can be retargeted to `main` once #323 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Cache IP whitelist rules across requests using a file-backed cache
> - Adds a file-backed cache (keyed `forest.ip_whitelist`) to `IpWhitelist` so the API is called only once per TTL window instead of on every request.
> - Extracts API fetching into `fetch_ip_whitelist_from_api`, with `fetch_rules` now reading from cache via `get_or_set`.
> - Adds `IpWhitelist.invalidate_cache` class method to manually clear the cached whitelist entry.
> - Test suite gains a `before` hook calling `invalidate_cache` for isolation and a new test asserting a single API call across multiple instances.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 57fbc5b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->