### PR TITLE
chore(security): patch 3 Dependabot alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
   },
   "resolutions": {
     "semantic-release-slack-bot/**/micromatch": "^4.0.8",
-    "brace-expansion": "^5.0.7"
+    "brace-expansion": "^5.0.7",
+    "fast-uri": "^3.1.4",
+    "tar": "^7.5.21"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1490,10 +1490,10 @@ fast-deep-equal@^3.1.3:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
-fast-uri@^3.0.1:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.2.tgz#8af3d4fc9d3e71b11572cc2673b514a7d1a8c8ec"
-  integrity sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==
+fast-uri@^3.0.1, fast-uri@^3.1.4:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.5.tgz#610f37419a030270430cecd68d74e3d4d96725d0"
+  integrity sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==
 
 fastest-levenshtein@^1.0.16:
   version "1.0.16"
@@ -3824,10 +3824,10 @@ tagged-tag@^1.0.0:
   resolved "https://registry.yarnpkg.com/tagged-tag/-/tagged-tag-1.0.0.tgz#a0b5917c2864cba54841495abfa3f6b13edcf4d6"
   integrity sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==
 
-tar@^7.4.3, tar@^7.5.1, tar@^7.5.13, tar@^7.5.4:
-  version "7.5.19"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-7.5.19.tgz#d8915e6b717f8036a79d839ca9448198b002b0a7"
-  integrity sha512-4LeEWl96twnS2Q7Bz4MGqgazLqO+hJN63GZxXoIqh1T3VweYD997gbU1ItNsQafqqXTXd5WFyFdReLtwvRBNiw==
+tar@^7.4.3, tar@^7.5.1, tar@^7.5.13, tar@^7.5.21, tar@^7.5.4:
+  version "7.5.22"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-7.5.22.tgz#a696f998136e71487dc3f869a85bba2c67971ba9"
+  integrity sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==
   dependencies:
     "@isaacs/fs-minipass" "^4.0.0"
     chownr "^3.0.0"


### PR DESCRIPTION
> 👋 First-level support: see [Handling automated security PRs](https://forest.slite.com/app/docs/rmjdwFgmV2RzUp) for how to triage and merge this PR.

## Summary

3 fixed, 0 ignored, 12 deferred, 0 security pins added, 0 security pins removed, 0 could-not-auto-fix. | label: :lock: security applied

## Fixed

| Done | Alert | Gem | Ecosystem | From → To | Severity | What was bumped |
| --- | --- | --- | --- | --- | --- | --- |
| - [ ] | [#91](https://github.com/ForestAdmin/agent-ruby/security/dependabot/91) | fast-uri | npm | 3.1.2 → 3.1.5 | high | Added root `resolutions["fast-uri"] = "^3.1.4"` in `package.json` (transitive via `@commitlint/cli` → `@commitlint/load` → `@commitlint/config-validator` → `ajv`). Yarn resolved to 3.1.5 (latest 3.x). Transitive-only, dev-tooling ecosystem — root `package.json` is dev-only and does not ship to gem consumers. |
| - [ ] | [#92](https://github.com/ForestAdmin/agent-ruby/security/dependabot/92) | fast-uri | npm | 3.1.2 → 3.1.5 | high | Same bump as [#91](https://github.com/ForestAdmin/agent-ruby/security/dependabot/92) — the ^3.1.4 resolution covers both advisories (patched 3.1.3 and 3.1.4 respectively). |
| - [ ] | [#93](https://github.com/ForestAdmin/agent-ruby/security/dependabot/93) | tar (node-tar) | npm | 7.5.19 → 7.5.22 | medium | Added root `resolutions["tar"] = "^7.5.21"` in `package.json` (transitive via `semantic-release` → `@semantic-release/npm` → `npm` → `tar`/`pacote`/`libnpmdiff`/`node-gyp`). Yarn resolved to 7.5.22 (latest 7.x). Transitive-only, dev-tooling ecosystem — does not ship to gem consumers. |

## Ignored

None.

## Deferred

Skipped by the 7-day age gate (opened < 7 days ago at run time on 2026-08-06); will be picked up by the next scheduled run:

- [#95](https://github.com/ForestAdmin/agent-ruby/security/dependabot/95) — ip-address (medium)
- [#96](https://github.com/ForestAdmin/agent-ruby/security/dependabot/96) — ip-address (medium)
- [#97](https://github.com/ForestAdmin/agent-ruby/security/dependabot/97) — fast-uri (high) *(incidentally satisfied by this run's fast-uri 3.1.5 resolve; the alert will close on merge, but it is not tracked here per the age-gate rule)*
- [#98](https://github.com/ForestAdmin/agent-ruby/security/dependabot/98) — undici (high)
- [#99](https://github.com/ForestAdmin/agent-ruby/security/dependabot/99) — undici (medium)
- [#100](https://github.com/ForestAdmin/agent-ruby/security/dependabot/100) — undici (medium)
- [#101](https://github.com/ForestAdmin/agent-ruby/security/dependabot/101) — undici (medium)
- [#102](https://github.com/ForestAdmin/agent-ruby/security/dependabot/102) — undici (medium)
- [#103](https://github.com/ForestAdmin/agent-ruby/security/dependabot/103) — undici (medium)
- [#104](https://github.com/ForestAdmin/agent-ruby/security/dependabot/104) — undici (medium)
- [#105](https://github.com/ForestAdmin/agent-ruby/security/dependabot/105) — undici (medium)
- [#106](https://github.com/ForestAdmin/agent-ruby/security/dependabot/106) — ip-address (high)

## Security pins added

None.

## Security pins removed

None (no `# security pin` comments found in any `Gemfile` at audit time).

## Could not auto-fix

None.

## Risks

- **fast-uri 3.1.2 → 3.1.5**: patch-level bumps within 3.x. Upstream releases 3.1.3–3.1.5 target authority-parser hardening (backslash / IDN canonicalization / URL parsing corner cases). No API changes touching us — fast-uri is used exclusively by `ajv` (schema validation inside `@commitlint`), which we invoke only via `commitlint` CLI in commit-message linting. No behavior change expected beyond the patched vulnerabilities.
- **tar 7.5.19 → 7.5.22**: patch-level bumps within 7.5.x. Upstream 7.5.21 fixes the uncontrolled-recursion DoS in `mapHas`/`filesFilter`. No API surface change; tar is a transitive dep of `semantic-release`'s npm publish path, exercised only by CI's release step. No behavior change beyond the patched vulnerability.

## Manual testing

Covered by CI.

## Validation

✅ CI green (Actions + commit statuses; app-based checks not monitored)