### PR TITLE
chore(security): patch 1 Dependabot alert

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "semantic-release-slack-bot": "4.0.2"
   },
   "resolutions": {
-    "semantic-release-slack-bot/**/micromatch": "^4.0.8"
+    "semantic-release-slack-bot/**/micromatch": "^4.0.8",
+    "brace-expansion": "^5.0.7"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -954,10 +954,10 @@ bottleneck@^2.15.3:
   resolved "https://registry.yarnpkg.com/bottleneck/-/bottleneck-2.19.5.tgz#5df0b90f59fd47656ebe63c78a98419205cadd91"
   integrity sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==
 
-brace-expansion@^5.0.5:
-  version "5.0.6"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.6.tgz#ec68fe0a641a29d8711579caf641d05bae1f2285"
-  integrity sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==
+brace-expansion@^5.0.5, brace-expansion@^5.0.7:
+  version "5.0.9"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.9.tgz#7c72438809b5fa5babf54199a1f1c281a6984fcf"
+  integrity sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==
   dependencies:
     balanced-match "^4.0.2"
 


### PR DESCRIPTION
> 👋 First-level support: see [Handling automated security PRs](https://forest.slite.com/app/docs/rmjdwFgmV2RzUp) for how to triage and merge this PR.

## Summary

1 fixed, 0 ignored, 4 deferred, 0 security pins added, 0 security pins removed, 0 could-not-auto-fix. | label: :lock: security applied

## Fixed

| Alert | Gem | Ecosystem | From → To | Severity | What was bumped |
|---|---|---|---|---|---|
| [#89](https://github.com/ForestAdmin/agent-ruby/security/dependabot/89) | brace-expansion | npm | 5.0.6 → 5.0.9 | high | Added root `resolutions` entry `"brace-expansion": "^5.0.7"` in `package.json`; parent `minimatch@^10.x` requires `^5.0.5`, resolution pulls the latest 5.x (5.0.9). |

## Ignored

None.

## Deferred

Skipped by the < 7-day age gate (will be handled by the next scheduled run):

- [#94](https://github.com/ForestAdmin/agent-ruby/security/dependabot/94) — brace-expansion (npm), high, `<= 5.0.7` (patched 5.0.8). Note: incidentally already resolved by this PR's bump to 5.0.9, but listed here because the alert itself was opened < 7 days ago.
- [#93](https://github.com/ForestAdmin/agent-ruby/security/dependabot/93) — tar (npm), medium, `<= 7.5.20` (patched 7.5.21).
- [#92](https://github.com/ForestAdmin/agent-ruby/security/dependabot/92) — fast-uri (npm), high, `>= 3.0.0, <= 3.1.3` (patched 3.1.4).
- [#91](https://github.com/ForestAdmin/agent-ruby/security/dependabot/91) — fast-uri (npm), high, `>= 3.0.0, < 3.1.3` (patched 3.1.3).

## Risks

- **brace-expansion 5.0.6 → 5.0.9**: patch-level bump within the 5.x line. Upstream 5.0.7/5.0.8/5.0.9 are all bug-fix/security releases (5.0.7 fixes the DoS in `expand()` covered by #89; 5.0.8 extends the same bound; 5.0.9 is a further patch on that fix). No API changes. No behavior change beyond the patched vuln for callers that aren't already blowing memory.

## Manual testing

Covered by CI.

## Validation

✅ CI green (Actions + commit statuses; app-based checks not monitored)

## Review checklist

**Fixes to verify** — tick once you have confirmed the bump landed:
- [ ] [#89](https://github.com/ForestAdmin/agent-ruby/security/dependabot/89) — `brace-expansion`
