### PR TITLE
fix(agent): store the model name in the polymorphic type column on create

### DIFF
--- a/packages/forest_admin_agent/lib/forest_admin_agent/routes/abstract_authenticated_route.rb
+++ b/packages/forest_admin_agent/lib/forest_admin_agent/routes/abstract_authenticated_route.rb
@@ -24,13 +24,13 @@ module ForestAdminAgent
             record[schema.foreign_key] = value.dig('data', 'id')
             json_api_type = value.dig('data', 'type')
             # Find matching collection from foreign_collections (handles both singular and plural forms)
-            model_name = schema.foreign_collections.find do |coll_name|
+            collection_name = schema.foreign_collections.find do |coll_name|
               coll = collection.datasource.get_collection(coll_name)
               coll.name == json_api_type || coll.name.pluralize == json_api_type
             rescue ForestAdminDatasourceToolkit::Exceptions::ForestException
               false
             end || json_api_type
-            record[schema.foreign_key_type_field] = model_name
+            record[schema.foreign_key_type_field] = collection_name.gsub('__', '::')
           end
         end
 

--- a/packages/forest_admin_agent/lib/forest_admin_agent/routes/abstract_authenticated_route.rb
+++ b/packages/forest_admin_agent/lib/forest_admin_agent/routes/abstract_authenticated_route.rb
@@ -30,7 +30,7 @@ module ForestAdminAgent
             rescue ForestAdminDatasourceToolkit::Exceptions::ForestException
               false
             end || json_api_type
-            record[schema.foreign_key_type_field] = collection_name.gsub('__', '::')
+            record[schema.foreign_key_type_field] = collection_name&.gsub('__', '::')
           end
         end
 

--- a/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/resources/store_spec.rb
+++ b/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/resources/store_spec.rb
@@ -348,7 +348,7 @@ module ForestAdminAgent
 
             it 'stores the namespaced model name, not the formatted collection name' do
               collection_account = build_collection(
-                name: 'Banking__Account',
+                name: 'Banking__Sepa__Transfer',
                 schema: {
                   fields: {
                     'id' => ColumnSchema.new(
@@ -373,10 +373,10 @@ module ForestAdminAgent
                     'memberable_id' => ColumnSchema.new(column_type: 'Number'),
                     'memberable_type' => ColumnSchema.new(column_type: 'String'),
                     'memberable' => Relations::PolymorphicManyToOneSchema.new(
-                      foreign_collections: ['Banking__Account'],
+                      foreign_collections: ['Banking__Sepa__Transfer'],
                       foreign_key: 'memberable_id',
                       foreign_key_type_field: 'memberable_type',
-                      foreign_key_targets: { 'Banking__Account' => 'id' }
+                      foreign_key_targets: { 'Banking__Sepa__Transfer' => 'id' }
                     )
                   }
                 }
@@ -387,18 +387,18 @@ module ForestAdminAgent
 
               args[:params][:data] = {
                 attributes: {},
-                relationships: { 'memberable' => { 'data' => { 'type' => 'Banking__Account', 'id' => 3 } } },
+                relationships: { 'memberable' => { 'data' => { 'type' => 'Banking__Sepa__Transfer', 'id' => 3 } } },
                 type: 'Member'
               }
               args[:params]['collection_name'] = 'member'
               allow(@datasource.get_collection('member')).to receive_messages(
-                create: { 'id' => 1, 'memberable_id' => 3, 'memberable_type' => 'Banking::Account' },
-                list: [{ 'id' => 1, 'memberable_id' => 3, 'memberable_type' => 'Banking::Account' }]
+                create: { 'id' => 1, 'memberable_id' => 3, 'memberable_type' => 'Banking::Sepa::Transfer' },
+                list: [{ 'id' => 1, 'memberable_id' => 3, 'memberable_type' => 'Banking::Sepa::Transfer' }]
               )
 
               store.handle_request(args)
               expect(@datasource.get_collection('member')).to have_received(:create) do |_caller, data|
-                expect(data).to eq({ 'memberable_id' => 3, 'memberable_type' => 'Banking::Account' })
+                expect(data).to eq({ 'memberable_id' => 3, 'memberable_type' => 'Banking::Sepa::Transfer' })
               end
             end
 

--- a/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/resources/store_spec.rb
+++ b/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/resources/store_spec.rb
@@ -345,6 +345,62 @@ module ForestAdminAgent
               end
               expect(result[:name]).to eq('member')
             end
+
+            it 'stores the namespaced model name, not the formatted collection name' do
+              collection_account = build_collection(
+                name: 'Banking__Account',
+                schema: {
+                  fields: {
+                    'id' => ColumnSchema.new(
+                      column_type: 'Number',
+                      is_primary_key: true,
+                      filter_operators: [Operators::IN, Operators::EQUAL]
+                    ),
+                    'iban' => ColumnSchema.new(column_type: 'String')
+                  }
+                }
+              )
+
+              collection_member = build_collection(
+                name: 'member',
+                schema: {
+                  fields: {
+                    'id' => ColumnSchema.new(
+                      column_type: 'Number',
+                      is_primary_key: true,
+                      filter_operators: [Operators::IN, Operators::EQUAL]
+                    ),
+                    'memberable_id' => ColumnSchema.new(column_type: 'Number'),
+                    'memberable_type' => ColumnSchema.new(column_type: 'String'),
+                    'memberable' => Relations::PolymorphicManyToOneSchema.new(
+                      foreign_collections: ['Banking__Account'],
+                      foreign_key: 'memberable_id',
+                      foreign_key_type_field: 'memberable_type',
+                      foreign_key_targets: { 'Banking__Account' => 'id' }
+                    )
+                  }
+                }
+              )
+
+              @datasource.add_collection(collection_account)
+              @datasource.add_collection(collection_member)
+
+              args[:params][:data] = {
+                attributes: {},
+                relationships: { 'memberable' => { 'data' => { 'type' => 'Banking__Account', 'id' => 3 } } },
+                type: 'Member'
+              }
+              args[:params]['collection_name'] = 'member'
+              allow(@datasource.get_collection('member')).to receive_messages(
+                create: { 'id' => 1, 'memberable_id' => 3, 'memberable_type' => 'Banking::Account' },
+                list: [{ 'id' => 1, 'memberable_id' => 3, 'memberable_type' => 'Banking::Account' }]
+              )
+
+              store.handle_request(args)
+              expect(@datasource.get_collection('member')).to have_received(:create) do |_caller, data|
+                expect(data).to eq({ 'memberable_id' => 3, 'memberable_type' => 'Banking::Account' })
+              end
+            end
           end
         end
       end

--- a/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/resources/store_spec.rb
+++ b/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/resources/store_spec.rb
@@ -401,6 +401,61 @@ module ForestAdminAgent
                 expect(data).to eq({ 'memberable_id' => 3, 'memberable_type' => 'Banking::Account' })
               end
             end
+
+            it 'clears both columns when the relationship carries no data' do
+              collection_company = build_collection(
+                name: 'company',
+                schema: {
+                  fields: {
+                    'id' => ColumnSchema.new(
+                      column_type: 'Number',
+                      is_primary_key: true,
+                      filter_operators: [Operators::IN, Operators::EQUAL]
+                    )
+                  }
+                }
+              )
+
+              collection_member = build_collection(
+                name: 'member',
+                schema: {
+                  fields: {
+                    'id' => ColumnSchema.new(
+                      column_type: 'Number',
+                      is_primary_key: true,
+                      filter_operators: [Operators::IN, Operators::EQUAL]
+                    ),
+                    'memberable_id' => ColumnSchema.new(column_type: 'Number'),
+                    'memberable_type' => ColumnSchema.new(column_type: 'String'),
+                    'memberable' => Relations::PolymorphicManyToOneSchema.new(
+                      foreign_collections: ['company'],
+                      foreign_key: 'memberable_id',
+                      foreign_key_type_field: 'memberable_type',
+                      foreign_key_targets: { 'company' => 'id' }
+                    )
+                  }
+                }
+              )
+
+              @datasource.add_collection(collection_company)
+              @datasource.add_collection(collection_member)
+
+              args[:params][:data] = {
+                attributes: {},
+                relationships: { 'memberable' => { 'data' => nil } },
+                type: 'Member'
+              }
+              args[:params]['collection_name'] = 'member'
+              allow(@datasource.get_collection('member')).to receive_messages(
+                create: { 'id' => 1, 'memberable_id' => nil, 'memberable_type' => nil },
+                list: [{ 'id' => 1, 'memberable_id' => nil, 'memberable_type' => nil }]
+              )
+
+              store.handle_request(args)
+              expect(@datasource.get_collection('member')).to have_received(:create) do |_caller, data|
+                expect(data).to eq({ 'memberable_id' => nil, 'memberable_type' => nil })
+              end
+            end
           end
         end
       end


### PR DESCRIPTION
## Problem

When a record is created through the JSON:API `relationships` payload and the relation is a `PolymorphicManyToOne`, the agent stored the **Forest collection name** in the polymorphic type column instead of the Rails class name. For a namespaced model, the column ended up holding `Banking__Account` where `Banking::Account` was expected.

Only namespaced models are affected — `gsub('__', '::')` is a no-op on the others, which is why this went unnoticed.

Consequences for a namespaced target:

1. Rails can no longer resolve the association: `commentable_type = 'Banking__Account'` is not a valid constant.
2. The record never shows up in the parent's related-data tab, since `PolymorphicOneToMany` filters on the model name.
3. It looks fine in the detail view: the serializer resolves the target by applying the reverse substitution, which is idempotent on an already-formatted value. So the row is corrupted while the UI seems healthy.

## Fix

`format_attributes` now converts the name back before storing it, like every other write path already did (`update_related`, `associate_related`, `delete`, `store`). The local variable was renamed `collection_name`, since it holds a collection name — naming it `model_name` is what hid the missing conversion in the first place.

The `|| json_api_type` fallback for unmatched types is **deliberately unchanged**: it is load-bearing for legitimate case variants (a frontend sending `Company` for a collection named `company`), so removing it would break existing flows. Hardening it (case-insensitive matching, then 400 on unknown types) is tracked in [PRD-874](https://linear.app/forestadmin/issue/PRD-874/ruby-agent-createupdate-persists-client-supplied-relationship-values).

## Tests

A spec on a namespaced collection was added next to the existing polymorphic one. It fails without the fix with `"memberable_type" => "Banking__Account"`, and passes with it. The 726 specs of `forest_admin_agent` pass, rubocop is clean.

fixes PRD-870

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix polymorphic type column to store namespaced model name on create
> When creating a record with a `PolymorphicManyToOne` relationship, the type column now stores the namespaced model name (e.g. `Foo::Bar`) by replacing `__` with `::` in the matched collection name. The fallback to the raw `json_api_type` when no foreign collection matches is unchanged (deliberately retained — see PRD-874). The safe navigation added in 6dab1da means a `{ data: nil }` payload now clears both columns instead of raising.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #342 opened
>
> - Updated test spec for polymorphic relationship type storage in `ForestAdminAgent::Routes::Resources` Store [61c148f]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6dab1da.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->
