### PR TITLE
feat: handle multiple projection on relation fields

### DIFF
--- a/packages/forest_admin_agent/lib/forest_admin_agent/routes/capabilities/collections.rb
+++ b/packages/forest_admin_agent/lib/forest_admin_agent/routes/capabilities/collections.rb
@@ -63,7 +63,8 @@ module ForestAdminAgent
               collections: result,
               nativeQueryConnections: connections,
               agentCapabilities: {
-                canUseProjectionOnGetOne: true
+                canUseProjectionOnGetOne: true,
+                canUseMultipleFieldsProjectionOnRelation: true
               }
             },
             status: 200

--- a/packages/forest_admin_agent/lib/forest_admin_agent/utils/query_string_parser.rb
+++ b/packages/forest_admin_agent/lib/forest_admin_agent/utils/query_string_parser.rb
@@ -63,7 +63,7 @@ module ForestAdminAgent
       end
 
       def self.build_projection_fields(collection, requested_field_names, args)
-        requested_field_names.map do |field_name|
+        requested_field_names.flat_map do |field_name|
           field = get_field(collection, field_name)
 
           case field.type
@@ -73,7 +73,12 @@ module ForestAdminAgent
             "#{field_name}:*"
           else
             relation_fields = args.dig(:params, :fields, field_name)
-            "#{field_name}:#{relation_fields}"
+
+            if relation_fields.nil? || relation_fields.empty?
+              "#{field_name}:#{relation_fields}"
+            else
+              relation_fields.split(',').map { |sub_field| "#{field_name}:#{sub_field.strip}" }
+            end
           end
         end
       end

--- a/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/capabilities/collections_spec.rb
+++ b/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/capabilities/collections_spec.rb
@@ -84,7 +84,7 @@ module ForestAdminAgent
 
           it 'returns agentCapabilities' do
             expect(result[:content][:agentCapabilities]).to eq(
-              { canUseProjectionOnGetOne: true }
+              { canUseProjectionOnGetOne: true, canUseMultipleFieldsProjectionOnRelation: true }
             )
           end
         end
@@ -131,7 +131,7 @@ module ForestAdminAgent
 
           it 'returns agentCapabilities' do
             expect(result[:content][:agentCapabilities]).to eq(
-              { canUseProjectionOnGetOne: true }
+              { canUseProjectionOnGetOne: true, canUseMultipleFieldsProjectionOnRelation: true }
             )
           end
         end

--- a/packages/forest_admin_agent/spec/lib/forest_admin_agent/utils/query_string_parser_spec.rb
+++ b/packages/forest_admin_agent/spec/lib/forest_admin_agent/utils/query_string_parser_spec.rb
@@ -333,6 +333,20 @@ module ForestAdminAgent
           expect(described_class.parse_projection_with_pks(collection,
                                                            args)).to eq(Projection.new(%w[id author:name author:id]))
         end
+
+        it 'supports multiple projected fields on a belongsTo relation' do
+          args = {
+            params: {
+              fields: {
+                'Book' => 'id, author',
+                'author' => 'id,name'
+              }
+            }
+          }
+
+          expect(described_class.parse_projection_with_pks(collection,
+                                                           args)).to eq(Projection.new(%w[id author:id author:name]))
+        end
       end
 
       describe 'parse_pagination' do


### PR DESCRIPTION
## Definition of Done

### General

- [ ] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [ ] Test manually the implemented changes
- [ ] Validate the code quality (indentation, syntax, style, simplicity, readability)

### Security

- [ ] Consider the security impact of the changes made


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Support multiple field projections on relation fields in query string parsing
> - `QueryStringParser.build_projection_fields` now uses `flat_map` to expand comma-separated relation subfields into individual projection entries (e.g., `author:id` and `author:name` instead of a single `author:id,name` token).
> - The `POST /_internal/capabilities` route now advertises `canUseMultipleFieldsProjectionOnRelation: true` in `agentCapabilities`.
> - Behavioral Change: projection output for relation fields with multiple subfields changes from a single token to multiple entries, which may affect consumers expecting the old format.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ab0cc12.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->