### PR TITLE
docs: add new-package checklist to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,5 +47,5 @@ releases silently, not loudly:
    - the codecov step's `files:` list (`.../<package>/coverage.json`)
 
 After merging, verify the next release actually bumps the new `version.rb` —
-the sed in step 3 silently no-ops if the format from step 1 is off, with no
+the sed in step 4 silently no-ops if the format from step 1 is off, with no
 CI failure to catch it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,22 +17,31 @@ releases silently, not loudly:
    Double quotes, no `.freeze`. The release sed in `.releaserc.js` only
    matches this exact format.
 
-2. **`.rubocop.yml`** — add the new `version.rb` to:
+2. **New `.gemspec`** — explicitly opt out of RubyGems MFA, matching every
+   other package:
+   ```ruby
+   spec.metadata['rubygems_mfa_required'] = 'false'
+   ```
+   Gem publishing runs unattended from CI (`.releaserc.js`), so it can't
+   satisfy an MFA prompt.
+
+3. **`.rubocop.yml`** — add the new `version.rb` to:
    - `Style/MutableConstant` Exclude
    - `Style/StringLiterals` Exclude
 
-   And the new `.gemspec` to `Gemspec/RequireMFA` Exclude.
+   And the new `.gemspec` to `Gemspec/RequireMFA` Exclude — the cop flags
+   the `'false'` opt-out from step 2 as an offense, so it needs suppressing.
 
    (Other per-file excludes — `Metrics/MethodLength`, `Metrics/BlockLength`,
    `Naming/PredicatePrefix` — are added case-by-case only if the cop actually
    fires; don't copy them blindly.)
 
-3. **`.releaserc.js`** — add the package in all three spots:
+4. **`.releaserc.js`** — add the package in all three spots:
    - `prepareCmd`: `sed -i 's/VERSION = ".*"/VERSION = "${nextRelease.version}"/g' packages/<package>/lib/<package>/version.rb;`
    - `successCmd`: `( cd packages/<package> && gem build && gem push <package>-*.gem );`
    - `@semantic-release/git` `assets`: `packages/<package>/lib/<package>/version.rb`
 
-4. **`.github/workflows/build.yml`** — add the package name to:
+5. **`.github/workflows/build.yml`** — add the package name to:
    - the `lint` job's `packages` matrix
    - the `test` job's `packages` matrix
    - the codecov step's `files:` list (`.../<package>/coverage.json`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,42 @@
+# CLAUDE.md
+
+## Adding a new package to the monorepo
+
+When scaffolding a new `packages/forest_admin_datasource_*` (or any new)
+package, mirror an existing package's scaffold (`Gemfile`, `Gemfile-test`,
+`Rakefile`, `.rspec`, gemspec, `LICENSE`, `spec/spec_helper.rb`, `.gitignore`)
+and update every one of these in the same PR — missing one breaks CI or
+releases silently, not loudly:
+
+1. **`lib/<package>/version.rb`** — must be exactly:
+   ```ruby
+   module <Module>
+     VERSION = "0.1.0"
+   end
+   ```
+   Double quotes, no `.freeze`. The release sed in `.releaserc.js` only
+   matches this exact format.
+
+2. **`.rubocop.yml`** — add the new `version.rb` to:
+   - `Style/MutableConstant` Exclude
+   - `Style/StringLiterals` Exclude
+
+   And the new `.gemspec` to `Gemspec/RequireMFA` Exclude.
+
+   (Other per-file excludes — `Metrics/MethodLength`, `Metrics/BlockLength`,
+   `Naming/PredicatePrefix` — are added case-by-case only if the cop actually
+   fires; don't copy them blindly.)
+
+3. **`.releaserc.js`** — add the package in all three spots:
+   - `prepareCmd`: `sed -i 's/VERSION = ".*"/VERSION = "${nextRelease.version}"/g' packages/<package>/lib/<package>/version.rb;`
+   - `successCmd`: `( cd packages/<package> && gem build && gem push <package>-*.gem );`
+   - `@semantic-release/git` `assets`: `packages/<package>/lib/<package>/version.rb`
+
+4. **`.github/workflows/build.yml`** — add the package name to:
+   - the `lint` job's `packages` matrix
+   - the `test` job's `packages` matrix
+   - the codecov step's `files:` list (`.../<package>/coverage.json`)
+
+After merging, verify the next release actually bumps the new `version.rb` —
+the sed in step 3 silently no-ops if the format from step 1 is off, with no
+CI failure to catch it.


### PR DESCRIPTION
## What

Adds a root `CLAUDE.md` with a checklist for scaffolding a new `packages/*` gem.

## Why

PR #343 (new `forest_admin_datasource_graphql_hasura` package) missed the `.rubocop.yml` exclusions for its `version.rb`, and shipped that file with a format (`VERSION = '1.0.0'.freeze`) that silently breaks the `.releaserc.js` version-bump sed — no CI failure catches either issue. This isn't the first time these steps have been missed when a package is scaffolded; they're currently tribal knowledge copy-pasted from the last package rather than documented anywhere.

## What's covered

- `version.rb` exact format (matches the release sed)
- `.rubocop.yml` exclusions to add
- `.releaserc.js` entries (3 spots)
- `.github/workflows/build.yml` CI matrices + coverage list

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add new-package checklist to CLAUDE.md
> Documents the required steps when adding a new package to the monorepo in [CLAUDE.md](https://github.com/ForestAdmin/agent-ruby/pull/345/files#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7). Covers version file format, RuboCop excludes, semantic-release config updates, and CI workflow matrix and coverage path entries.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #345 opened
>
> - Added checklist step requiring `spec.metadata['rubygems_mfa_required']` set to `'false'` in new `.gemspec` files with explanation that CI publishing is unattended [6ee9b00]
> - Updated RuboCop configuration requirements to exclude new `version.rb` from `Style/MutableConstant` and `Style/StringLiterals` cops and add new `.gemspec` to `Gemspec/RequireMFA` Exclude list [6ee9b00]
> - Renumbered subsequent checklist steps from step 3 to step 5, changing `.releaserc.js` to step 4 and `.github/workflows/build.yml` to step 5 [6ee9b00]
> - Corrected step reference in documentation note about `sed` command behavior [bf1bcfb]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 6ee9b00. 1 file reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->