### PR TITLE
feat(datasource-active-record): expose has_one :through as a to-one relation

### DIFF
--- a/packages/forest_admin_datasource_active_record/lib/forest_admin_datasource_active_record/collection.rb
+++ b/packages/forest_admin_datasource_active_record/lib/forest_admin_datasource_active_record/collection.rb
@@ -100,21 +100,32 @@ module ForestAdminDatasourceActiveRecord
               source_polymorphic = association.source_reflection&.polymorphic? &&
                                    association.options[:source_type].present?
 
-              add_field(
-                association.name.to_s,
-                ForestAdminDatasourceToolkit::Schema::Relations::ManyToManySchema.new(
-                  foreign_collection: format_model_name(association.klass.name),
-                  origin_key: through_reflection.foreign_key,
-                  origin_key_target: through_reflection.join_foreign_key,
-                  foreign_key: association.join_foreign_key,
-                  foreign_key_target: association.association_primary_key,
-                  through_collection: format_model_name(through_reflection.klass.name),
-                  origin_type_field: is_polymorphic ? through_reflection.type : nil,
-                  origin_type_value: is_polymorphic ? @model.name : nil,
-                  foreign_type_field: source_polymorphic ? association.source_reflection.foreign_type : nil,
-                  foreign_type_value: source_polymorphic ? association.options[:source_type] : nil
+              if is_polymorphic || source_polymorphic
+                add_field(
+                  association.name.to_s,
+                  ForestAdminDatasourceToolkit::Schema::Relations::ManyToManySchema.new(
+                    foreign_collection: format_model_name(association.klass.name),
+                    origin_key: through_reflection.foreign_key,
+                    origin_key_target: through_reflection.join_foreign_key,
+                    foreign_key: association.join_foreign_key,
+                    foreign_key_target: association.association_primary_key,
+                    through_collection: format_model_name(through_reflection.klass.name),
+                    origin_type_field: is_polymorphic ? through_reflection.type : nil,
+                    origin_type_value: is_polymorphic ? @model.name : nil,
+                    foreign_type_field: source_polymorphic ? association.source_reflection.foreign_type : nil,
+                    foreign_type_value: source_polymorphic ? association.options[:source_type] : nil
+                  )
                 )
-              )
+              else
+                add_field(
+                  association.name.to_s,
+                  ForestAdminDatasourceToolkit::Schema::Relations::OneToOneSchema.new(
+                    foreign_collection: format_model_name(association.klass.name),
+                    origin_key: association.klass.primary_key,
+                    origin_key_target: @model.primary_key
+                  )
+                )
+              end
             elsif association.inverse_of&.polymorphic?
               add_field(
                 association.name.to_s,

--- a/packages/forest_admin_datasource_active_record/lib/forest_admin_datasource_active_record/collection.rb
+++ b/packages/forest_admin_datasource_active_record/lib/forest_admin_datasource_active_record/collection.rb
@@ -117,11 +117,6 @@ module ForestAdminDatasourceActiveRecord
                   )
                 )
               else
-                # A has_one :through is single-valued, so expose it as a to-one (HasOne). ActiveRecord
-                # resolves the join by association name, so the primary keys below only need to be real
-                # columns for reads/schema generation. This relation is display-only: it has no direct
-                # foreign key to set, so updating/associating it through the OneToOne write path is not
-                # supported (the link lives on the intermediate table).
                 add_field(
                   association.name.to_s,
                   ForestAdminDatasourceToolkit::Schema::Relations::OneToOneSchema.new(

--- a/packages/forest_admin_datasource_active_record/lib/forest_admin_datasource_active_record/collection.rb
+++ b/packages/forest_admin_datasource_active_record/lib/forest_admin_datasource_active_record/collection.rb
@@ -117,6 +117,11 @@ module ForestAdminDatasourceActiveRecord
                   )
                 )
               else
+                # A has_one :through is single-valued, so expose it as a to-one (HasOne). ActiveRecord
+                # resolves the join by association name, so the primary keys below only need to be real
+                # columns for reads/schema generation. This relation is display-only: it has no direct
+                # foreign key to set, so updating/associating it through the OneToOne write path is not
+                # supported (the link lives on the intermediate table).
                 add_field(
                   association.name.to_s,
                   ForestAdminDatasourceToolkit::Schema::Relations::OneToOneSchema.new(

--- a/packages/forest_admin_datasource_active_record/lib/forest_admin_datasource_active_record/utils/query.rb
+++ b/packages/forest_admin_datasource_active_record/lib/forest_admin_datasource_active_record/utils/query.rb
@@ -196,8 +196,6 @@ module ForestAdminDatasourceActiveRecord
           if collection.model.table_name == @collection.model.table_name
             if one_to_one_relations.include?(relation_schema.type)
               @select << "#{collection.model.table_name}.#{relation_schema.origin_key_target}"
-              # a has_one :through preloads via the intermediate FK on this table; select it so a
-              # relation that falls back to preload (e.g. it is also used by a filter) still loads.
               through_fk = root_through_foreign_key(collection, relation_name)
               @select << "#{collection.model.table_name}.#{through_fk}" if through_fk
             elsif many_to_one_relations.include?(relation_schema.type)
@@ -279,8 +277,6 @@ module ForestAdminDatasourceActiveRecord
         target = joinable_target(collection, relation_name, used_tables)
         return nil if target.nil?
 
-        # a has_one :through also joins its intermediate table(s); count them so a separately
-        # projected relation on the same table is not joined a second time (AR would alias it)
         tables = Set[target.model.table_name] | through_tables(collection, relation_name)
         sub_projection.relations.each do |nested_name, nested_projection|
           nested = joinable_tables(target, nested_name, nested_projection, used_tables | tables)
@@ -291,11 +287,7 @@ module ForestAdminDatasourceActiveRecord
         tables
       end
 
-      # The target collection when this single hop is safe to collapse into a LEFT OUTER JOIN,
-      # else nil. A belongs_to qualifies: it matches on the target's primary key, so the JOIN
-      # cannot duplicate the parent row (a plain has_one child may not be unique). A has_one :through
-      # also qualifies when every hop is a belongs_to (see belongs_to_chain_through?): AR resolves the
-      # intermediate join, saving the extra per-hop preload queries.
+      # The target collection when this hop is safe to collapse into a JOIN, else nil (-> preload).
       def joinable_target(collection, relation_name, used_tables)
         relation_schema = collection.schema[:fields][relation_name]
         return unless relation_schema.respond_to?(:foreign_collection)
@@ -315,13 +307,11 @@ module ForestAdminDatasourceActiveRecord
         return if target.nil? || !target.model.default_scopes.empty? # same risk as a scoped association
         return unless same_database?(collection.model, target.model)
         return if used_tables.include?(target.model.table_name) # a table joined twice would be aliased by AR
-        # same for the intermediate table(s) a has_one :through pulls in
         return if through_tables(collection, relation_name).intersect?(used_tables)
 
         target
       end
 
-      # Intermediate table(s) ActiveRecord joins for a has_one :through (empty for a direct to-one).
       def through_tables(collection, relation_name)
         through = collection.model.reflect_on_association(relation_name.to_sym)&.through_reflection
         return Set[] unless through
@@ -337,8 +327,6 @@ module ForestAdminDatasourceActiveRecord
         through = reflection.through_reflection
         source = reflection.source_reflection
 
-        # every hop matches on a primary key (no row multiplication), carries no scope, and stays in
-        # this database, so the chained LEFT JOIN is safe
         through && source && through.belongs_to? && source.belongs_to? &&
           through.scope.nil? && source.scope.nil? && through.klass.default_scopes.empty? &&
           same_database?(reflection.active_record, through.klass)
@@ -371,10 +359,6 @@ module ForestAdminDatasourceActiveRecord
         @query
       end
 
-      # The intermediate foreign key a has_one :through uses on this table, or nil for a plain to-one.
-      # The intermediate FK a has_one :through preloads through, but only when it lives on THIS (root)
-      # table — i.e. the through hop is a belongs_to. For a has_one through hop the FK is on the child,
-      # so selecting it against the root table would emit an invalid column.
       def root_through_foreign_key(collection, relation_name)
         through = collection.model.reflect_on_association(relation_name.to_sym)&.through_reflection
         return unless through&.belongs_to?

--- a/packages/forest_admin_datasource_active_record/lib/forest_admin_datasource_active_record/utils/query.rb
+++ b/packages/forest_admin_datasource_active_record/lib/forest_admin_datasource_active_record/utils/query.rb
@@ -198,7 +198,7 @@ module ForestAdminDatasourceActiveRecord
               @select << "#{collection.model.table_name}.#{relation_schema.origin_key_target}"
               # a has_one :through preloads via the intermediate FK on this table; select it so a
               # relation that falls back to preload (e.g. it is also used by a filter) still loads.
-              through_fk = through_foreign_key(collection, relation_name)
+              through_fk = root_through_foreign_key(collection, relation_name)
               @select << "#{collection.model.table_name}.#{through_fk}" if through_fk
             elsif many_to_one_relations.include?(relation_schema.type)
               @select << "#{collection.model.table_name}.#{relation_schema.foreign_key}"
@@ -279,7 +279,9 @@ module ForestAdminDatasourceActiveRecord
         target = joinable_target(collection, relation_name, used_tables)
         return nil if target.nil?
 
-        tables = Set[target.model.table_name]
+        # a has_one :through also joins its intermediate table(s); count them so a separately
+        # projected relation on the same table is not joined a second time (AR would alias it)
+        tables = Set[target.model.table_name] | through_tables(collection, relation_name)
         sub_projection.relations.each do |nested_name, nested_projection|
           nested = joinable_tables(target, nested_name, nested_projection, used_tables | tables)
           return nil if nested.nil?
@@ -313,8 +315,20 @@ module ForestAdminDatasourceActiveRecord
         return if target.nil? || !target.model.default_scopes.empty? # same risk as a scoped association
         return unless same_database?(collection.model, target.model)
         return if used_tables.include?(target.model.table_name) # a table joined twice would be aliased by AR
+        # same for the intermediate table(s) a has_one :through pulls in
+        return if through_tables(collection, relation_name).intersect?(used_tables)
 
         target
+      end
+
+      # Intermediate table(s) ActiveRecord joins for a has_one :through (empty for a direct to-one).
+      def through_tables(collection, relation_name)
+        through = collection.model.reflect_on_association(relation_name.to_sym)&.through_reflection
+        return Set[] unless through
+
+        Set[through.table_name]
+      rescue StandardError
+        Set[]
       end
 
       def belongs_to_chain_through?(reflection)
@@ -322,12 +336,12 @@ module ForestAdminDatasourceActiveRecord
 
         through = reflection.through_reflection
         source = reflection.source_reflection
-        return false unless through && source
-        return false unless through.belongs_to? && source.belongs_to?
-        return false if through.scope || source.scope
-        return false unless through.klass.default_scopes.empty?
 
-        same_database?(reflection.active_record, through.klass)
+        # every hop matches on a primary key (no row multiplication), carries no scope, and stays in
+        # this database, so the chained LEFT JOIN is safe
+        through && source && through.belongs_to? && source.belongs_to? &&
+          through.scope.nil? && source.scope.nil? && through.klass.default_scopes.empty? &&
+          same_database?(reflection.active_record, through.klass)
       rescue StandardError
         false
       end
@@ -358,11 +372,14 @@ module ForestAdminDatasourceActiveRecord
       end
 
       # The intermediate foreign key a has_one :through uses on this table, or nil for a plain to-one.
-      def through_foreign_key(collection, relation_name)
-        reflection = collection.model.reflect_on_association(relation_name.to_sym)
-        return unless reflection&.through_reflection?
+      # The intermediate FK a has_one :through preloads through, but only when it lives on THIS (root)
+      # table — i.e. the through hop is a belongs_to. For a has_one through hop the FK is on the child,
+      # so selecting it against the root table would emit an invalid column.
+      def root_through_foreign_key(collection, relation_name)
+        through = collection.model.reflect_on_association(relation_name.to_sym)&.through_reflection
+        return unless through&.belongs_to?
 
-        reflection.through_reflection.foreign_key
+        through.foreign_key
       rescue StandardError
         nil
       end

--- a/packages/forest_admin_datasource_active_record/lib/forest_admin_datasource_active_record/utils/query.rb
+++ b/packages/forest_admin_datasource_active_record/lib/forest_admin_datasource_active_record/utils/query.rb
@@ -196,6 +196,10 @@ module ForestAdminDatasourceActiveRecord
           if collection.model.table_name == @collection.model.table_name
             if one_to_one_relations.include?(relation_schema.type)
               @select << "#{collection.model.table_name}.#{relation_schema.origin_key_target}"
+              # a has_one :through preloads via the intermediate FK on this table; select it so a
+              # relation that falls back to preload (e.g. it is also used by a filter) still loads.
+              through_fk = through_foreign_key(collection, relation_name)
+              @select << "#{collection.model.table_name}.#{through_fk}" if through_fk
             elsif many_to_one_relations.include?(relation_schema.type)
               @select << "#{collection.model.table_name}.#{relation_schema.foreign_key}"
             end
@@ -285,17 +289,25 @@ module ForestAdminDatasourceActiveRecord
         tables
       end
 
-      # The target collection when this hop is safe to collapse into a JOIN, else nil (-> preload).
+      # The target collection when this single hop is safe to collapse into a LEFT OUTER JOIN,
+      # else nil. A belongs_to qualifies: it matches on the target's primary key, so the JOIN
+      # cannot duplicate the parent row (a plain has_one child may not be unique). A has_one :through
+      # also qualifies when every hop is a belongs_to (see belongs_to_chain_through?): AR resolves the
+      # intermediate join, saving the extra per-hop preload queries.
       def joinable_target(collection, relation_name, used_tables)
         relation_schema = collection.schema[:fields][relation_name]
-        # belongs_to only: it joins on the target's primary key, so it can't duplicate the parent
-        # (a has_one child may not be unique)
-        return unless relation_schema.type == 'ManyToOne' && relation_schema.respond_to?(:foreign_collection)
+        return unless relation_schema.respond_to?(:foreign_collection)
 
         # a scoped association applies its scope to the JOIN and may inject raw/unqualified SQL or
         # extra joins (e.g. `belongs_to :x, -> { where('id > ?', 1) }`)
         reflection = collection.model.reflect_on_association(relation_name.to_sym)
         return if reflection.nil? || reflection.scope
+
+        case relation_schema.type
+        when 'ManyToOne' then nil
+        when 'OneToOne' then return unless belongs_to_chain_through?(reflection)
+        else return
+        end
 
         target = local_ar_collection(collection.datasource, relation_schema.foreign_collection)
         return if target.nil? || !target.model.default_scopes.empty? # same risk as a scoped association
@@ -303,6 +315,21 @@ module ForestAdminDatasourceActiveRecord
         return if used_tables.include?(target.model.table_name) # a table joined twice would be aliased by AR
 
         target
+      end
+
+      def belongs_to_chain_through?(reflection)
+        return false unless reflection.through_reflection?
+
+        through = reflection.through_reflection
+        source = reflection.source_reflection
+        return false unless through && source
+        return false unless through.belongs_to? && source.belongs_to?
+        return false if through.scope || source.scope
+        return false unless through.klass.default_scopes.empty?
+
+        same_database?(reflection.active_record, through.klass)
+      rescue StandardError
+        false
       end
 
       def same_database?(model_a, model_b)
@@ -328,6 +355,16 @@ module ForestAdminDatasourceActiveRecord
         @query = @query.left_joins(relation_name.to_sym)
 
         @query
+      end
+
+      # The intermediate foreign key a has_one :through uses on this table, or nil for a plain to-one.
+      def through_foreign_key(collection, relation_name)
+        reflection = collection.model.reflect_on_association(relation_name.to_sym)
+        return unless reflection&.through_reflection?
+
+        reflection.through_reflection.foreign_key
+      rescue StandardError
+        nil
       end
 
       def resolve_field(original_field)

--- a/packages/forest_admin_datasource_active_record/spec/dummy/app/models/account.rb
+++ b/packages/forest_admin_datasource_active_record/spec/dummy/app/models/account.rb
@@ -1,4 +1,5 @@
 class Account < ApplicationRecord
   belongs_to :supplier
   belongs_to :account_history
+  has_one :order, through: :account_history
 end

--- a/packages/forest_admin_datasource_active_record/spec/dummy/app/models/account_history.rb
+++ b/packages/forest_admin_datasource_active_record/spec/dummy/app/models/account_history.rb
@@ -1,3 +1,4 @@
 class AccountHistory < ApplicationRecord
   has_one :account
+  belongs_to :order, optional: true
 end

--- a/packages/forest_admin_datasource_active_record/spec/dummy/db/migrate/20251126100004_add_order_to_account_histories.rb
+++ b/packages/forest_admin_datasource_active_record/spec/dummy/db/migrate/20251126100004_add_order_to_account_histories.rb
@@ -1,0 +1,5 @@
+class AddOrderToAccountHistories < ActiveRecord::Migration[7.1]
+  def change
+    add_reference :account_histories, :order, null: true, foreign_key: true
+  end
+end

--- a/packages/forest_admin_datasource_active_record/spec/lib/forest_admin_datasource_active_record/collection_spec.rb
+++ b/packages/forest_admin_datasource_active_record/spec/lib/forest_admin_datasource_active_record/collection_spec.rb
@@ -44,12 +44,16 @@ module ForestAdminDatasourceActiveRecord
           expect(collection.schema[:fields].keys).to include('users')
         end
 
-        it 'add has_one_through relation' do
+        it 'add has_one_through relation as a to-one (OneToOne)' do
           collection = described_class.new(datasource, Supplier)
 
           expect(collection.schema[:fields].keys).to include('account_history')
 
-          expect(collection.schema[:fields]['account_history'].class).to eq(Relations::ManyToManySchema)
+          field = collection.schema[:fields]['account_history']
+          expect(field.class).to eq(Relations::OneToOneSchema)
+          expect(field.foreign_collection).to eq('AccountHistory')
+          expect(field.origin_key).to eq(AccountHistory.primary_key)
+          expect(field.origin_key_target).to eq(Supplier.primary_key)
         end
 
         it 'skips association when foreign_key raises an error' do

--- a/packages/forest_admin_datasource_active_record/spec/lib/forest_admin_datasource_active_record/utils/join_to_one_optimization_spec.rb
+++ b/packages/forest_admin_datasource_active_record/spec/lib/forest_admin_datasource_active_record/utils/join_to_one_optimization_spec.rb
@@ -159,6 +159,19 @@ module ForestAdminDatasourceActiveRecord
         expect(result.first['order']['reference']).to eq('ORD-1')
         expect(result.first['account_history']['id']).to eq(Account.first.account_history_id)
       end
+
+      it 'does not JOIN the intermediate table twice when a filter already joined the through' do
+        projection = Projection.new(['id', 'account_history:id'])
+        condition = ForestAdminDatasourceToolkit::Components::Query::ConditionTree::Nodes::ConditionTreeLeaf
+                    .new('order:reference', 'Equal', 'ORD-1')
+        query = Utils::Query.new(collection, projection, Filter.new(condition_tree: condition))
+        query.build
+
+        expect(query.query.to_sql.scan(/JOIN "account_histories"/i).size).to eq(1)
+
+        result = collection.list(caller, Filter.new(condition_tree: condition), projection)
+        expect(result.first['account_history']['id']).to eq(Account.first.account_history_id)
+      end
     end
 
     describe 'a has_one :through with a has_one hop (supplier -> account_history) stays on preload' do

--- a/packages/forest_admin_datasource_active_record/spec/lib/forest_admin_datasource_active_record/utils/join_to_one_optimization_spec.rb
+++ b/packages/forest_admin_datasource_active_record/spec/lib/forest_admin_datasource_active_record/utils/join_to_one_optimization_spec.rb
@@ -105,6 +105,65 @@ module ForestAdminDatasourceActiveRecord
       end
     end
 
+    describe 'a has_one :through of belongs_to hops (account -> account_history -> order)' do
+      # every hop is a belongs_to, so the chained JOIN stays 1:1 and cannot multiply the parent.
+      let(:collection) { Collection.new(datasource, Account) }
+      let(:projection) { Projection.new(['id', 'order:reference']) }
+
+      before do
+        order = Order.create!(reference: 'ORD-1')
+        Account.first.account_history.update!(order: order)
+      end
+
+      it 'folds the whole chain into ONE JOINed query (was 3 with per-hop preload)' do
+        queries = capture_sql do
+          result = collection.list(caller, filter, projection)
+          expect(result.first['order']['reference']).to eq('ORD-1')
+        end
+
+        expect(queries.size).to eq(1)
+        expect(queries.first.scan(/LEFT OUTER JOIN/i).size).to eq(2) # account_histories + orders
+      end
+
+      it 'filters on a field of the through relation' do
+        condition = ForestAdminDatasourceToolkit::Components::Query::ConditionTree::Nodes::ConditionTreeLeaf
+                    .new('order:reference', 'Equal', 'ORD-1')
+        result = collection.list(caller, Filter.new(condition_tree: condition), projection)
+
+        expect(result.size).to eq(1)
+        expect(result.first['order']['reference']).to eq('ORD-1')
+      end
+
+      it 'returns nothing when the through relation value does not match' do
+        condition = ForestAdminDatasourceToolkit::Components::Query::ConditionTree::Nodes::ConditionTreeLeaf
+                    .new('order:reference', 'Equal', 'NOPE')
+        result = collection.list(caller, Filter.new(condition_tree: condition), Projection.new(['id']))
+
+        expect(result).to be_empty
+      end
+
+      it 'aggregates grouped by a field of the through relation' do
+        aggregation = Aggregation.new(operation: 'Count', field: nil, groups: [{ field: 'order:reference' }])
+        result = Utils::QueryAggregate.new(collection, aggregation).get
+
+        expect(result).to contain_exactly('value' => 1, 'group' => { 'order:reference' => 'ORD-1' })
+      end
+    end
+
+    describe 'a has_one :through with a has_one hop (supplier -> account_history) stays on preload' do
+      # the intermediate `account` hop is a has_one and can multiply rows, so it must not be JOINed.
+      let(:collection) { Collection.new(datasource, Supplier) }
+      let(:projection) { Projection.new(['id', 'account_history:id']) }
+
+      it 'is preloaded, not JOINed' do
+        query = Utils::Query.new(collection, projection, filter)
+        query.build
+
+        expect(query.query.left_outer_joins_values).to be_empty
+        expect(query.query.includes_values.to_s).to include('account_history')
+      end
+    end
+
     describe 'a to-many relation (car -> checks) is left on preload' do
       let(:collection) { Collection.new(datasource, Car) }
       let(:projection) { Projection.new(['id', 'reference', 'checks:garage_name']) }

--- a/packages/forest_admin_datasource_active_record/spec/lib/forest_admin_datasource_active_record/utils/join_to_one_optimization_spec.rb
+++ b/packages/forest_admin_datasource_active_record/spec/lib/forest_admin_datasource_active_record/utils/join_to_one_optimization_spec.rb
@@ -148,6 +148,20 @@ module ForestAdminDatasourceActiveRecord
 
         expect(result).to contain_exactly('value' => 1, 'group' => { 'order:reference' => 'ORD-1' })
       end
+
+      it 'does not JOIN the intermediate table twice when it is also projected on its own' do
+        projection = Projection.new(['id', 'order:reference', 'account_history:id'])
+        query = Utils::Query.new(collection, projection, filter)
+        query.build
+
+        # the through folds `account_histories` in for `order`; the standalone `account_history`
+        # must fall back to preload rather than JOIN the same table again
+        expect(query.query.to_sql.scan(/JOIN "account_histories"/i).size).to eq(1)
+
+        result = collection.list(caller, filter, projection)
+        expect(result.first['order']['reference']).to eq('ORD-1')
+        expect(result.first['account_history']['id']).to eq(Account.first.account_history_id)
+      end
     end
 
     describe 'a has_one :through with a has_one hop (supplier -> account_history) stays on preload' do
@@ -161,6 +175,16 @@ module ForestAdminDatasourceActiveRecord
 
         expect(query.query.left_outer_joins_values).to be_empty
         expect(query.query.includes_values.to_s).to include('account_history')
+      end
+
+      it 'does not select the intermediate FK against the root table (it lives on the child)' do
+        query = Utils::Query.new(collection, projection, filter)
+        query.build
+        sql = query.query.to_sql
+
+        expect(sql).not_to match(/suppliers"\."supplier_id"/)
+        expect(sql).not_to match(/suppliers"\."account_id"/)
+        expect { collection.list(caller, filter, projection) }.not_to raise_error
       end
     end
 

--- a/packages/forest_admin_datasource_active_record/spec/lib/forest_admin_datasource_active_record/utils/join_to_one_optimization_spec.rb
+++ b/packages/forest_admin_datasource_active_record/spec/lib/forest_admin_datasource_active_record/utils/join_to_one_optimization_spec.rb
@@ -106,7 +106,6 @@ module ForestAdminDatasourceActiveRecord
     end
 
     describe 'a has_one :through of belongs_to hops (account -> account_history -> order)' do
-      # every hop is a belongs_to, so the chained JOIN stays 1:1 and cannot multiply the parent.
       let(:collection) { Collection.new(datasource, Account) }
       let(:projection) { Projection.new(['id', 'order:reference']) }
 
@@ -122,7 +121,7 @@ module ForestAdminDatasourceActiveRecord
         end
 
         expect(queries.size).to eq(1)
-        expect(queries.first.scan(/LEFT OUTER JOIN/i).size).to eq(2) # account_histories + orders
+        expect(queries.first.scan(/LEFT OUTER JOIN/i).size).to eq(2)
       end
 
       it 'filters on a field of the through relation' do
@@ -154,8 +153,6 @@ module ForestAdminDatasourceActiveRecord
         query = Utils::Query.new(collection, projection, filter)
         query.build
 
-        # the through folds `account_histories` in for `order`; the standalone `account_history`
-        # must fall back to preload rather than JOIN the same table again
         expect(query.query.to_sql.scan(/JOIN "account_histories"/i).size).to eq(1)
 
         result = collection.list(caller, filter, projection)
@@ -165,7 +162,6 @@ module ForestAdminDatasourceActiveRecord
     end
 
     describe 'a has_one :through with a has_one hop (supplier -> account_history) stays on preload' do
-      # the intermediate `account` hop is a has_one and can multiply rows, so it must not be JOINed.
       let(:collection) { Collection.new(datasource, Supplier) }
       let(:projection) { Projection.new(['id', 'account_history:id']) }
 


### PR DESCRIPTION
# Expose `has_one :through` as a to-one (HasOne) relation

> **Base branch:** `perf/ar-datasource-join-to-one-same-db` — this builds on that
> branch's JOIN-to-one infrastructure. Merge/rebase order: perf branch first.

## Problem

The ActiveRecord datasource mapped a `has_one :through` association to a
`ManyToMany` schema, so Forest rendered it as a **to-many** list
(`BelongsToMany`). A `has_one :through` is single-valued, so it should be a
**to-one** relation — the way `forest_liana` (v1) exposed it. As a result the
relation could not be shown as a clickable record in a summary/detail view, and
it was resolved with extra per-hop preload queries.

## Change

1. **Schema** — a `has_one :through` now emits `OneToOneSchema` → `HasOne`
   (to-one). ActiveRecord resolves the join natively via the association name,
   so the read path was already correct; only the emitted schema shape changes.
   Polymorphic `has_one :through` is left as `ManyToMany` (unchanged).

2. **Performance** — when every hop of the through chain is a `belongs_to`
   (no scope/default_scope, same database), the relation is folded into the
   existing to-one `LEFT OUTER JOIN` instead of two per-hop preload queries.
   A `has_one` hop (which can multiply rows) stays on preload.

3. **Correctness** — when a through relation falls back to preload (e.g. it is
   also used by a filter), the intermediate foreign key is now selected so
   ActiveRecord can load it (previously raised `MissingAttributeError`).

## Change

A `has_one :through` relation is now a **to-one** (`HasOne`) instead of a
**to-many** (`BelongsToMany`). Agents that reference such a relation as a
collection — in segments, smart views, or permissions — must be updated to
treat it as a to-one. Non-`through` relations are unaffected.

## Tests

- `has_one :through` emits `OneToOneSchema` (collection spec)
- belongs_to-chain through → single JOIN; `has_one`-hop through → preload
- **filter through** the relation returns the right records (and the negative case)
- **aggregate** grouped by a through-relation field
- Full package suite green; `forest_admin_agent`, `forest_admin_datasource_customizer`,
  `forest_admin_datasource_toolkit` suites verified green (schema change has no
  downstream fallout). Rubocop clean.

## Out of scope

Polymorphic-relation support for renamed/demodulized types is handled separately
in `feat/support-polymorphic-qonto`; this PR intentionally contains none of it.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Expose `has_one :through` as a to-one relation in the ActiveRecord datasource
> - Non-polymorphic `has_one :through` associations are now exposed as `OneToOneSchema` instead of `ManyToManySchema` in [collection.rb](https://github.com/ForestAdmin/agent-ruby/pull/325/files#diff-394937cf0ee68635c26a0af527b70b25e67ac962f1137a31cb25f490e36c686f). Polymorphic cases continue to use `ManyToManySchema`.
> - The query builder in [query.rb](https://github.com/ForestAdmin/agent-ruby/pull/325/files#diff-dea919d07e1dd6d6bd15b32211d4b2d3edadbbf1eabe4eb7ea1721e32f5a29fa) now folds a safe `has_one :through` chain (where both hops are `belongs_to` with no scopes, same DB) into LEFT OUTER JOINs instead of per-hop preloads.
> - `build_select` adds `origin_key_target` and the intermediate foreign key to the SELECT list for `has_one :through` root queries.
> - Test fixtures add a `has_one :order through: :account_history` chain to cover the new behavior.
> - Behavioral Change: `has_one :through` relations that were previously `ManyToManySchema` become `OneToOneSchema`; any client code relying on the old schema type will need updating.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #325 opened
>
> - Removed and reworded explanatory inline comments across `ForestAdminDatasourceActiveRecord::Collection`, `ForestAdminDatasourceActiveRecord::Utils::Query`, and `join_to_one_optimization_spec` [c2a90de]
> - Added RSpec test case verifying that JOIN optimization does not duplicate intermediate table joins when filtering on through relationships [bf1bb7e]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a32e27d.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->