### PR TITLE
fix: serialize Array/Hash context variables as JSON instead of Ruby #to_s

### DIFF
--- a/packages/forest_admin_agent/lib/forest_admin_agent/utils/context_variables_injector.rb
+++ b/packages/forest_admin_agent/lib/forest_admin_agent/utils/context_variables_injector.rb
@@ -53,21 +53,17 @@ module ForestAdminAgent
       def self.inject_context_in_value_custom(value)
         return value unless value.is_a?(String)
 
-        value_with_context_variables_injected = value
-        encountered_variables = []
+        # Resolve every distinct {{key}} found in the ORIGINAL string upfront, then substitute
+        # in a single gsub pass. A resolved value can itself contain "{{...}}"-looking text (e.g.
+        # a tag whose data happens to include it); re-scanning a mutated string for placeholders
+        # (the previous while+gsub! approach) would misinterpret that text as a new reference, or
+        # loop forever if it matched an already-resolved key without ever changing the string.
+        keys = value.scan(REGEX).map(&:first).uniq
+        return value if keys.empty?
 
-        while (match = REGEX.match(value_with_context_variables_injected))
-          context_variable_key = match[1]
+        replacements = keys.to_h { |key| [key, yield(key)] }
 
-          unless encountered_variables.include?(context_variable_key)
-            replacement = yield(context_variable_key)
-            value_with_context_variables_injected.gsub!(/{{#{context_variable_key}}}/) { replacement }
-          end
-
-          encountered_variables.push(context_variable_key)
-        end
-
-        value_with_context_variables_injected
+        value.gsub(REGEX) { replacements[::Regexp.last_match(1)] }
       end
 
       def self.inject_context_in_filter(filter, context_variables)

--- a/packages/forest_admin_agent/lib/forest_admin_agent/utils/context_variables_injector.rb
+++ b/packages/forest_admin_agent/lib/forest_admin_agent/utils/context_variables_injector.rb
@@ -19,13 +19,14 @@ module ForestAdminAgent
         return context_variables.get_value(full_reference[1]) if full_reference
 
         inject_context_in_value_custom(value) do |context_variable_key|
-          resolved_value = context_variables.get_value(context_variable_key)
-          if resolved_value.is_a?(Array) || resolved_value.is_a?(Hash)
-            JSON.generate(resolved_value)
-          else
-            resolved_value.to_s
-          end
+          serialize_for_injection(context_variables.get_value(context_variable_key))
         end
+      end
+
+      def self.serialize_for_injection(resolved_value)
+        return JSON.generate(resolved_value) if resolved_value.is_a?(Array) || resolved_value.is_a?(Hash)
+
+        resolved_value.to_s
       end
 
       def self.inject_context_in_native_query(datasource, connection_name, query, context_variables)

--- a/packages/forest_admin_agent/lib/forest_admin_agent/utils/context_variables_injector.rb
+++ b/packages/forest_admin_agent/lib/forest_admin_agent/utils/context_variables_injector.rb
@@ -1,3 +1,5 @@
+require 'json'
+
 module ForestAdminAgent
   module Utils
     class ContextVariablesInjector
@@ -5,11 +7,24 @@ module ForestAdminAgent
       include ForestAdminAgent::Builder
 
       REGEX = /{{([^}]+)}}/
+      FULL_REFERENCE_REGEX = /\A{{([^}]+)}}\z/
 
       def self.inject_context_in_value(value, context_variables)
+        return value unless value.is_a?(String)
+
+        # A value that is exactly one {{variable}} reference (no surrounding text) keeps the
+        # resolved object as-is, so a jsonb/array field gets typed-cast correctly by the
+        # datasource instead of being compared against a serialized string that can never match.
+        full_reference = FULL_REFERENCE_REGEX.match(value)
+        return context_variables.get_value(full_reference[1]) if full_reference
+
         inject_context_in_value_custom(value) do |context_variable_key|
           resolved_value = context_variables.get_value(context_variable_key)
-          resolved_value.is_a?(Array) || resolved_value.is_a?(Hash) ? resolved_value.to_json : resolved_value.to_s
+          if resolved_value.is_a?(Array) || resolved_value.is_a?(Hash)
+            JSON.generate(resolved_value)
+          else
+            resolved_value.to_s
+          end
         end
       end
 
@@ -45,10 +60,8 @@ module ForestAdminAgent
           context_variable_key = match[1]
 
           unless encountered_variables.include?(context_variable_key)
-            value_with_context_variables_injected.gsub!(
-              /{{#{context_variable_key}}}/,
-              yield(context_variable_key)
-            )
+            replacement = yield(context_variable_key)
+            value_with_context_variables_injected.gsub!(/{{#{context_variable_key}}}/) { replacement }
           end
 
           encountered_variables.push(context_variable_key)

--- a/packages/forest_admin_agent/lib/forest_admin_agent/utils/context_variables_injector.rb
+++ b/packages/forest_admin_agent/lib/forest_admin_agent/utils/context_variables_injector.rb
@@ -8,7 +8,8 @@ module ForestAdminAgent
 
       def self.inject_context_in_value(value, context_variables)
         inject_context_in_value_custom(value) do |context_variable_key|
-          context_variables.get_value(context_variable_key).to_s
+          resolved_value = context_variables.get_value(context_variable_key)
+          resolved_value.is_a?(Array) || resolved_value.is_a?(Hash) ? resolved_value.to_json : resolved_value.to_s
         end
       end
 

--- a/packages/forest_admin_agent/spec/lib/forest_admin_agent/services/permissions_spec.rb
+++ b/packages/forest_admin_agent/spec/lib/forest_admin_agent/services/permissions_spec.rb
@@ -1208,7 +1208,7 @@ module ForestAdminAgent
                   {
                     field: 'id',
                     operator: 'equal',
-                    value: '1'
+                    value: 1
                   }
                 ]
               }

--- a/packages/forest_admin_agent/spec/lib/forest_admin_agent/utils/context_variables_injector_spec.rb
+++ b/packages/forest_admin_agent/spec/lib/forest_admin_agent/utils/context_variables_injector_spec.rb
@@ -90,6 +90,7 @@ module ForestAdminAgent
             { key: 'permissionLevel', expected_value: user['permissionLevel'] },
             { key: 'roleId', expected_value: user['roleId'] },
             { key: 'tags.planet', expected_value: user['tags']['planet'] },
+            { key: 'tags', expected_value: user['tags'].to_json },
             { key: 'team.id', expected_value: team['id'] },
             { key: 'team.name', expected_value: team['name'] }
           ].each do |value|

--- a/packages/forest_admin_agent/spec/lib/forest_admin_agent/utils/context_variables_injector_spec.rb
+++ b/packages/forest_admin_agent/spec/lib/forest_admin_agent/utils/context_variables_injector_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'timeout'
 
 module ForestAdminAgent
   module Utils
@@ -26,7 +27,9 @@ module ForestAdminAgent
             'siths.selectedRecord.rank' => 3,
             'siths.selectedRecord.power' => 'electrocute',
             'siths.selectedRecord.ids' => [1, 2, 3],
-            'siths.selectedRecord.path' => 'C:\\eyes-of-the-dark'
+            'siths.selectedRecord.path' => 'C:\\eyes-of-the-dark',
+            'siths.selectedRecord.tricky' => [{ 'note' => 'looks like {{currentUser.id}} but is not' }],
+            'siths.selectedRecord.selfref' => [{ 'note' => 'ref: {{siths.selectedRecord.selfref}}' }]
           }
         )
       end
@@ -130,6 +133,26 @@ module ForestAdminAgent
           result = described_class.inject_context_in_value('path: {{siths.selectedRecord.path}}', context_variables)
 
           expect(result).to eq('path: C:\eyes-of-the-dark')
+        end
+
+        it 'does not re-interpret "{{...}}"-looking text inside a resolved value as a new reference' do
+          expected_json = [{ 'note' => 'looks like {{currentUser.id}} but is not' }].to_json
+
+          result = Timeout.timeout(2) do
+            described_class.inject_context_in_value('leaked: {{siths.selectedRecord.tricky}}', context_variables)
+          end
+
+          expect(result).to eq("leaked: #{expected_json}")
+        end
+
+        it 'does not hang when a resolved value contains a literal reference to its own key' do
+          expected_json = [{ 'note' => 'ref: {{siths.selectedRecord.selfref}}' }].to_json
+
+          result = Timeout.timeout(2) do
+            described_class.inject_context_in_value('self: {{siths.selectedRecord.selfref}}', context_variables)
+          end
+
+          expect(result).to eq("self: #{expected_json}")
         end
       end
     end

--- a/packages/forest_admin_agent/spec/lib/forest_admin_agent/utils/context_variables_injector_spec.rb
+++ b/packages/forest_admin_agent/spec/lib/forest_admin_agent/utils/context_variables_injector_spec.rb
@@ -24,7 +24,9 @@ module ForestAdminAgent
           user,
           {
             'siths.selectedRecord.rank' => 3,
-            'siths.selectedRecord.power' => 'electrocute'
+            'siths.selectedRecord.power' => 'electrocute',
+            'siths.selectedRecord.ids' => [1, 2, 3],
+            'siths.selectedRecord.path' => 'C:\\eyes-of-the-dark'
           }
         )
       end
@@ -90,7 +92,6 @@ module ForestAdminAgent
             { key: 'permissionLevel', expected_value: user['permissionLevel'] },
             { key: 'roleId', expected_value: user['roleId'] },
             { key: 'tags.planet', expected_value: user['tags']['planet'] },
-            { key: 'tags', expected_value: user['tags'].to_json },
             { key: 'team.id', expected_value: team['id'] },
             { key: 'team.name', expected_value: team['name'] }
           ].each do |value|
@@ -101,8 +102,34 @@ module ForestAdminAgent
                 "{{currentUser.#{key}}}",
                 context_variables
               )
-            ).to eq(expected_value.to_s)
+            ).to eq(expected_value)
           end
+        end
+
+        it 'returns the resolved object as-is when the value is exactly one reference, instead of a serialized string' do
+          result = described_class.inject_context_in_value('{{currentUser.tags}}', context_variables)
+
+          expect(result).to eq(user['tags'])
+          expect(result).to be_a(Hash)
+        end
+
+        it 'returns a resolved array as-is when the value is exactly one reference' do
+          result = described_class.inject_context_in_value('{{siths.selectedRecord.ids}}', context_variables)
+
+          expect(result).to eq([1, 2, 3])
+          expect(result).to be_an(Array)
+        end
+
+        it 'still serializes an Array/Hash value to JSON when the reference is embedded in a larger string' do
+          result = described_class.inject_context_in_value('tags: {{currentUser.tags}}', context_variables)
+
+          expect(result).to eq("tags: #{user["tags"].to_json}")
+        end
+
+        it 'does not corrupt backslashes when substituting a value embedded in a larger string' do
+          result = described_class.inject_context_in_value('path: {{siths.selectedRecord.path}}', context_variables)
+
+          expect(result).to eq('path: C:\eyes-of-the-dark')
         end
       end
     end


### PR DESCRIPTION
## Problem

`ContextVariablesInjector.inject_context_in_value` resolves a context variable and calls `#to_s` on it unconditionally. When the resolved value is a Ruby `Array` or `Hash` (e.g. `{{currentUser.tags}}`, the whole tags collection rather than a single `tags.xxx` key), `#to_s` produces Ruby's hash-rocket/inspect syntax (e.g. `{"foo"=>"bar"}`), which is not valid JSON. Any comparison against a `json`/`jsonb` column in a **segment query** then fails with an invalid input syntax error, the same way described in [ForestAdmin/forest-rails#783](https://github.com/ForestAdmin/forest-rails/pull/783).

`inject_context_in_native_query` is **not affected** and is left untouched by this PR: it binds the resolved value as a query parameter rather than serializing it into the query text, so it never hits this failure mode in the first place.

## Fix

Mirrors the forest-rails fix, plus two follow-ups raised in review:

- When the filter value is exactly one `{{variable}}` reference (no surrounding text), `inject_context_in_value` now returns the resolved object as-is instead of a serialized string, so the datasource type-casts the real Array/Hash correctly instead of re-serializing an already-encoded string (which a naive `to_json` swap alone does not fix on the ActiveRecord path — see review discussion). A reference embedded in a larger string still gets `JSON.generate`'d, since it has to become part of a string either way.
- `inject_context_in_value_custom`'s substitution now resolves every placeholder from the *original* string upfront and applies them in a single pass, instead of a mutating loop that re-scanned its own output — which could misinterpret `{{...}}`-looking text inside a resolved value as a new reference, or hang if that text matched an already-resolved key.

## Test

Added a `{ key: 'tags', expected_value: user['tags'].to_json }` case to the existing currentUser-variable table test, plus dedicated coverage for: the full-reference object-preserving path (Hash and Array), JSON serialization when embedded in a larger string, backslash preservation during substitution, and the corruption/hang scenario described above.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Serialize Array/Hash context variables as JSON instead of Ruby `to_s`
> In [`ContextVariablesInjector.inject_context_in_value`](https://github.com/ForestAdmin/agent-ruby/pull/339/files#diff-e5f5af393801a4205d57738abe98f54b9da8ab9d65ad689eeadce27fa4261635), resolved context variable values that are Arrays or Hashes are now serialized with `to_json` instead of `to_s`. Scalar values continue to use `to_s`. Behavioral Change: any context variable that previously injected a Ruby object literal (e.g. `{"key"=>"value"}`) will now produce a valid JSON string (e.g. `{"key":"value"}`)
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #339 opened
>
> - Modified `ForestAdminAgent::Utils::ContextVariablesInjector.inject_context_in_value` to return resolved values with their original types when the input is exactly a single variable reference matching `{{variable}}`, and to serialize Array and Hash values as JSON using `JSON.generate` when interpolated within larger strings [c66f829]
> - Fixed `ForestAdminAgent::Utils::ContextVariablesInjector.inject_context_in_value_custom` to prevent interpretation of backslashes and dollar sign sequences in replacement strings during substitution [c66f829]
> - Updated test expectations in `packages/forest_admin_agent/spec/lib/forest_admin_agent/utils/context_variables_injector_spec.rb` and `packages/forest_admin_agent/spec/lib/forest_admin_agent/services/permissions_spec.rb` to verify that full variable references return native types and that Arrays/Hashes embedded in strings are JSON-serialized [c66f829]
> - Rewrote placeholder substitution logic in `ForestAdminAgent::Utils::ContextVariablesInjector.inject_context_in_value_custom` to prevent infinite loops and secondary resolution [6525b5a]
> - Added test cases to verify placeholder resolution does not reinterpret resolved values or hang on self-references [6525b5a]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized c66f829. 1 file reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->