### PR TITLE
chore(security): patch 4 Dependabot alerts

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -667,17 +667,17 @@
   dependencies:
     "@sigstore/protobuf-specs" "^0.5.0"
 
-"@sigstore/core@^3.1.0", "@sigstore/core@^3.2.0":
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/@sigstore/core/-/core-3.2.0.tgz#beaea6ea4d7d4caadadb7453168e35636b78830e"
-  integrity sha512-kxHrDQ9YgfrWUSXU0cjsQGv8JykOFZQ9ErNKbFPWzk3Hgpwu8x2hHrQ9IdA8yl+j9RTLTC3sAF3Tdq1IQCP4oA==
+"@sigstore/core@^3.2.0", "@sigstore/core@^3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@sigstore/core/-/core-3.2.1.tgz#4efd4ab0f59e768b6daf65612024ba925787de72"
+  integrity sha512-qRsxPnCrbC/puegGxKuynfnxgLiHqWStrSjxkoB4YKqq3Z3s4cyZyj42ZdWFAEblNP65C+rBH8EuREHIXoi83g==
 
 "@sigstore/protobuf-specs@^0.5.0":
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/@sigstore/protobuf-specs/-/protobuf-specs-0.5.1.tgz#5401e444b6ab0db7d1969c91c43e7954927a52fe"
   integrity sha512-/ScWUhhoFasJsSRGTVBwId1loQjjnjAfE4djL6ZhrXRpNCmPTnUKF5Jokd58ILseOMjzET3UrMOtJPS9sYeI0g==
 
-"@sigstore/sign@^4.1.0":
+"@sigstore/sign@^4.1.1":
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/@sigstore/sign/-/sign-4.1.1.tgz#34765fe4a190d693340c0771a3d150a397bcfc55"
   integrity sha512-Hf4xglukg0XXQ2RiD5vSoLjdPe8OBUPA8XeVjUObheuDcWdYWrnH/BNmxZCzkAy68MzmNCxXLeurJvs6hcP2OQ==
@@ -689,7 +689,7 @@
     make-fetch-happen "^15.0.4"
     proc-log "^6.1.0"
 
-"@sigstore/tuf@^4.0.1", "@sigstore/tuf@^4.0.2":
+"@sigstore/tuf@^4.0.2":
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/@sigstore/tuf/-/tuf-4.0.2.tgz#7d2fa2abcd5afa5baf752671d14a1c6ed0ed3196"
   integrity sha512-TCAzTy0xzdP79EnxSjq9KQ3eaR7+FmudLC6eRKknVKZbV7ZNlGLClAAQb/HMNJ5n2OBNk2GT1tEmU0xuPr+SLQ==
@@ -697,13 +697,13 @@
     "@sigstore/protobuf-specs" "^0.5.0"
     tuf-js "^4.1.0"
 
-"@sigstore/verify@^3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@sigstore/verify/-/verify-3.1.0.tgz#4046d4186421db779501fe87fa5acaa5d4d21b08"
-  integrity sha512-mNe0Iigql08YupSOGv197YdHpPPr+EzDZmfCgMc7RPNaZTw5aLN01nBl6CHJOh3BGtnMIj83EeN4butBchc8Ag==
+"@sigstore/verify@^3.1.1":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@sigstore/verify/-/verify-3.1.1.tgz#13c1c1cff28fe81f662de29d85ba5ae048fcbd8d"
+  integrity sha512-qv7+G3J2cc6wwFj3yKvXOamzqhMwSk1ogPGmhpS8iXllcPrJaIIBA+4HbttlHVu1pqWTdmaCH/WE7UOC51kdoA==
   dependencies:
     "@sigstore/bundle" "^4.0.0"
-    "@sigstore/core" "^3.1.0"
+    "@sigstore/core" "^3.2.1"
     "@sigstore/protobuf-specs" "^0.5.0"
 
 "@simple-libs/stream-utils@^1.2.0":
@@ -2010,9 +2010,9 @@ js-tokens@^4.0.0:
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
 js-yaml@^4.1.0:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.1.tgz#854c292467705b699476e1a2decc0c8a3458806b"
-  integrity sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.3.0.tgz#d1900572a7f7cf0b5f540c83673e60bad3436592"
+  integrity sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==
   dependencies:
     argparse "^2.0.1"
 
@@ -3574,16 +3574,16 @@ signale@^1.2.1:
     pkg-conf "^2.1.0"
 
 sigstore@^4.0.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/sigstore/-/sigstore-4.1.0.tgz#d34b92a544a05e003a2430209d26d8dfafd805a0"
-  integrity sha512-/fUgUhYghuLzVT/gaJoeVehLCgZiUxPCPMcyVNY0lIf/cTCz58K/WTI7PefDarXxp9nUKpEwg1yyz3eSBMTtgA==
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/sigstore/-/sigstore-4.1.1.tgz#2959993dbf978c759a5d23d854cbd3729b6dcd97"
+  integrity sha512-endqECJkfhozrXMK5ngu/UAA0xVcVEFdnHJCElGaExypjW+HK5i6zu3NteLoaX/iFbRUbC3+DjttQs0GARr+5w==
   dependencies:
     "@sigstore/bundle" "^4.0.0"
-    "@sigstore/core" "^3.1.0"
+    "@sigstore/core" "^3.2.1"
     "@sigstore/protobuf-specs" "^0.5.0"
-    "@sigstore/sign" "^4.1.0"
-    "@sigstore/tuf" "^4.0.1"
-    "@sigstore/verify" "^3.1.0"
+    "@sigstore/sign" "^4.1.1"
+    "@sigstore/tuf" "^4.0.2"
+    "@sigstore/verify" "^3.1.1"
 
 skin-tone@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
> 👋 First-level support: see [Handling automated security PRs](https://forest.slite.com/app/docs/rmjdwFgmV2RzUp) for how to triage and merge this PR.

## Summary

4 fixed, 0 ignored, 2 deferred, 0 resolutions added, 0 resolutions removed. | label: :lock: security applied

All fixes are lockfile-only refreshes: every patched version already satisfies the semver range declared by the parent packages, so no `package.json` change and no new `resolutions` entry was needed.

## Fixed

| Done | Alert | Package | Ecosystem | From → To | Severity | What was bumped |
|---|---|---|---|---|---|---|
| - [ ] | [#88](https://github.com/ForestAdmin/agent-ruby/security/dependabot/88) | js-yaml | npm | 4.1.1 → 4.3.0 | medium | transitive (`semantic-release > cosmiconfig`, `@commitlint/cli > @commitlint/load > cosmiconfig`) — in-range lockfile refresh of `js-yaml@^4.1.0` |
| - [ ] | [#87](https://github.com/ForestAdmin/agent-ruby/security/dependabot/87) | sigstore | npm | 4.1.0 → 4.1.1 | high | transitive (`semantic-release > @semantic-release/npm > npm > libnpmpublish`) — in-range lockfile refresh of `sigstore@^4.0.0` |
| - [ ] | [#86](https://github.com/ForestAdmin/agent-ruby/security/dependabot/86) | @sigstore/verify | npm | 3.1.0 → 3.1.1 | medium | transitive (via `sigstore`) — in-range lockfile refresh of `@sigstore/verify@^3.1.0` → `^3.1.1` |
| - [ ] | [#85](https://github.com/ForestAdmin/agent-ruby/security/dependabot/85) | @sigstore/core | npm | 3.2.0 → 3.2.1 | medium | transitive (via `sigstore` / `@sigstore/verify` / `@sigstore/sign`) — in-range lockfile refresh of `@sigstore/core@^3.2.0` → `^3.2.1` |

Note: the js-yaml bump to 4.3.0 also incidentally covers deferred alert [#90](https://github.com/ForestAdmin/agent-ruby/security/dependabot/90) (patched in 4.3.0) — GitHub should auto-close it on merge.

## Ignored

None.

## Deferred

Opened less than 7 days ago — left for the next run:

| Alert | Package | Severity | Opened |
|---|---|---|---|
| [#90](https://github.com/ForestAdmin/agent-ruby/security/dependabot/90) | js-yaml | high | 2026-07-21 |
| [#89](https://github.com/ForestAdmin/agent-ruby/security/dependabot/89) | brace-expansion | high | 2026-07-21 |

## Resolutions added

None.

## Resolutions removed

None. The existing root entry `"semantic-release-slack-bot/**/micromatch": "^4.0.8"` was audited: it is neither stale (micromatch is still in the tree) nor redundant (removing it makes `semantic-release-slack-bot`'s exact pin `micromatch@4.0.2` win again, which is < 4.0.8) — so it was kept.

## Risks

All four packages are devDependencies of the release tooling (`semantic-release`, `@commitlint/cli`) — nothing here ships with the Ruby gem.

- **js-yaml 4.1.1 → 4.3.0** (two minors): 4.2.0 adds bundled TypeScript types and fixes the quadratic merge-key DoS; 4.3.0 hardens merge-key chain handling. No breaking API changes in the 4.x line; consumed only by `cosmiconfig` for config parsing.
- **sigstore 4.1.0 → 4.1.1 / @sigstore/verify 3.1.0 → 3.1.1 / @sigstore/core 3.2.0 → 3.2.1** (patches): fix verification-constraint enforcement (certificateOIDs, DSSE payloadType, data-authenticity checks). Behavior change is strictly "verification gets stricter"; used only by `npm publish` provenance inside semantic-release.

No behavior change expected beyond the patched vulnerabilities.

## Manual testing

Covered by CI.

## Validation

✅ CI green

Note: the first CI attempt failed on one flaky timing test unrelated to this diff (`forest_admin_datasource_toolkit` Ruby 4.0, `times_spec.rb:49` — 1-second boundary race in `BeforeXHoursAgo`). Failed jobs were re-run once per policy and passed.
