### PR TITLE
fix: surface HTTP errors instead of silently skipping schema sync

### DIFF
--- a/packages/forest_admin_agent/lib/forest_admin_agent/builder/agent_factory.rb
+++ b/packages/forest_admin_agent/lib/forest_admin_agent/builder/agent_factory.rb
@@ -211,6 +211,7 @@ module ForestAdminAgent
 
         begin
           response = client.post('/forest/apimaps/hashcheck', { schemaFileHash: hash }.to_json)
+          client.raise_for_response!(response)
           body = JSON.parse(response.body)
           body['sendSchema']
         rescue JSON::ParserError => e
@@ -281,7 +282,8 @@ module ForestAdminAgent
       def send_schema_to_server(api_map)
         ForestAdminAgent::Facades::Container.logger.log('Info', 'schema was updated, sending new version')
         client = ForestAdminAgent::Http::ForestAdminApiRequester.new
-        client.post('/forest/apimaps', api_map.to_json)
+        response = client.post('/forest/apimaps', api_map.to_json)
+        client.raise_for_response!(response)
       rescue Faraday::Error => e
         status = e.response[:status] if e.response
         if status

--- a/packages/forest_admin_agent/lib/forest_admin_agent/builder/agent_factory.rb
+++ b/packages/forest_admin_agent/lib/forest_admin_agent/builder/agent_factory.rb
@@ -131,6 +131,14 @@ module ForestAdminAgent
         end
 
         post_schema(schema, force)
+      rescue StandardError => e
+        # A well-formed secret can still be rejected by the server (wrong project, revoked
+        # secret, network down, ...). Same rule as an invalid format: block boot in
+        # production, but never in dev - warn and move on instead.
+        raise e if Facades::Container.cache(:is_production)
+
+        @logger.log('Warn', "[ForestAdmin] #{e.message}")
+        @logger.log('Warn', '[ForestAdmin] Schema sync failed, continuing without it.')
       end
 
       # Generates or loads the schema and writes it to file (in development mode).
@@ -184,7 +192,9 @@ module ForestAdminAgent
         errors = secret_format_errors
         return true if errors.empty?
 
-        raise ForestAdminAgent::Http::Exceptions::ValidationError, errors.join(' ') if @options.to_h[:is_production]
+        if Facades::Container.cache(:is_production)
+          raise ForestAdminAgent::Http::Exceptions::ValidationError, errors.join(' ')
+        end
 
         # Don't block boot on a config mistake in dev: warn loudly and skip the schema
         # sync instead, so the developer can still work on the rest of the app.

--- a/packages/forest_admin_agent/lib/forest_admin_agent/builder/agent_factory.rb
+++ b/packages/forest_admin_agent/lib/forest_admin_agent/builder/agent_factory.rb
@@ -23,11 +23,12 @@ module ForestAdminAgent
       def setup(options)
         @options = options
         @has_env_secret = options.to_h.key?(:env_secret)
-        validate_secrets_format! if @has_env_secret
+        @secrets_format_invalid = false
         @customizer = ForestAdminDatasourceCustomizer::DatasourceCustomizer.new
         build_container
         build_cache
         build_logger
+        validate_secrets_format! if @has_env_secret
       end
 
       def add_datasource(datasource, options = {})
@@ -118,6 +119,7 @@ module ForestAdminAgent
         end
 
         return unless @has_env_secret
+        return if @secrets_format_invalid
 
         schema = generate_schema_file
 
@@ -179,19 +181,33 @@ module ForestAdminAgent
       private
 
       def validate_secrets_format!
+        errors = secret_format_errors
+        return if errors.empty?
+
+        raise ForestAdminAgent::Http::Exceptions::ValidationError, errors.join(' ') if @options.to_h[:is_production]
+
+        # Don't block boot on a config mistake in dev: warn loudly and skip the schema
+        # sync instead, so the developer can still work on the rest of the app.
+        errors.each { |error| @logger.log('Warn', "[ForestAdmin] #{error}") }
+        @logger.log('Warn', '[ForestAdmin] Skipping schema sync until this is fixed.')
+        @secrets_format_invalid = true
+      end
+
+      def secret_format_errors
+        errors = []
         env_secret = @options.to_h[:env_secret]
 
         unless env_secret.is_a?(String) && env_secret.match?(ENV_SECRET_FORMAT)
-          raise ForestAdminAgent::Http::Exceptions::ValidationError,
-                'config.env_secret is invalid: it must be the 64-character hexadecimal secret from your ' \
-                'Forest Admin project settings.'
+          errors << 'config.env_secret is invalid: it must be the 64-character hexadecimal secret from your ' \
+                    'Forest Admin project settings.'
         end
 
         auth_secret = @options.to_h[:auth_secret]
-        return if auth_secret.is_a?(String)
+        unless auth_secret.is_a?(String)
+          errors << 'config.auth_secret is invalid: it must be a string. Any long random value works.'
+        end
 
-        raise ForestAdminAgent::Http::Exceptions::ValidationError,
-              'config.auth_secret is invalid: it must be a string. Any long random value works.'
+        errors
       end
 
       def container_replace(key, value)

--- a/packages/forest_admin_agent/lib/forest_admin_agent/builder/agent_factory.rb
+++ b/packages/forest_admin_agent/lib/forest_admin_agent/builder/agent_factory.rb
@@ -13,6 +13,8 @@ module ForestAdminAgent
       attr_reader :customizer, :container, :has_env_secret
       attr_accessor :schema_only_mode
 
+      ENV_SECRET_FORMAT = /\A[0-9a-f]{64}\z/
+
       def initialize
         super
         @reloading = false
@@ -21,6 +23,7 @@ module ForestAdminAgent
       def setup(options)
         @options = options
         @has_env_secret = options.to_h.key?(:env_secret)
+        validate_secrets_format! if @has_env_secret
         @customizer = ForestAdminDatasourceCustomizer::DatasourceCustomizer.new
         build_container
         build_cache
@@ -174,6 +177,22 @@ module ForestAdminAgent
       end
 
       private
+
+      def validate_secrets_format!
+        env_secret = @options.to_h[:env_secret]
+
+        unless env_secret.is_a?(String) && env_secret.match?(ENV_SECRET_FORMAT)
+          raise ForestAdminAgent::Http::Exceptions::ValidationError,
+                'config.env_secret is invalid: it must be the 64-character hexadecimal secret from your ' \
+                'Forest Admin project settings.'
+        end
+
+        auth_secret = @options.to_h[:auth_secret]
+        return if auth_secret.is_a?(String)
+
+        raise ForestAdminAgent::Http::Exceptions::ValidationError,
+              'config.auth_secret is invalid: it must be a string. Any long random value works.'
+      end
 
       def container_replace(key, value)
         @container._container.delete(key.to_s)

--- a/packages/forest_admin_agent/lib/forest_admin_agent/builder/agent_factory.rb
+++ b/packages/forest_admin_agent/lib/forest_admin_agent/builder/agent_factory.rb
@@ -22,7 +22,7 @@ module ForestAdminAgent
 
       def setup(options)
         @options = options
-        @has_env_secret = options.to_h.key?(:env_secret)
+        @has_env_secret = !options.to_h[:env_secret].nil?
         @secrets_format_invalid = false
         @customizer = ForestAdminDatasourceCustomizer::DatasourceCustomizer.new
         build_container

--- a/packages/forest_admin_agent/lib/forest_admin_agent/builder/agent_factory.rb
+++ b/packages/forest_admin_agent/lib/forest_admin_agent/builder/agent_factory.rb
@@ -130,15 +130,19 @@ module ForestAdminAgent
           end
         end
 
-        post_schema(schema, force)
-      rescue StandardError => e
-        # A well-formed secret can still be rejected by the server (wrong project, revoked
-        # secret, network down, ...). Same rule as an invalid format: block boot in
-        # production, but never in dev - warn and move on instead.
-        raise e if Facades::Container.cache(:is_production)
+        begin
+          post_schema(schema, force)
+        rescue StandardError => e
+          # A well-formed secret can still be rejected by the server (wrong project, revoked
+          # secret, network down, ...). Same rule as an invalid format: block boot in
+          # production, but never in dev - warn and move on instead. Scoped to this call
+          # only, so a local bug (a broken customization, an unwritable schema_path, ...)
+          # still surfaces immediately instead of being logged as a generic warning.
+          raise e if Facades::Container.cache(:is_production)
 
-        @logger.log('Warn', "[ForestAdmin] #{e.message}")
-        @logger.log('Warn', '[ForestAdmin] Schema sync failed, continuing without it.')
+          @logger.log('Warn', "[ForestAdmin] #{e.message}")
+          @logger.log('Warn', '[ForestAdmin] Schema sync failed, continuing without it.')
+        end
       end
 
       # Generates or loads the schema and writes it to file (in development mode).

--- a/packages/forest_admin_agent/lib/forest_admin_agent/builder/agent_factory.rb
+++ b/packages/forest_admin_agent/lib/forest_admin_agent/builder/agent_factory.rb
@@ -23,12 +23,10 @@ module ForestAdminAgent
       def setup(options)
         @options = options
         @has_env_secret = !options.to_h[:env_secret].nil?
-        @secrets_format_invalid = false
         @customizer = ForestAdminDatasourceCustomizer::DatasourceCustomizer.new
         build_container
         build_cache
         build_logger
-        validate_secrets_format! if @has_env_secret
       end
 
       def add_datasource(datasource, options = {})
@@ -119,7 +117,7 @@ module ForestAdminAgent
         end
 
         return unless @has_env_secret
-        return if @secrets_format_invalid
+        return unless secrets_format_valid?
 
         schema = generate_schema_file
 
@@ -180,9 +178,11 @@ module ForestAdminAgent
 
       private
 
-      def validate_secrets_format!
+      # Checked from send_schema rather than setup, so that schema-only mode (which never
+      # syncs to the server) never fails on a secret it doesn't actually need.
+      def secrets_format_valid?
         errors = secret_format_errors
-        return if errors.empty?
+        return true if errors.empty?
 
         raise ForestAdminAgent::Http::Exceptions::ValidationError, errors.join(' ') if @options.to_h[:is_production]
 
@@ -190,7 +190,7 @@ module ForestAdminAgent
         # sync instead, so the developer can still work on the rest of the app.
         errors.each { |error| @logger.log('Warn', "[ForestAdmin] #{error}") }
         @logger.log('Warn', '[ForestAdmin] Skipping schema sync until this is fixed.')
-        @secrets_format_invalid = true
+        false
       end
 
       def secret_format_errors

--- a/packages/forest_admin_agent/lib/forest_admin_agent/http/forest_admin_api_requester.rb
+++ b/packages/forest_admin_agent/lib/forest_admin_agent/http/forest_admin_api_requester.rb
@@ -50,12 +50,12 @@ module ForestAdminAgent
       def raise_for_response!(response)
         return if response.success?
 
-        raise_for_status(response.status)
+        raise_for_status(response.status, message: response.reason_phrase)
       end
 
       private
 
-      def raise_for_status(status, cause: nil)
+      def raise_for_status(status, cause: nil, message: cause&.message)
         if status.zero? || status == 502
           raise BadGatewayError.new(
             'Failed to reach ForestAdmin server. Are you online?',
@@ -81,7 +81,7 @@ module ForestAdminAgent
 
         raise InternalServerError.new(
           'An unexpected error occurred while contacting the ForestAdmin server. Please contact support@forestadmin.com for further investigations.',
-          details: { status: status },
+          details: { status: status, message: message },
           cause: cause
         )
       end

--- a/packages/forest_admin_agent/lib/forest_admin_agent/http/forest_admin_api_requester.rb
+++ b/packages/forest_admin_agent/lib/forest_admin_agent/http/forest_admin_api_requester.rb
@@ -41,33 +41,48 @@ module ForestAdminAgent
           )
         end
 
-        if error.response[:status].zero? || error.response[:status] == 502
+        raise_for_status(error.response[:status], cause: error)
+      end
+
+      # Faraday does not raise on HTTP error statuses here (no raise_error middleware
+      # configured), so a response has to be checked explicitly to turn e.g. an
+      # invalid envSecret (404) into the same typed errors as handle_response_error.
+      def raise_for_response!(response)
+        return if response.success?
+
+        raise_for_status(response.status)
+      end
+
+      private
+
+      def raise_for_status(status, cause: nil)
+        if status.zero? || status == 502
           raise BadGatewayError.new(
             'Failed to reach ForestAdmin server. Are you online?',
-            details: { status: error.response[:status] },
-            cause: error
+            details: { status: status },
+            cause: cause
           )
         end
 
-        if error.response[:status] == 404
+        if status == 404
           raise NotFoundError.new(
             'ForestAdmin server failed to find the project related to the envSecret you configured. Can you check that you copied it properly in the Forest initialization?',
-            details: { status: error.response[:status] }
+            details: { status: status }
           )
         end
 
-        if error.response[:status] == 503
+        if status == 503
           raise ServiceUnavailableError.new(
             'Forest is in maintenance for a few minutes. We are upgrading your experience in the forest. We just need a few more minutes to get it right.',
-            details: { status: error.response[:status] },
-            cause: error
+            details: { status: status },
+            cause: cause
           )
         end
 
         raise InternalServerError.new(
           'An unexpected error occurred while contacting the ForestAdmin server. Please contact support@forestadmin.com for further investigations.',
-          details: { status: error.response[:status], message: error.message },
-          cause: error
+          details: { status: status },
+          cause: cause
         )
       end
     end

--- a/packages/forest_admin_agent/spec/lib/forest_admin_agent/builder/agent_factory_spec.rb
+++ b/packages/forest_admin_agent/spec/lib/forest_admin_agent/builder/agent_factory_spec.rb
@@ -158,7 +158,8 @@ module ForestAdminAgent
             {
               auth_secret: 'cba803d01a4d43b55010cab41fa1ea1f1f51a95e',
               env_secret: '89719c6d8e2e2de2694c2f220fe2dbf02d5289487364daf1e4c6b13733ed0cdb',
-              skip_schema_update: false
+              skip_schema_update: false,
+              append_schema_path: nil
             }
           end
           let(:not_found_error) do
@@ -170,7 +171,8 @@ module ForestAdminAgent
           context 'when running in production' do
             it 'raises the error the server returned' do
               instance.setup(valid_options.merge(is_production: true))
-              allow(instance).to receive(:generate_schema_file).and_raise(not_found_error)
+              allow(instance).to receive_messages(generate_schema_file: { meta: {}, collections: [] })
+              allow(instance).to receive(:post_schema).and_raise(not_found_error)
 
               expect { instance.send_schema }.to raise_error(ForestAdminAgent::Http::Exceptions::NotFoundError)
             end
@@ -181,13 +183,29 @@ module ForestAdminAgent
               logger = instance_spy(Services::LoggerService)
               allow(Services::LoggerService).to receive(:new).and_return(logger)
               instance.setup(valid_options.merge(is_production: false))
-              allow(instance).to receive(:generate_schema_file).and_raise(not_found_error)
+              allow(instance).to receive_messages(generate_schema_file: { meta: {}, collections: [] })
+              allow(instance).to receive(:post_schema).and_raise(not_found_error)
 
               expect { instance.send_schema }.not_to raise_error
 
               expect(logger).to have_received(:log).with('Warn', /failed to find the project/)
               expect(logger).to have_received(:log).with('Warn', /Schema sync failed/)
             end
+          end
+        end
+
+        context 'when generate_schema_file raises a local error (e.g. a broken customization)' do
+          it 'still raises it outside production, instead of swallowing it as a Forest warning' do
+            instance = described_class.instance
+            instance.setup(
+              auth_secret: 'cba803d01a4d43b55010cab41fa1ea1f1f51a95e',
+              env_secret: '89719c6d8e2e2de2694c2f220fe2dbf02d5289487364daf1e4c6b13733ed0cdb',
+              skip_schema_update: false,
+              is_production: false
+            )
+            allow(instance).to receive(:generate_schema_file).and_raise(ArgumentError, 'broken chart definition')
+
+            expect { instance.send_schema }.to raise_error(ArgumentError, 'broken chart definition')
           end
         end
 
@@ -478,30 +496,9 @@ module ForestAdminAgent
             expect(instance).to have_received(:post_schema).with(hash_including(collections: [{ name: 'Main' }, { name: 'Extra' }]), anything)
           end
 
-          it 'raises error if append_schema file cannot be loaded, in production' do
+          it 'raises error if append_schema file cannot be loaded, regardless of environment' do
             instance = described_class.instance
             instance.instance_variable_set(:@has_env_secret, true)
-
-            datasource = instance_double(ForestAdminDatasourceToolkit::Datasource)
-            instance.container.register(:datasource, datasource)
-
-            allow(Facades::Container).to receive(:cache).with(:skip_schema_update).and_return(false)
-            allow(Facades::Container).to receive(:cache).with(:schema_path).and_return('/path/to/schema.json')
-            allow(Facades::Container).to receive(:cache).with(:is_production).and_return(true)
-            allow(Facades::Container).to receive(:cache).with(:append_schema_path).and_return('/path/to/append.json')
-            allow(ForestAdminAgent::Utils::Schema::SchemaEmitter).to receive_messages(generate: [], meta: {})
-            allow(File).to receive(:exist?).with('/path/to/schema.json').and_return(true)
-            allow(File).to receive(:read).with('/path/to/schema.json').and_return({ meta: {}, collections: [] }.to_json)
-            allow(File).to receive(:read).with('/path/to/append.json').and_raise(Errno::ENOENT)
-
-            expect { instance.send_schema }.to raise_error(/Can't load additional schema/)
-          end
-
-          it 'warns instead of raising if append_schema file cannot be loaded, outside production' do
-            instance = described_class.instance
-            instance.instance_variable_set(:@has_env_secret, true)
-            logger = instance_spy(Services::LoggerService)
-            instance.instance_variable_set(:@logger, logger)
 
             datasource = instance_double(ForestAdminDatasourceToolkit::Datasource)
             instance.container.register(:datasource, datasource)
@@ -514,9 +511,7 @@ module ForestAdminAgent
             allow(File).to receive(:write)
             allow(File).to receive(:read).with('/path/to/append.json').and_raise(Errno::ENOENT)
 
-            expect { instance.send_schema }.not_to raise_error
-
-            expect(logger).to have_received(:log).with('Warn', /Can't load additional schema/)
+            expect { instance.send_schema }.to raise_error(/Can't load additional schema/)
           end
 
           context 'with skip_schema_update enabled' do

--- a/packages/forest_admin_agent/spec/lib/forest_admin_agent/builder/agent_factory_spec.rb
+++ b/packages/forest_admin_agent/spec/lib/forest_admin_agent/builder/agent_factory_spec.rb
@@ -24,6 +24,44 @@ module ForestAdminAgent
             expect(described_class.instance.container.resolve(:logger)).not_to be_nil
             expect(described_class.instance.container.resolve(:logger)).to be_instance_of Services::LoggerService
           end
+
+          context 'when env_secret is present but malformed' do
+            let(:instance) { described_class.instance }
+            let(:valid_options) do
+              {
+                auth_secret: 'cba803d01a4d43b55010cab41fa1ea1f1f51a95e',
+                env_secret: '89719c6d8e2e2de2694c2f220fe2dbf02d5289487364daf1e4c6b13733ed0cdb'
+              }
+            end
+
+            it 'raises a ValidationError when env_secret is too short' do
+              expect do
+                instance.setup(valid_options.merge(env_secret: 'abc123'))
+              end.to raise_error(ForestAdminAgent::Http::Exceptions::ValidationError, /config\.env_secret is invalid/)
+            end
+
+            it 'raises a ValidationError when env_secret contains the variable name (a common copy-paste mistake)' do
+              expect do
+                instance.setup(valid_options.merge(env_secret: "FOREST_ENV_SECRET=#{valid_options[:env_secret]}"))
+              end.to raise_error(ForestAdminAgent::Http::Exceptions::ValidationError, /config\.env_secret is invalid/)
+            end
+
+            it 'raises a ValidationError when env_secret has uppercase characters' do
+              expect do
+                instance.setup(valid_options.merge(env_secret: valid_options[:env_secret].upcase))
+              end.to raise_error(ForestAdminAgent::Http::Exceptions::ValidationError, /config\.env_secret is invalid/)
+            end
+
+            it 'raises a ValidationError when auth_secret is not a string' do
+              expect do
+                instance.setup(valid_options.merge(auth_secret: 42))
+              end.to raise_error(ForestAdminAgent::Http::Exceptions::ValidationError, /config\.auth_secret is invalid/)
+            end
+
+            it 'does not raise when both secrets are well-formed' do
+              expect { instance.setup(valid_options) }.not_to raise_error
+            end
+          end
         end
 
         describe 'add_datasource' do

--- a/packages/forest_admin_agent/spec/lib/forest_admin_agent/builder/agent_factory_spec.rb
+++ b/packages/forest_admin_agent/spec/lib/forest_admin_agent/builder/agent_factory_spec.rb
@@ -34,32 +34,65 @@ module ForestAdminAgent
               }
             end
 
-            it 'raises a ValidationError when env_secret is too short' do
-              expect do
-                instance.setup(valid_options.merge(env_secret: 'abc123'))
-              end.to raise_error(ForestAdminAgent::Http::Exceptions::ValidationError, /config\.env_secret is invalid/)
+            context 'when running in production' do
+              let(:prod_options) { valid_options.merge(is_production: true) }
+
+              it 'raises a ValidationError when env_secret is too short' do
+                expect do
+                  instance.setup(prod_options.merge(env_secret: 'abc123'))
+                end.to raise_error(ForestAdminAgent::Http::Exceptions::ValidationError, /config\.env_secret is invalid/)
+              end
+
+              it 'raises a ValidationError when env_secret contains the variable name (a common copy-paste mistake)' do
+                expect do
+                  instance.setup(prod_options.merge(env_secret: "FOREST_ENV_SECRET=#{valid_options[:env_secret]}"))
+                end.to raise_error(ForestAdminAgent::Http::Exceptions::ValidationError, /config\.env_secret is invalid/)
+              end
+
+              it 'raises a ValidationError when env_secret has uppercase characters' do
+                expect do
+                  instance.setup(prod_options.merge(env_secret: valid_options[:env_secret].upcase))
+                end.to raise_error(ForestAdminAgent::Http::Exceptions::ValidationError, /config\.env_secret is invalid/)
+              end
+
+              it 'raises a ValidationError when auth_secret is not a string' do
+                expect do
+                  instance.setup(prod_options.merge(auth_secret: 42))
+                end.to raise_error(ForestAdminAgent::Http::Exceptions::ValidationError, /config\.auth_secret is invalid/)
+              end
+
+              it 'does not raise when both secrets are well-formed' do
+                expect { instance.setup(prod_options) }.not_to raise_error
+              end
             end
 
-            it 'raises a ValidationError when env_secret contains the variable name (a common copy-paste mistake)' do
-              expect do
-                instance.setup(valid_options.merge(env_secret: "FOREST_ENV_SECRET=#{valid_options[:env_secret]}"))
-              end.to raise_error(ForestAdminAgent::Http::Exceptions::ValidationError, /config\.env_secret is invalid/)
-            end
+            context 'when running outside production' do
+              let(:dev_options) { valid_options.merge(is_production: false) }
 
-            it 'raises a ValidationError when env_secret has uppercase characters' do
-              expect do
-                instance.setup(valid_options.merge(env_secret: valid_options[:env_secret].upcase))
-              end.to raise_error(ForestAdminAgent::Http::Exceptions::ValidationError, /config\.env_secret is invalid/)
-            end
+              it 'does not raise, warns instead, and skips the schema sync' do
+                logger = instance_spy(Services::LoggerService)
+                allow(Services::LoggerService).to receive(:new).and_return(logger)
 
-            it 'raises a ValidationError when auth_secret is not a string' do
-              expect do
-                instance.setup(valid_options.merge(auth_secret: 42))
-              end.to raise_error(ForestAdminAgent::Http::Exceptions::ValidationError, /config\.auth_secret is invalid/)
-            end
+                expect { instance.setup(dev_options.merge(env_secret: 'abc123')) }.not_to raise_error
 
-            it 'does not raise when both secrets are well-formed' do
-              expect { instance.setup(valid_options) }.not_to raise_error
+                expect(logger).to have_received(:log).with('Warn', /config\.env_secret is invalid/)
+                expect(logger).to have_received(:log).with('Warn', /Skipping schema sync/)
+
+                allow(Facades::Container).to receive(:cache).with(:skip_schema_update).and_return(false)
+                allow(instance).to receive(:generate_schema_file)
+                instance.send_schema
+
+                expect(instance).not_to have_received(:generate_schema_file)
+              end
+
+              it 'does not raise and does not warn when both secrets are well-formed' do
+                logger = instance_spy(Services::LoggerService)
+                allow(Services::LoggerService).to receive(:new).and_return(logger)
+
+                expect { instance.setup(dev_options) }.not_to raise_error
+
+                expect(logger).not_to have_received(:log).with('Warn', /is invalid/)
+              end
             end
           end
         end

--- a/packages/forest_admin_agent/spec/lib/forest_admin_agent/builder/agent_factory_spec.rb
+++ b/packages/forest_admin_agent/spec/lib/forest_admin_agent/builder/agent_factory_spec.rb
@@ -74,12 +74,10 @@ module ForestAdminAgent
           let(:valid_options) do
             {
               auth_secret: 'cba803d01a4d43b55010cab41fa1ea1f1f51a95e',
-              env_secret: '89719c6d8e2e2de2694c2f220fe2dbf02d5289487364daf1e4c6b13733ed0cdb'
+              env_secret: '89719c6d8e2e2de2694c2f220fe2dbf02d5289487364daf1e4c6b13733ed0cdb',
+              skip_schema_update: false,
+              append_schema_path: nil
             }
-          end
-
-          before do
-            allow(Facades::Container).to receive(:cache).with(:skip_schema_update).and_return(false)
           end
 
           context 'when running in production' do
@@ -120,7 +118,6 @@ module ForestAdminAgent
             it 'does not raise when both secrets are well-formed' do
               instance.setup(prod_options)
               allow(instance).to receive_messages(generate_schema_file: { meta: {}, collections: [] }, post_schema: nil)
-              allow(Facades::Container).to receive(:cache).with(:append_schema_path).and_return(nil)
 
               expect { instance.send_schema }.not_to raise_error
             end
@@ -147,11 +144,49 @@ module ForestAdminAgent
               allow(Services::LoggerService).to receive(:new).and_return(logger)
               instance.setup(dev_options)
               allow(instance).to receive_messages(generate_schema_file: { meta: {}, collections: [] }, post_schema: nil)
-              allow(Facades::Container).to receive(:cache).with(:append_schema_path).and_return(nil)
 
               expect { instance.send_schema }.not_to raise_error
 
               expect(logger).not_to have_received(:log).with('Warn', /is invalid/)
+            end
+          end
+        end
+
+        context 'when the secret is well-formed but rejected by the server' do
+          let(:instance) { described_class.instance }
+          let(:valid_options) do
+            {
+              auth_secret: 'cba803d01a4d43b55010cab41fa1ea1f1f51a95e',
+              env_secret: '89719c6d8e2e2de2694c2f220fe2dbf02d5289487364daf1e4c6b13733ed0cdb',
+              skip_schema_update: false
+            }
+          end
+          let(:not_found_error) do
+            ForestAdminAgent::Http::Exceptions::NotFoundError.new(
+              'ForestAdmin server failed to find the project related to the envSecret you configured.'
+            )
+          end
+
+          context 'when running in production' do
+            it 'raises the error the server returned' do
+              instance.setup(valid_options.merge(is_production: true))
+              allow(instance).to receive(:generate_schema_file).and_raise(not_found_error)
+
+              expect { instance.send_schema }.to raise_error(ForestAdminAgent::Http::Exceptions::NotFoundError)
+            end
+          end
+
+          context 'when running outside production' do
+            it 'does not raise, warns instead, and continues without the schema' do
+              logger = instance_spy(Services::LoggerService)
+              allow(Services::LoggerService).to receive(:new).and_return(logger)
+              instance.setup(valid_options.merge(is_production: false))
+              allow(instance).to receive(:generate_schema_file).and_raise(not_found_error)
+
+              expect { instance.send_schema }.not_to raise_error
+
+              expect(logger).to have_received(:log).with('Warn', /failed to find the project/)
+              expect(logger).to have_received(:log).with('Warn', /Schema sync failed/)
             end
           end
         end
@@ -443,9 +478,30 @@ module ForestAdminAgent
             expect(instance).to have_received(:post_schema).with(hash_including(collections: [{ name: 'Main' }, { name: 'Extra' }]), anything)
           end
 
-          it 'raises error if append_schema file cannot be loaded' do
+          it 'raises error if append_schema file cannot be loaded, in production' do
             instance = described_class.instance
             instance.instance_variable_set(:@has_env_secret, true)
+
+            datasource = instance_double(ForestAdminDatasourceToolkit::Datasource)
+            instance.container.register(:datasource, datasource)
+
+            allow(Facades::Container).to receive(:cache).with(:skip_schema_update).and_return(false)
+            allow(Facades::Container).to receive(:cache).with(:schema_path).and_return('/path/to/schema.json')
+            allow(Facades::Container).to receive(:cache).with(:is_production).and_return(true)
+            allow(Facades::Container).to receive(:cache).with(:append_schema_path).and_return('/path/to/append.json')
+            allow(ForestAdminAgent::Utils::Schema::SchemaEmitter).to receive_messages(generate: [], meta: {})
+            allow(File).to receive(:exist?).with('/path/to/schema.json').and_return(true)
+            allow(File).to receive(:read).with('/path/to/schema.json').and_return({ meta: {}, collections: [] }.to_json)
+            allow(File).to receive(:read).with('/path/to/append.json').and_raise(Errno::ENOENT)
+
+            expect { instance.send_schema }.to raise_error(/Can't load additional schema/)
+          end
+
+          it 'warns instead of raising if append_schema file cannot be loaded, outside production' do
+            instance = described_class.instance
+            instance.instance_variable_set(:@has_env_secret, true)
+            logger = instance_spy(Services::LoggerService)
+            instance.instance_variable_set(:@logger, logger)
 
             datasource = instance_double(ForestAdminDatasourceToolkit::Datasource)
             instance.container.register(:datasource, datasource)
@@ -458,7 +514,9 @@ module ForestAdminAgent
             allow(File).to receive(:write)
             allow(File).to receive(:read).with('/path/to/append.json').and_raise(Errno::ENOENT)
 
-            expect { instance.send_schema }.to raise_error(/Can't load additional schema/)
+            expect { instance.send_schema }.not_to raise_error
+
+            expect(logger).to have_received(:log).with('Warn', /Can't load additional schema/)
           end
 
           context 'with skip_schema_update enabled' do

--- a/packages/forest_admin_agent/spec/lib/forest_admin_agent/builder/agent_factory_spec.rb
+++ b/packages/forest_admin_agent/spec/lib/forest_admin_agent/builder/agent_factory_spec.rb
@@ -25,6 +25,22 @@ module ForestAdminAgent
             expect(described_class.instance.container.resolve(:logger)).to be_instance_of Services::LoggerService
           end
 
+          context 'when env_secret key is present but nil (e.g. an unconfigured sibling agent, like ' \
+                  'ForestAdminRpcAgent bundled but never set up)' do
+            it 'sets @has_env_secret to false and skips validation entirely, without warning or raising' do
+              instance = described_class.instance
+              logger = instance_spy(Services::LoggerService)
+              allow(Services::LoggerService).to receive(:new).and_return(logger)
+
+              expect do
+                instance.setup(auth_secret: nil, env_secret: nil, is_production: true)
+              end.not_to raise_error
+
+              expect(instance.has_env_secret).to be false
+              expect(logger).not_to have_received(:log).with('Warn', anything)
+            end
+          end
+
           context 'when env_secret is present but malformed' do
             let(:instance) { described_class.instance }
             let(:valid_options) do

--- a/packages/forest_admin_agent/spec/lib/forest_admin_agent/builder/agent_factory_spec.rb
+++ b/packages/forest_admin_agent/spec/lib/forest_admin_agent/builder/agent_factory_spec.rb
@@ -31,84 +31,127 @@ module ForestAdminAgent
               instance = described_class.instance
               logger = instance_spy(Services::LoggerService)
               allow(Services::LoggerService).to receive(:new).and_return(logger)
+              allow(Facades::Container).to receive(:cache).with(:skip_schema_update).and_return(false)
 
               expect do
                 instance.setup(auth_secret: nil, env_secret: nil, is_production: true)
               end.not_to raise_error
 
               expect(instance.has_env_secret).to be false
+
+              instance.send_schema
+
               expect(logger).not_to have_received(:log).with('Warn', anything)
             end
           end
 
-          context 'when env_secret is present but malformed' do
-            let(:instance) { described_class.instance }
-            let(:valid_options) do
-              {
-                auth_secret: 'cba803d01a4d43b55010cab41fa1ea1f1f51a95e',
-                env_secret: '89719c6d8e2e2de2694c2f220fe2dbf02d5289487364daf1e4c6b13733ed0cdb'
-              }
+          context 'with schema_only_mode enabled (offline schema generation, e.g. ' \
+                  'rake forest_admin:schema:generate)' do
+            it 'never validates secrets, even a malformed env_secret in production' do
+              instance = described_class.instance
+
+              expect do
+                instance.setup(
+                  auth_secret: 'cba803d01a4d43b55010cab41fa1ea1f1f51a95e',
+                  env_secret: 'not-a-valid-secret',
+                  is_production: true
+                )
+              end.not_to raise_error
+
+              instance.schema_only_mode = true
+              allow(instance).to receive(:generate_schema_only)
+
+              expect { instance.build }.not_to raise_error
+              expect(instance).to have_received(:generate_schema_only)
+            ensure
+              instance.schema_only_mode = false
+            end
+          end
+        end
+
+        context 'when env_secret is present but malformed' do
+          let(:instance) { described_class.instance }
+          let(:valid_options) do
+            {
+              auth_secret: 'cba803d01a4d43b55010cab41fa1ea1f1f51a95e',
+              env_secret: '89719c6d8e2e2de2694c2f220fe2dbf02d5289487364daf1e4c6b13733ed0cdb'
+            }
+          end
+
+          before do
+            allow(Facades::Container).to receive(:cache).with(:skip_schema_update).and_return(false)
+          end
+
+          context 'when running in production' do
+            let(:prod_options) { valid_options.merge(is_production: true) }
+
+            it 'raises a ValidationError when env_secret is too short' do
+              instance.setup(prod_options.merge(env_secret: 'abc123'))
+
+              expect { instance.send_schema }.to raise_error(
+                ForestAdminAgent::Http::Exceptions::ValidationError, /config\.env_secret is invalid/
+              )
             end
 
-            context 'when running in production' do
-              let(:prod_options) { valid_options.merge(is_production: true) }
+            it 'raises a ValidationError when env_secret contains the variable name (a common copy-paste mistake)' do
+              instance.setup(prod_options.merge(env_secret: "FOREST_ENV_SECRET=#{valid_options[:env_secret]}"))
 
-              it 'raises a ValidationError when env_secret is too short' do
-                expect do
-                  instance.setup(prod_options.merge(env_secret: 'abc123'))
-                end.to raise_error(ForestAdminAgent::Http::Exceptions::ValidationError, /config\.env_secret is invalid/)
-              end
-
-              it 'raises a ValidationError when env_secret contains the variable name (a common copy-paste mistake)' do
-                expect do
-                  instance.setup(prod_options.merge(env_secret: "FOREST_ENV_SECRET=#{valid_options[:env_secret]}"))
-                end.to raise_error(ForestAdminAgent::Http::Exceptions::ValidationError, /config\.env_secret is invalid/)
-              end
-
-              it 'raises a ValidationError when env_secret has uppercase characters' do
-                expect do
-                  instance.setup(prod_options.merge(env_secret: valid_options[:env_secret].upcase))
-                end.to raise_error(ForestAdminAgent::Http::Exceptions::ValidationError, /config\.env_secret is invalid/)
-              end
-
-              it 'raises a ValidationError when auth_secret is not a string' do
-                expect do
-                  instance.setup(prod_options.merge(auth_secret: 42))
-                end.to raise_error(ForestAdminAgent::Http::Exceptions::ValidationError, /config\.auth_secret is invalid/)
-              end
-
-              it 'does not raise when both secrets are well-formed' do
-                expect { instance.setup(prod_options) }.not_to raise_error
-              end
+              expect { instance.send_schema }.to raise_error(
+                ForestAdminAgent::Http::Exceptions::ValidationError, /config\.env_secret is invalid/
+              )
             end
 
-            context 'when running outside production' do
-              let(:dev_options) { valid_options.merge(is_production: false) }
+            it 'raises a ValidationError when env_secret has uppercase characters' do
+              instance.setup(prod_options.merge(env_secret: valid_options[:env_secret].upcase))
 
-              it 'does not raise, warns instead, and skips the schema sync' do
-                logger = instance_spy(Services::LoggerService)
-                allow(Services::LoggerService).to receive(:new).and_return(logger)
+              expect { instance.send_schema }.to raise_error(
+                ForestAdminAgent::Http::Exceptions::ValidationError, /config\.env_secret is invalid/
+              )
+            end
 
-                expect { instance.setup(dev_options.merge(env_secret: 'abc123')) }.not_to raise_error
+            it 'raises a ValidationError when auth_secret is not a string' do
+              instance.setup(prod_options.merge(auth_secret: 42))
 
-                expect(logger).to have_received(:log).with('Warn', /config\.env_secret is invalid/)
-                expect(logger).to have_received(:log).with('Warn', /Skipping schema sync/)
+              expect { instance.send_schema }.to raise_error(
+                ForestAdminAgent::Http::Exceptions::ValidationError, /config\.auth_secret is invalid/
+              )
+            end
 
-                allow(Facades::Container).to receive(:cache).with(:skip_schema_update).and_return(false)
-                allow(instance).to receive(:generate_schema_file)
-                instance.send_schema
+            it 'does not raise when both secrets are well-formed' do
+              instance.setup(prod_options)
+              allow(instance).to receive_messages(generate_schema_file: { meta: {}, collections: [] }, post_schema: nil)
+              allow(Facades::Container).to receive(:cache).with(:append_schema_path).and_return(nil)
 
-                expect(instance).not_to have_received(:generate_schema_file)
-              end
+              expect { instance.send_schema }.not_to raise_error
+            end
+          end
 
-              it 'does not raise and does not warn when both secrets are well-formed' do
-                logger = instance_spy(Services::LoggerService)
-                allow(Services::LoggerService).to receive(:new).and_return(logger)
+          context 'when running outside production' do
+            let(:dev_options) { valid_options.merge(is_production: false) }
 
-                expect { instance.setup(dev_options) }.not_to raise_error
+            it 'does not raise, warns instead, and skips the schema sync' do
+              logger = instance_spy(Services::LoggerService)
+              allow(Services::LoggerService).to receive(:new).and_return(logger)
+              instance.setup(dev_options.merge(env_secret: 'abc123'))
+              allow(instance).to receive(:generate_schema_file)
 
-                expect(logger).not_to have_received(:log).with('Warn', /is invalid/)
-              end
+              expect { instance.send_schema }.not_to raise_error
+
+              expect(logger).to have_received(:log).with('Warn', /config\.env_secret is invalid/)
+              expect(logger).to have_received(:log).with('Warn', /Skipping schema sync/)
+              expect(instance).not_to have_received(:generate_schema_file)
+            end
+
+            it 'does not raise and does not warn when both secrets are well-formed' do
+              logger = instance_spy(Services::LoggerService)
+              allow(Services::LoggerService).to receive(:new).and_return(logger)
+              instance.setup(dev_options)
+              allow(instance).to receive_messages(generate_schema_file: { meta: {}, collections: [] }, post_schema: nil)
+              allow(Facades::Container).to receive(:cache).with(:append_schema_path).and_return(nil)
+
+              expect { instance.send_schema }.not_to raise_error
+
+              expect(logger).not_to have_received(:log).with('Warn', /is invalid/)
             end
           end
         end

--- a/packages/forest_admin_agent/spec/lib/forest_admin_agent/builder/agent_factory_spec.rb
+++ b/packages/forest_admin_agent/spec/lib/forest_admin_agent/builder/agent_factory_spec.rb
@@ -543,12 +543,15 @@ module ForestAdminAgent
           end
 
           it 'logs success message and posts schema when successful' do
-            allow(client).to receive(:post).with('/forest/apimaps', api_map.to_json)
+            response = instance_double(Faraday::Response)
+            allow(client).to receive(:post).with('/forest/apimaps', api_map.to_json).and_return(response)
+            allow(client).to receive(:raise_for_response!).with(response)
 
             instance.send(:send_schema_to_server, api_map)
 
             expect(logger).to have_received(:log).with('Info', 'schema was updated, sending new version')
             expect(client).to have_received(:post).with('/forest/apimaps', api_map.to_json)
+            expect(client).to have_received(:raise_for_response!).with(response)
           end
 
           context 'when error occurs with HTTP status' do
@@ -600,6 +603,68 @@ module ForestAdminAgent
 
               expect(logger).to have_received(:log).with('Error', 'Failed to send schema: cannot reach ForestAdmin server')
             end
+          end
+        end
+
+        describe 'do_server_want_schema' do
+          let(:instance) { described_class.instance }
+          let(:client) { instance_double(ForestAdminAgent::Http::ForestAdminApiRequester) }
+
+          before do
+            allow(ForestAdminAgent::Http::ForestAdminApiRequester).to receive(:new).and_return(client)
+          end
+
+          it 'returns true when the server asks for the schema' do
+            response = instance_double(Faraday::Response, body: { sendSchema: true }.to_json)
+            allow(client).to receive(:post).and_return(response)
+            allow(client).to receive(:raise_for_response!).with(response)
+
+            expect(instance.send(:do_server_want_schema, 'abc123')).to be true
+          end
+
+          it 'returns false when the server already has this schema' do
+            response = instance_double(Faraday::Response, body: { sendSchema: false }.to_json)
+            allow(client).to receive(:post).and_return(response)
+            allow(client).to receive(:raise_for_response!).with(response)
+
+            expect(instance.send(:do_server_want_schema, 'abc123')).to be false
+          end
+
+          it 'propagates the error raised by raise_for_response! (e.g. an invalid envSecret)' do
+            response = instance_double(Faraday::Response, status: 404, body: '{"errors":[]}')
+            allow(client).to receive(:post).and_return(response)
+            allow(client).to receive(:raise_for_response!).with(response).and_raise(
+              ForestAdminAgent::Http::Exceptions::NotFoundError.new(
+                'ForestAdmin server failed to find the project related to the envSecret you configured. ' \
+                'Can you check that you copied it properly in the Forest initialization?'
+              )
+            )
+
+            expect do
+              instance.send(:do_server_want_schema, 'abc123')
+            end.to raise_error(ForestAdminAgent::Http::Exceptions::NotFoundError, /envSecret/)
+          end
+
+          it 'raises InternalServerError when the response body is not valid JSON' do
+            response = instance_double(Faraday::Response, status: 200, body: 'not json')
+            allow(client).to receive(:post).and_return(response)
+            allow(client).to receive(:raise_for_response!).with(response)
+
+            expect do
+              instance.send(:do_server_want_schema, 'abc123')
+            end.to raise_error(ForestAdminAgent::Http::Exceptions::InternalServerError, /Invalid JSON response/)
+          end
+
+          it 'delegates to handle_response_error when the connection itself fails' do
+            error = Faraday::ConnectionFailed.new('Failed to open TCP connection')
+            allow(client).to receive(:post).and_raise(error)
+            allow(client).to receive(:handle_response_error).with(error).and_raise(
+              ForestAdminAgent::Http::Exceptions::BadGatewayError.new('Failed to reach ForestAdmin server. Are you online?')
+            )
+
+            expect do
+              instance.send(:do_server_want_schema, 'abc123')
+            end.to raise_error(ForestAdminAgent::Http::Exceptions::BadGatewayError)
           end
         end
       end

--- a/packages/forest_admin_agent/spec/lib/forest_admin_agent/http/forest_admin_api_requester_spec.rb
+++ b/packages/forest_admin_agent/spec/lib/forest_admin_agent/http/forest_admin_api_requester_spec.rb
@@ -91,6 +91,12 @@ module ForestAdminAgent
             'An unexpected error occurred while contacting the ForestAdmin server. Please contact support@forestadmin.com for further investigations.'
           )
         end
+
+        it 'keeps the original error message in details for diagnostics' do
+          expect do
+            forest_admin_api_requester.handle_response_error(Faraday::ConnectionFailed.new('test', { status: 500 }))
+          end.to(raise_error { |error| expect(error.details[:message]).to eq('test') })
+        end
       end
 
       context 'when raise_for_response! is called' do
@@ -101,7 +107,7 @@ module ForestAdminAgent
         end
 
         it 'raises NotFoundError when the response status is 404 (e.g. an invalid envSecret)' do
-          response = instance_double(Faraday::Response, success?: false, status: 404)
+          response = instance_double(Faraday::Response, success?: false, status: 404, reason_phrase: 'Not Found')
 
           expect do
             forest_admin_api_requester.raise_for_response!(response)
@@ -112,7 +118,7 @@ module ForestAdminAgent
         end
 
         it 'raises BadGatewayError when the response status is 502' do
-          response = instance_double(Faraday::Response, success?: false, status: 502)
+          response = instance_double(Faraday::Response, success?: false, status: 502, reason_phrase: 'Bad Gateway')
 
           expect do
             forest_admin_api_requester.raise_for_response!(response)
@@ -123,7 +129,7 @@ module ForestAdminAgent
         end
 
         it 'raises ServiceUnavailableError when the response status is 503' do
-          response = instance_double(Faraday::Response, success?: false, status: 503)
+          response = instance_double(Faraday::Response, success?: false, status: 503, reason_phrase: 'Service Unavailable')
 
           expect do
             forest_admin_api_requester.raise_for_response!(response)
@@ -134,7 +140,7 @@ module ForestAdminAgent
         end
 
         it 'raises InternalServerError for any other error status' do
-          response = instance_double(Faraday::Response, success?: false, status: 500)
+          response = instance_double(Faraday::Response, success?: false, status: 500, reason_phrase: 'Internal Server Error')
 
           expect do
             forest_admin_api_requester.raise_for_response!(response)
@@ -142,6 +148,14 @@ module ForestAdminAgent
             ForestAdminAgent::Http::Exceptions::InternalServerError,
             'An unexpected error occurred while contacting the ForestAdmin server. Please contact support@forestadmin.com for further investigations.'
           )
+        end
+
+        it 'keeps the response reason phrase in details for diagnostics' do
+          response = instance_double(Faraday::Response, success?: false, status: 500, reason_phrase: 'Internal Server Error')
+
+          expect do
+            forest_admin_api_requester.raise_for_response!(response)
+          end.to(raise_error { |error| expect(error.details[:message]).to eq('Internal Server Error') })
         end
       end
     end

--- a/packages/forest_admin_agent/spec/lib/forest_admin_agent/http/forest_admin_api_requester_spec.rb
+++ b/packages/forest_admin_agent/spec/lib/forest_admin_agent/http/forest_admin_api_requester_spec.rb
@@ -92,6 +92,58 @@ module ForestAdminAgent
           )
         end
       end
+
+      context 'when raise_for_response! is called' do
+        it 'does nothing when the response is successful' do
+          response = instance_double(Faraday::Response, success?: true)
+
+          expect { forest_admin_api_requester.raise_for_response!(response) }.not_to raise_error
+        end
+
+        it 'raises NotFoundError when the response status is 404 (e.g. an invalid envSecret)' do
+          response = instance_double(Faraday::Response, success?: false, status: 404)
+
+          expect do
+            forest_admin_api_requester.raise_for_response!(response)
+          end.to raise_error(
+            ForestAdminAgent::Http::Exceptions::NotFoundError,
+            'ForestAdmin server failed to find the project related to the envSecret you configured. Can you check that you copied it properly in the Forest initialization?'
+          )
+        end
+
+        it 'raises BadGatewayError when the response status is 502' do
+          response = instance_double(Faraday::Response, success?: false, status: 502)
+
+          expect do
+            forest_admin_api_requester.raise_for_response!(response)
+          end.to raise_error(
+            ForestAdminAgent::Http::Exceptions::BadGatewayError,
+            'Failed to reach ForestAdmin server. Are you online?'
+          )
+        end
+
+        it 'raises ServiceUnavailableError when the response status is 503' do
+          response = instance_double(Faraday::Response, success?: false, status: 503)
+
+          expect do
+            forest_admin_api_requester.raise_for_response!(response)
+          end.to raise_error(
+            ForestAdminAgent::Http::Exceptions::ServiceUnavailableError,
+            'Forest is in maintenance for a few minutes. We are upgrading your experience in the forest. We just need a few more minutes to get it right.'
+          )
+        end
+
+        it 'raises InternalServerError for any other error status' do
+          response = instance_double(Faraday::Response, success?: false, status: 500)
+
+          expect do
+            forest_admin_api_requester.raise_for_response!(response)
+          end.to raise_error(
+            ForestAdminAgent::Http::Exceptions::InternalServerError,
+            'An unexpected error occurred while contacting the ForestAdmin server. Please contact support@forestadmin.com for further investigations.'
+          )
+        end
+      end
     end
   end
 end

--- a/packages/forest_admin_rails/config/initializers/forest_admin_error_subscriber.rb
+++ b/packages/forest_admin_rails/config/initializers/forest_admin_error_subscriber.rb
@@ -1,7 +1,12 @@
 class ForestAdminErrorSubscriber
-  def report(error, handled:, severity:, context:, source: nil)
-    return if ForestAdminAgent::Facades::Container.cache(:is_production)
+  SEVERITY_TO_LEVEL = {
+    error: 'Error',
+    warning: 'Warn',
+    info: 'Info'
+  }.freeze
 
-    ForestAdminAgent::Facades::Container.logger.log('Debug', error.full_message)
+  def report(error, handled:, severity:, context:, source: nil)
+    level = SEVERITY_TO_LEVEL.fetch(severity, 'Error')
+    ForestAdminAgent::Facades::Container.logger.log(level, "[ForestAdmin] #{error.full_message}")
   end
 end

--- a/packages/forest_admin_rails/lib/forest_admin_rails/engine.rb
+++ b/packages/forest_admin_rails/lib/forest_admin_rails/engine.rb
@@ -29,7 +29,7 @@ module ForestAdminRails
     end
 
     config.after_initialize do
-      Rails.error.handle(ForestAdminDatasourceToolkit::Exceptions::ForestException) do
+      Rails.error.handle(ForestAdminDatasourceToolkit::Exceptions::ForestException, severity: :error) do
         agent_factory = ForestAdminAgent::Builder::AgentFactory.instance
         agent_factory.setup(ForestAdminRails.config)
         load_configuration

--- a/packages/forest_admin_rails/spec/config/initializers/forest_admin_error_subscriber_spec.rb
+++ b/packages/forest_admin_rails/spec/config/initializers/forest_admin_error_subscriber_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+require 'logger'
+
+require_relative '../../../config/initializers/forest_admin_error_subscriber'
+
+RSpec.describe ForestAdminErrorSubscriber do
+  subject(:subscriber) { described_class.new }
+
+  let(:logger) { instance_double(Logger, log: nil) }
+  let(:error) { StandardError.new('envSecret invalid') }
+
+  before do
+    logger_double = logger
+    container = Class.new
+    container.define_singleton_method(:logger) { logger_double }
+    stub_const('ForestAdminAgent::Facades::Container', container)
+  end
+
+  it 'logs the error even when running in production' do
+    subscriber.report(error, handled: true, severity: :error, context: {})
+
+    expect(logger).to have_received(:log).with('Error', /envSecret invalid/)
+  end
+
+  it 'maps each Rails error severity to the matching Forest logger level' do
+    subscriber.report(error, handled: true, severity: :error, context: {})
+    expect(logger).to have_received(:log).with('Error', anything)
+
+    subscriber.report(error, handled: true, severity: :warning, context: {})
+    expect(logger).to have_received(:log).with('Warn', anything)
+
+    subscriber.report(error, handled: true, severity: :info, context: {})
+    expect(logger).to have_received(:log).with('Info', anything)
+  end
+
+  it 'defaults to Error when given an unknown severity' do
+    subscriber.report(error, handled: true, severity: :unknown, context: {})
+
+    expect(logger).to have_received(:log).with('Error', anything)
+  end
+end


### PR DESCRIPTION
## Context

PRD-878. A client (core-banking-system, staging) was installing a new Forest Admin environment and its schema never reached Forest, with no visible error in their application logs — the Rails app booted normally. Root cause on the client side: `FOREST_ENV_SECRET` was copied with the variable name included in the value.

## Root cause (gem side)

`ForestAdminApiRequester` builds its Faraday connection without the `raise_error` middleware, so a non-2xx HTTP response (e.g. a 404 "unknown secret key") never raises an exception. `AgentFactory#do_server_want_schema` just parsed the JSON body, found no `sendSchema` key, and treated it as "nothing to send" → logged `Info: Schema was not updated since last run`. The invalid secret was never detected, in any environment.

The HTTP-status-to-business-error mapping (`handle_response_error`, 404 → "invalid envSecret", etc.) already existed but was never reached on this path.

## Fix

1. `ForestAdminApiRequester#raise_for_response!(response)`: checks `response.success?` and raises the same typed errors `handle_response_error` already maps, without depending on the missing Faraday middleware. Called from both `do_server_want_schema` and `send_schema_to_server`.
2. `ForestAdminErrorSubscriber` (found while digging further): it dropped every log in production (`return if is_production` before any log) for `ForestException`s caught by `Rails.error.handle` at boot — invisible even on a real error. Logging is now unconditional, mapping the real Rails error `severity:` to the matching Forest logger level. `severity: :error` is now explicit on the `Rails.error.handle` call in `engine.rb`.
3. Addressed a review comment: the fallback `InternalServerError` was dropping the original error message from `details` — restored it (via `cause&.message` / `response.reason_phrase`).
4. `AgentFactory#send_schema` now validates `env_secret` (64-char lowercase hex) and `auth_secret` (must be a string) before syncing — mirroring the Node agent's `OptionsValidator`. This catches the exact client mistake (a secret copied with the variable name still glued to the value) instantly, without needing network access.
5. Both that format check and the actual server sync (`post_schema`) are handled the same way: **raise in production**, **warn and move on everywhere else**. A local secret typo, or a well-formed secret the server rejects (wrong project, revoked, network down), no longer blocks dev boot — logs two clear `[ForestAdmin] Warn` lines and skips the schema sync instead. The rescue is scoped to that HTTP sync call only (not the whole method), so a real local bug — a broken customization, an unwritable `schema_path`, a malformed `append_schema` file — still surfaces immediately in every environment instead of being logged as a generic warning (addressed after review feedback).
6. The validation only fires for a secret that was actually **configured** (non-nil), not merely present as a settings key, and it's checked from `send_schema` rather than `setup` so `schema_only_mode` (offline generation, e.g. `rake forest_admin:schema:generate`) never fails on a secret it doesn't need — both addressed after review feedback (Macroscope high-severity finding on the second one).

## Resulting behavior (confirmed intentional, see PRD-878)

- In production, any problem syncing the schema — malformed secret, well-formed secret rejected by the server, network down — crashes the Rails server boot with a clear message, consistent with how every other Forest setup error is already handled.
- Outside production, the same problems log two clear `Warn` lines and let the app boot normally, skipping only the schema sync until it's fixed. A genuine local bug (customization, file I/O) is never swallowed — it always raises, in every environment.
- An agent that was never configured at all (secret left `nil`) stays completely silent, in every environment — matching the pre-PR behavior.
- `schema_only_mode` (offline generation) never validates secrets at all, since it never talks to the server.

## Tests

- 785/785 `forest_admin_agent` tests green
- New spec `forest_admin_error_subscriber_spec.rb`
- No regression on `forest_admin_rails` / `forest_admin_datasource_customizer` (5 pre-existing `forest_admin_rails` failures confirmed identical on `main`, unrelated — missing gems locally)
- Rebased on latest `main`
- Reproduced and validated live on real Rails boots, in every combination: invalid-format secret in prod → crash; well-formed-but-wrong secret in prod → crash; either case outside production → warns and boots normally (app still serves traffic); unconfigured `forest_admin_rpc_agent` bundled in `_examples/demo` → no spurious warnings; valid secret → clean boot, no regression

Closes PRD-878

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Surface HTTP errors during schema sync instead of silently skipping
> - Adds `raise_for_response!` to `ForestAdminApiRequester` that maps non-2xx HTTP responses to typed exceptions (`NotFoundError`, `BadGatewayError`, `ServiceUnavailableError`, `InternalServerError`); `do_server_want_schema` and `send_schema_to_server` now call this instead of ignoring failures.
> - Validates `env_secret` format (64-char lowercase hex) and `auth_secret` type before attempting schema sync; in production, invalid config raises `ValidationError`, while non-production logs a warning and skips sync.
> - Fixes `@has_env_secret` to be `false` when `env_secret` is `nil` (previously a nil secret was treated as present).
> - Updates `ForestAdminErrorSubscriber` to log in all environments (including production) with severity mapping; previously errors were silently dropped in production.
> - Behavioral Change: schema sync errors that were previously swallowed in production are now re-raised, which may surface startup failures that were previously hidden.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9225c8e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->