### PR TITLE
chore(security): patch 12 Dependabot alerts

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -3825,9 +3825,9 @@ tagged-tag@^1.0.0:
   integrity sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==
 
 tar@^7.4.3, tar@^7.5.1, tar@^7.5.13, tar@^7.5.4:
-  version "7.5.15"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-7.5.15.tgz#afe6d1316cddf614a566e3813e42fe01aed46fee"
-  integrity sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==
+  version "7.5.19"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-7.5.19.tgz#d8915e6b717f8036a79d839ca9448198b002b0a7"
+  integrity sha512-4LeEWl96twnS2Q7Bz4MGqgazLqO+hJN63GZxXoIqh1T3VweYD997gbU1ItNsQafqqXTXd5WFyFdReLtwvRBNiw==
   dependencies:
     "@isaacs/fs-minipass" "^4.0.0"
     chownr "^3.0.0"
@@ -4027,14 +4027,14 @@ uglify-js@^3.1.4:
   integrity sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==
 
 undici@^6.23.0, undici@^6.25.0:
-  version "6.25.0"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-6.25.0.tgz#8c4efb8c998dc187fc1cfb5dde1ef19a211849fb"
-  integrity sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==
+  version "6.27.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-6.27.0.tgz#41f9e48f7c5a40d27376caaead8c9a9fc7bca9c4"
+  integrity sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==
 
 undici@^7.0.0:
-  version "7.25.0"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-7.25.0.tgz#7d72fc429a0421769ca2966fd07cac875c85b781"
-  integrity sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==
+  version "7.28.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-7.28.0.tgz#97d64564198b285bc281f0e8e29597e3d11fe7ec"
+  integrity sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==
 
 unicode-emoji-modifier-base@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
> 👋 First-level support: see [Handling automated security PRs](https://forest.slite.com/app/docs/rmjdwFgmV2RzUp) for how to triage and merge this PR.

## Summary

12 fixed, 0 ignored, 4 deferred, 0 resolutions added, 0 resolutions removed. | label: :lock: security applied

All fixes are lockfile-only re-resolutions in `yarn.lock`: the patched versions already satisfy the semver ranges declared by the parent packages (semantic-release tooling), so no `package.json` change was needed.

## Fixed

| Done | Alert | Package | Ecosystem | From → To | Severity | What was bumped |
|------|-------|---------|-----------|-----------|----------|-----------------|
| - [ ] | [#73](https://github.com/ForestAdmin/agent-ruby/security/dependabot/73) | tar | npm | 7.5.15 → 7.5.19 | medium | lockfile re-resolution (transitive via `semantic-release > @semantic-release/npm > npm`) |
| - [ ] | [#74](https://github.com/ForestAdmin/agent-ruby/security/dependabot/74) | undici | npm | 7.25.0 → 7.28.0 | high | lockfile re-resolution (transitive via `semantic-release > @semantic-release/github`) |
| - [ ] | [#75](https://github.com/ForestAdmin/agent-ruby/security/dependabot/75) | undici | npm | 7.25.0 → 7.28.0 | medium | lockfile re-resolution (same chain as [#74](https://github.com/ForestAdmin/agent-ruby/security/dependabot/74)) |
| - [ ] | [#76](https://github.com/ForestAdmin/agent-ruby/security/dependabot/76) | undici | npm | 7.25.0 → 7.28.0 | high | lockfile re-resolution (same chain as [#74](https://github.com/ForestAdmin/agent-ruby/security/dependabot/74)) |
| - [ ] | [#77](https://github.com/ForestAdmin/agent-ruby/security/dependabot/77) | undici | npm | 7.25.0 → 7.28.0 | low | lockfile re-resolution (same chain as [#74](https://github.com/ForestAdmin/agent-ruby/security/dependabot/74)) |
| - [ ] | [#78](https://github.com/ForestAdmin/agent-ruby/security/dependabot/78) | undici | npm | 7.25.0 → 7.28.0 | high | lockfile re-resolution (same chain as [#74](https://github.com/ForestAdmin/agent-ruby/security/dependabot/74)) |
| - [ ] | [#79](https://github.com/ForestAdmin/agent-ruby/security/dependabot/79) | undici | npm | 7.25.0 → 7.28.0 | medium | lockfile re-resolution (same chain as [#74](https://github.com/ForestAdmin/agent-ruby/security/dependabot/74)) |
| - [ ] | [#80](https://github.com/ForestAdmin/agent-ruby/security/dependabot/80) | undici | npm | 7.25.0 → 7.28.0 | low | lockfile re-resolution (same chain as [#74](https://github.com/ForestAdmin/agent-ruby/security/dependabot/74)) |
| - [ ] | [#81](https://github.com/ForestAdmin/agent-ruby/security/dependabot/81) | undici | npm | 6.25.0 → 6.27.0 | high | lockfile re-resolution (transitive via `semantic-release > @semantic-release/npm > npm > node-gyp` and `@actions/http-client`) |
| - [ ] | [#82](https://github.com/ForestAdmin/agent-ruby/security/dependabot/82) | undici | npm | 6.25.0 → 6.27.0 | medium | lockfile re-resolution (same chain as [#81](https://github.com/ForestAdmin/agent-ruby/security/dependabot/81)) |
| - [ ] | [#83](https://github.com/ForestAdmin/agent-ruby/security/dependabot/83) | undici | npm | 6.25.0 → 6.27.0 | low | lockfile re-resolution (same chain as [#81](https://github.com/ForestAdmin/agent-ruby/security/dependabot/81)) |
| - [ ] | [#84](https://github.com/ForestAdmin/agent-ruby/security/dependabot/84) | undici | npm | 6.25.0 → 6.27.0 | low | lockfile re-resolution (same chain as [#81](https://github.com/ForestAdmin/agent-ruby/security/dependabot/81)) |

## Ignored

None.

## Deferred

Skipped by the 7-day age gate — will be handled by the next run:

- [#85](https://github.com/ForestAdmin/agent-ruby/security/dependabot/85) — @sigstore/core ≤ 3.2.0 (medium, opened 2026-06-30)
- [#86](https://github.com/ForestAdmin/agent-ruby/security/dependabot/86) — @sigstore/verify = 3.1.0 (medium, opened 2026-07-02)
- [#87](https://github.com/ForestAdmin/agent-ruby/security/dependabot/87) — sigstore ≤ 4.1.0 (high, opened 2026-07-02)
- [#88](https://github.com/ForestAdmin/agent-ruby/security/dependabot/88) — js-yaml ≥ 4.0.0, ≤ 4.1.1 (medium, opened 2026-07-02)

## Resolutions added

None — every patched version satisfies the semver range already declared by its parent, so plain lockfile re-resolution was sufficient.

## Resolutions removed

None — the root `package.json` `resolutions` block is empty; no other `package.json` exists in the repo.

## Risks

- **undici 6.25.0 → 6.27.0 / 7.25.0 → 7.28.0**: minor/patch releases within the ranges declared by `@semantic-release/github`, `@actions/http-client`, `node-gyp`. undici is only used by release tooling in CI; no source code in this repo imports it. No breaking changes in these ranges per upstream changelog.
- **tar 7.5.15 → 7.5.19**: patch releases (parser hardening fixes). Only consumed by the bundled `npm`/`pacote`/`node-gyp` chain inside release tooling. No behavior change beyond the patched vulnerabilities.
- All three packages are `devDependencies`-scope transitives of semantic-release; the shipped Ruby gems are unaffected.

## Manual testing

Covered by CI.

## Validation

✅ CI green
