### PR TITLE
fix(forest_admin_agent): build PolymorphicManyToOne linkage id from foreign key (#332)

### DIFF
--- a/packages/forest_admin_agent/lib/forest_admin_agent/serializer/forest_serializer.rb
+++ b/packages/forest_admin_agent/lib/forest_admin_agent/serializer/forest_serializer.rb
@@ -112,7 +112,9 @@ module ForestAdminAgent
         foreign_type = @object[field.foreign_key_type_field]
         return nil if foreign_key.nil? || foreign_type.nil?
 
-        primary_key = (field.foreign_key_targets || {})[foreign_type] || 'id'
+        # foreign_key_targets is keyed by formatted collection names (Admin::User => Admin__User),
+        # but foreign_type is the raw AR type column value, so format it before the lookup.
+        primary_key = (field.foreign_key_targets || {})[foreign_type.gsub('::', '__')] || 'id'
         (object.is_a?(Hash) ? object : {}).merge(primary_key => foreign_key)
       end
 

--- a/packages/forest_admin_agent/lib/forest_admin_agent/serializer/forest_serializer.rb
+++ b/packages/forest_admin_agent/lib/forest_admin_agent/serializer/forest_serializer.rb
@@ -99,6 +99,10 @@ module ForestAdminAgent
       # the frontend). No extra query is issued.
       def has_one_relationship(attribute_name, attr_data)
         object = super
+        # nil means the relation wasn't projected/loaded at all (e.g. update/store responses) — keep
+        # the previous behavior. Only the phantom object returned by list projections needs rebuilding.
+        return object if object.nil?
+
         field = ForestAdminAgent::Facades::Container.datasource
                                                     .get_collection(@options[:class_name].gsub('::', '__'))
                                                     .schema[:fields][attribute_name.to_s]

--- a/packages/forest_admin_agent/lib/forest_admin_agent/serializer/forest_serializer.rb
+++ b/packages/forest_admin_agent/lib/forest_admin_agent/serializer/forest_serializer.rb
@@ -93,6 +93,25 @@ module ForestAdminAgent
         @to_one_associations[name] = format_field(name, options)
       end
 
+      # For a PolymorphicManyToOne the related record can't be SQL-joined, so the datasource returns
+      # a phantom object without a primary key. Rebuild the id from the foreign key already loaded on
+      # the owner record instead of reading it off that phantom (which yields an empty id and crashes
+      # the frontend). No extra query is issued.
+      def has_one_relationship(attribute_name, attr_data)
+        object = super
+        field = ForestAdminAgent::Facades::Container.datasource
+                                                    .get_collection(@options[:class_name].gsub('::', '__'))
+                                                    .schema[:fields][attribute_name.to_s]
+        return object unless field&.type == 'PolymorphicManyToOne'
+
+        foreign_key = @object[field.foreign_key]
+        foreign_type = @object[field.foreign_key_type_field]
+        return nil if foreign_key.nil? || foreign_type.nil?
+
+        primary_key = (field.foreign_key_targets || {})[foreign_type] || 'id'
+        (object.is_a?(Hash) ? object : {}).merge(primary_key => foreign_key)
+      end
+
       def has_one_relationships
         return {} if @to_one_associations.nil?
         data = {}

--- a/packages/forest_admin_agent/lib/forest_admin_agent/serializer/forest_serializer.rb
+++ b/packages/forest_admin_agent/lib/forest_admin_agent/serializer/forest_serializer.rb
@@ -93,15 +93,11 @@ module ForestAdminAgent
         @to_one_associations[name] = format_field(name, options)
       end
 
-      # For a PolymorphicManyToOne the related record can't be SQL-joined, so the datasource returns
-      # a phantom object without a primary key. Rebuild the id from the foreign key already loaded on
-      # the owner record instead of reading it off that phantom (which yields an empty id and crashes
-      # the frontend). No extra query is issued.
+      # A PolymorphicManyToOne can't be SQL-joined, so list projections return a phantom object with no
+      # primary key. Rebuild the id from the foreign key on the owner record.
       def has_one_relationship(attribute_name, attr_data)
         object = super
-        # nil means the relation wasn't projected/loaded at all (e.g. update/store responses) — keep
-        # the previous behavior. Only the phantom object returned by list projections needs rebuilding.
-        return object if object.nil?
+        return object if object.nil? # relation not projected (e.g. update/store responses)
 
         field = ForestAdminAgent::Facades::Container.datasource
                                                     .get_collection(@options[:class_name].gsub('::', '__'))

--- a/packages/forest_admin_agent/spec/lib/forest_admin_agent/serializer/forest_serializer_spec.rb
+++ b/packages/forest_admin_agent/spec/lib/forest_admin_agent/serializer/forest_serializer_spec.rb
@@ -77,6 +77,38 @@ module ForestAdminAgent
             expect(relationship['data']['id']).to eq('10')
           end
 
+          it 'builds the linkage id from the foreign key when the related record is a phantom (issue #332)' do
+            # The AR datasource skips polymorphic relations while building the SELECT, so the related
+            # object comes back without a primary key. The id must still be built from the owner FK.
+            record = {
+              'id' => 1,
+              'title' => 'Registration Certificate',
+              'documentable_id' => 10,
+              'documentable_type' => 'Car',
+              'documentable' => { '*' => nil }
+            }
+
+            result = JSONAPI::Serializer.serialize(record, class_name: 'Document', serializer: described_class)
+
+            relationship = result['data']['relationships']['documentable']
+            expect(relationship['data']['type']).to eq('Car')
+            expect(relationship['data']['id']).to eq('10')
+          end
+
+          it 'omits the data key for an unlinked polymorphic relation (issue #332)' do
+            record = {
+              'id' => 3,
+              'title' => 'Orphan',
+              'documentable_id' => nil,
+              'documentable_type' => nil,
+              'documentable' => { '*' => nil }
+            }
+
+            result = JSONAPI::Serializer.serialize(record, class_name: 'Document', serializer: described_class)
+
+            expect(result['data']['relationships']['documentable']).not_to have_key('data')
+          end
+
           it 'serializes a polymorphic belongs_to relation pointing to User' do
             record = {
               'id' => 2,

--- a/packages/forest_admin_agent/spec/lib/forest_admin_agent/serializer/forest_serializer_spec.rb
+++ b/packages/forest_admin_agent/spec/lib/forest_admin_agent/serializer/forest_serializer_spec.rb
@@ -34,6 +34,17 @@ module ForestAdminAgent
               }
             )
 
+            # Namespaced model (Admin::User => Admin__User) with a custom primary key
+            admin_user_collection = build_collection(
+              name: 'Admin__User',
+              schema: {
+                fields: {
+                  'reference' => ColumnSchema.new(column_type: 'String', is_primary_key: true, filter_operators: [Operators::EQUAL]),
+                  'name' => ColumnSchema.new(column_type: 'String')
+                }
+              }
+            )
+
             document_collection = build_collection(
               name: 'Document',
               schema: {
@@ -45,8 +56,8 @@ module ForestAdminAgent
                   'documentable' => PolymorphicManyToOneSchema.new(
                     foreign_key: 'documentable_id',
                     foreign_key_type_field: 'documentable_type',
-                    foreign_collections: %w[Car User],
-                    foreign_key_targets: { 'Car' => 'id', 'User' => 'id' }
+                    foreign_collections: %w[Car User Admin__User],
+                    foreign_key_targets: { 'Car' => 'id', 'User' => 'id', 'Admin__User' => 'reference' }
                   )
                 }
               }
@@ -55,6 +66,7 @@ module ForestAdminAgent
             allow(ForestAdminAgent::Builder::AgentFactory.instance).to receive(:send_schema).and_return(nil)
             datasource.add_collection(car_collection)
             datasource.add_collection(user_collection)
+            datasource.add_collection(admin_user_collection)
             datasource.add_collection(document_collection)
             ForestAdminAgent::Builder::AgentFactory.instance.add_datasource(datasource)
             ForestAdminAgent::Builder::AgentFactory.instance.build
@@ -93,6 +105,24 @@ module ForestAdminAgent
             relationship = result['data']['relationships']['documentable']
             expect(relationship['data']['type']).to eq('Car')
             expect(relationship['data']['id']).to eq('10')
+          end
+
+          it 'builds the linkage id for a namespaced target with a custom primary key (issue #332)' do
+            # foreign_key_targets is keyed by the formatted name (Admin__User), but the type column
+            # stores the raw class name (Admin::User); the lookup must reconcile the two.
+            record = {
+              'id' => 4,
+              'title' => 'Audit Log',
+              'documentable_id' => 'ref-42',
+              'documentable_type' => 'Admin::User',
+              'documentable' => { '*' => nil }
+            }
+
+            result = JSONAPI::Serializer.serialize(record, class_name: 'Document', serializer: described_class)
+
+            relationship = result['data']['relationships']['documentable']
+            expect(relationship['data']['type']).to eq('Admin__User')
+            expect(relationship['data']['id']).to eq('ref-42')
           end
 
           it 'omits the data key for an unlinked polymorphic relation (issue #332)' do

--- a/packages/forest_admin_agent/spec/lib/forest_admin_agent/serializer/forest_serializer_spec.rb
+++ b/packages/forest_admin_agent/spec/lib/forest_admin_agent/serializer/forest_serializer_spec.rb
@@ -107,6 +107,24 @@ module ForestAdminAgent
             expect(relationship['data']['id']).to eq('10')
           end
 
+          it 'builds the included document id and self-link from the foreign key (issue #332)' do
+            record = {
+              'id' => 1,
+              'title' => 'Registration Certificate',
+              'documentable_id' => 10,
+              'documentable_type' => 'Car',
+              'documentable' => { '*' => nil }
+            }
+
+            result = JSONAPI::Serializer.serialize(
+              record, class_name: 'Document', serializer: described_class, include: 'documentable'
+            )
+
+            included = result['included'].find { |r| r['type'] == 'Car' }
+            expect(included['id']).to eq('10')
+            expect(included['links']['self']).to eq('/forest/Car/10')
+          end
+
           it 'builds the linkage id for a namespaced target with a custom primary key (issue #332)' do
             # foreign_key_targets is keyed by the formatted name (Admin__User), but the type column
             # stores the raw class name (Admin::User); the lookup must reconcile the two.


### PR DESCRIPTION
Fixes #332

## Problem
Opening the list view of a collection with a polymorphic `belongs_to` crashes the frontend:

```
UnknownClientRecordAgentError: Expected id to be a string or number, received null
```

The backend returns 200 OK but the payload is malformed: the relationship linkage `id` is an empty string.

## Root cause
A `PolymorphicManyToOne` can't be SQL-joined, so `query.rb:208` skips it while building the SELECT. The record therefore comes back with a **phantom** related object that has no primary key (`{ "*" => nil }`). `ForestSerializer` then reads the PK off that phantom object, producing an empty id in the JSON:API linkage.

The existing serializer specs didn't catch this because they hand-fed a fully-populated related hash, which the real datasource never produces.

## Fix
Override `has_one_relationship` in `ForestSerializer`. For a `PolymorphicManyToOne` it rebuilds the linkage id from the foreign key (`*_id` + `*_type`) already loaded on the owner record — no extra query — and returns `nil` (omitting the `data` key) when the relation is unlinked. Both the linkage and the compound `included` document go through this method, so a single override covers both.

This is the workaround reported in #332, moved into the gem.

## Tests
Added two specs reproducing the real datasource output (phantom related object) — both fail without the fix:
- builds the linkage id from the foreign key when the related record is a phantom
- omits the `data` key for an unlinked polymorphic relation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `PolymorphicManyToOne` linkage id serialization in `ForestSerializer`
> When a polymorphic many-to-one related record is a phantom (no primary key), the serializer now rebuilds the linkage `id` from the owner's foreign key fields instead of returning an empty or broken relationship.
>
> - Overrides `has_one_relationship` in [`ForestSerializer`](https://github.com/ForestAdmin/agent-ruby/pull/333/files#diff-b79f280368f0a5ff9ed78fbf1be38a2a2b042e30672ddc1244b31713fae3ffd6) to post-process `PolymorphicManyToOne` relationships, computing `id` from the foreign key value and resolving the type using `foreign_key_targets`.
> - Namespaced type values (e.g. `Admin::User`) are formatted to `Admin__User` to match collection naming conventions, and custom primary keys are respected.
> - Relationships with a nil foreign key or nil type omit the `data` member entirely.
> - Risk: any consumer relying on the previous (broken) phantom linkage behavior will see different output.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #333 opened
>
> - Added test verifying PolymorphicManyToOne relationship serialization [618ae03]
> - Clarified comments for PolymorphicManyToOne relationship handling [618ae03]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 870bad8.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->