### PR TITLE
fix(agent): authorize and scope related read routes on the target collection

### DIFF
--- a/packages/forest_admin_agent/lib/forest_admin_agent/routes/resources/related/count_related.rb
+++ b/packages/forest_admin_agent/lib/forest_admin_agent/routes/resources/related/count_related.rb
@@ -22,10 +22,10 @@ module ForestAdminAgent
 
           def handle_request(args = {})
             context = build(args)
-            context.permissions.can?(:browse, context.collection)
+            context.permissions.can?(:browse, context.child_collection)
 
             if context.child_collection.is_countable?
-              filter = Filter.new(condition_tree: context.permissions.get_scope(context.collection))
+              filter = Filter.new(condition_tree: context.permissions.get_scope(context.child_collection))
               primary_key_values = Utils::Id.unpack_id(context.collection, args[:params]['id'], with_key: true)
               result = Collection.aggregate_relation(
                 context.collection,

--- a/packages/forest_admin_agent/lib/forest_admin_agent/routes/resources/related/csv_related.rb
+++ b/packages/forest_admin_agent/lib/forest_admin_agent/routes/resources/related/csv_related.rb
@@ -21,13 +21,13 @@ module ForestAdminAgent
 
           def handle_request(args = {})
             context = build(args)
-            context.permissions.can?(:browse, context.collection)
-            context.permissions.can?(:export, context.collection)
+            context.permissions.can?(:browse, context.child_collection)
+            context.permissions.can?(:export, context.child_collection)
 
             filter = ForestAdminDatasourceToolkit::Components::Query::Filter.new(
               condition_tree: ConditionTreeFactory.intersect(
                 [
-                  context.permissions.get_scope(context.collection),
+                  context.permissions.get_scope(context.child_collection),
                   ForestAdminAgent::Utils::QueryStringParser.parse_condition_tree(context.child_collection, args)
                 ]
               )

--- a/packages/forest_admin_agent/lib/forest_admin_agent/routes/resources/related/list_related.rb
+++ b/packages/forest_admin_agent/lib/forest_admin_agent/routes/resources/related/list_related.rb
@@ -22,12 +22,12 @@ module ForestAdminAgent
 
           def handle_request(args = {})
             context = build(args)
-            context.permissions.can?(:browse, context.collection)
+            context.permissions.can?(:browse, context.child_collection)
 
             filter = ForestAdminDatasourceToolkit::Components::Query::Filter.new(
               condition_tree: ConditionTreeFactory.intersect(
                 [
-                  context.permissions.get_scope(context.collection),
+                  context.permissions.get_scope(context.child_collection),
                   ForestAdminAgent::Utils::QueryStringParser.parse_condition_tree(context.child_collection, args)
                 ]
               ),

--- a/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/resources/related/count_related_spec.rb
+++ b/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/resources/related/count_related_spec.rb
@@ -102,6 +102,29 @@ module ForestAdminAgent
             end
           end
 
+          context 'when checking permissions and scope' do
+            it 'authorizes and scopes on the related collection, not the parent' do
+              args[:params]['relation_name'] = 'category'
+              args[:params]['id'] = 1
+              ForestAdminAgent::Facades::Container.datasource.get_collection('category').enable_count
+              allow(permissions).to receive(:get_scope)
+                .and_return(Nodes::ConditionTreeLeaf.new('label', Operators::EQUAL, 'active'))
+              allow(ForestAdminDatasourceToolkit::Utils::Collection).to receive(:aggregate_relation)
+                .and_return([{ value: 1 }])
+              count.handle_request(args)
+
+              expect(permissions).to have_received(:can?).with(:browse, having_attributes(name: 'category'))
+              expect(permissions).not_to have_received(:can?).with(:browse, having_attributes(name: 'user'))
+              expect(permissions).to have_received(:get_scope).with(having_attributes(name: 'category'))
+              expect(ForestAdminDatasourceToolkit::Utils::Collection).to have_received(:aggregate_relation) do
+              |_collection, _id, _relation_name, _caller, foreign_filter, _aggregation|
+                expect(foreign_filter.condition_tree).to have_attributes(
+                  field: 'label', operator: Operators::EQUAL, value: 'active'
+                )
+              end
+            end
+          end
+
           context 'when collection is not countable' do
             it 'return response without call aggregate_relation' do
               args[:params]['relation_name'] = 'category'

--- a/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/resources/related/count_related_spec.rb
+++ b/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/resources/related/count_related_spec.rb
@@ -110,12 +110,14 @@ module ForestAdminAgent
               allow(permissions).to receive(:get_scope)
                 .and_return(Nodes::ConditionTreeLeaf.new('label', Operators::EQUAL, 'active'))
               allow(ForestAdminDatasourceToolkit::Utils::Collection).to receive(:aggregate_relation)
-                .and_return([{ value: 1 }])
-              count.handle_request(args)
+                .and_return([{ 'value' => 1 }])
+              result = count.handle_request(args)
 
+              expect(result[:content]).to eq({ count: 1 })
               expect(permissions).to have_received(:can?).with(:browse, having_attributes(name: 'category'))
               expect(permissions).not_to have_received(:can?).with(:browse, having_attributes(name: 'user'))
               expect(permissions).to have_received(:get_scope).with(having_attributes(name: 'category'))
+              expect(permissions).not_to have_received(:get_scope).with(having_attributes(name: 'user'))
               expect(ForestAdminDatasourceToolkit::Utils::Collection).to have_received(:aggregate_relation) do
               |_collection, _id, _relation_name, _caller, foreign_filter, _aggregation|
                 expect(foreign_filter.condition_tree).to have_attributes(

--- a/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/resources/related/csv_related_spec.rb
+++ b/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/resources/related/csv_related_spec.rb
@@ -132,6 +132,7 @@ module ForestAdminAgent
               expect(permissions).to have_received(:can?).with(:export, having_attributes(name: 'category'))
               expect(permissions).not_to have_received(:can?).with(anything, having_attributes(name: 'user'))
               expect(permissions).to have_received(:get_scope).with(having_attributes(name: 'category'))
+              expect(permissions).not_to have_received(:get_scope).with(having_attributes(name: 'user'))
               expect(captured_filter.condition_tree).to have_attributes(
                 field: 'label', operator: Operators::EQUAL, value: 'active'
               )

--- a/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/resources/related/csv_related_spec.rb
+++ b/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/resources/related/csv_related_spec.rb
@@ -114,6 +114,29 @@ module ForestAdminAgent
               expect(result[:content][:headers]['Content-Disposition']).to match(/attachment; filename="user_category_export_\d{8}_\d{6}\.csv"/)
             end
 
+            it 'authorizes and scopes on the related collection, not the parent' do
+              args[:params]['relation_name'] = 'category'
+              args[:params]['id'] = 1
+              allow(permissions).to receive(:get_scope)
+                .and_return(Nodes::ConditionTreeLeaf.new('label', Operators::EQUAL, 'active'))
+
+              captured_filter = nil
+              allow(csv_generator_stream).to receive(:stream) do |_header, filter, _projection, _list_records, _limit|
+                captured_filter = filter
+                ["id,label\n"].to_enum
+              end
+
+              csv.handle_request(args)
+
+              expect(permissions).to have_received(:can?).with(:browse, having_attributes(name: 'category'))
+              expect(permissions).to have_received(:can?).with(:export, having_attributes(name: 'category'))
+              expect(permissions).not_to have_received(:can?).with(anything, having_attributes(name: 'user'))
+              expect(permissions).to have_received(:get_scope).with(having_attributes(name: 'category'))
+              expect(captured_filter.condition_tree).to have_attributes(
+                field: 'label', operator: Operators::EQUAL, value: 'active'
+              )
+            end
+
             it 'passes a lambda to stream that calls list_relation with correct parameters' do
               args[:params]['relation_name'] = 'category'
               args[:params]['id'] = 1

--- a/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/resources/related/list_related_spec.rb
+++ b/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/resources/related/list_related_spec.rb
@@ -117,6 +117,7 @@ module ForestAdminAgent
               expect(permissions).to have_received(:can?).with(:browse, having_attributes(name: 'category'))
               expect(permissions).not_to have_received(:can?).with(:browse, having_attributes(name: 'user'))
               expect(permissions).to have_received(:get_scope).with(having_attributes(name: 'category'))
+              expect(permissions).not_to have_received(:get_scope).with(having_attributes(name: 'user'))
               expect(ForestAdminDatasourceToolkit::Utils::Collection).to have_received(:list_relation) do
               |_collection, _id, _relation_name, _caller, foreign_filter, _projection|
                 expect(foreign_filter.condition_tree).to have_attributes(

--- a/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/resources/related/list_related_spec.rb
+++ b/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/resources/related/list_related_spec.rb
@@ -105,6 +105,27 @@ module ForestAdminAgent
             end
           end
 
+          context 'when checking permissions and scope' do
+            it 'authorizes and scopes on the related collection, not the parent' do
+              args[:params]['relation_name'] = 'category'
+              args[:params]['id'] = 1
+              allow(permissions).to receive(:get_scope)
+                .and_return(Nodes::ConditionTreeLeaf.new('label', Operators::EQUAL, 'active'))
+              allow(ForestAdminDatasourceToolkit::Utils::Collection).to receive(:list_relation).and_return([])
+              list.handle_request(args)
+
+              expect(permissions).to have_received(:can?).with(:browse, having_attributes(name: 'category'))
+              expect(permissions).not_to have_received(:can?).with(:browse, having_attributes(name: 'user'))
+              expect(permissions).to have_received(:get_scope).with(having_attributes(name: 'category'))
+              expect(ForestAdminDatasourceToolkit::Utils::Collection).to have_received(:list_relation) do
+              |_collection, _id, _relation_name, _caller, foreign_filter, _projection|
+                expect(foreign_filter.condition_tree).to have_attributes(
+                  field: 'label', operator: Operators::EQUAL, value: 'active'
+                )
+              end
+            end
+          end
+
           context 'when call with filters' do
             it 'call list_relation with expected args' do
               args[:params]['relation_name'] = 'category'


### PR DESCRIPTION
## Problem

Fixes [PRD-897](https://linear.app/forestadmin/issue/PRD-897/agent-ruby-related-read-routes-authorize-and-scope-on-the-parent).

The three read routes on relations — `list_related`, `csv_related`, `count_related` — checked permissions and applied the scope on the **parent** collection (`context.collection`) while returning records from the **related** collection (`context.child_collection`). Two consequences:

- **Permission bypass**: a role with no access at all to `orders` could list, export and count a user's orders through `/user/1/relationships/orders`, as long as it had `browse` on `user`.
- **Wrong scope applied**: the parent's scope condition tree (expressed in the parent's field names) was intersected unnested into the foreign filter, so it was evaluated against the **child's** columns — erroring when the field doesn't exist, or silently filtering on the wrong field when names collide (`status`, `company_id`, …).

`agent-nodejs` settled this model in 2023 (`14b4e3e1`, #823): you authorize the collection whose data you return. The write route next door (`dissociate_related.rb`) already uses `context.child_collection`; the three read routes were inconsistent with it.

## Fix

Use `context.child_collection` for both `can?` and `get_scope` in the three routes. The scope is now expressed in the target collection's fields and applied to the target collection, so no nesting is needed.

## Tests

One new example per route asserting that `can?` and `get_scope` receive the related collection (never the parent), and that a realistic scope ends up in the filter passed to `list_relation` / `aggregate_relation` / the CSV stream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix authorization and scoping to target the related collection in related record routes
> The `handle_request` methods in `CountRelated`, `ListRelated`, and `CsvRelated` were checking permissions and applying scope against the parent collection instead of the child (related) collection. This fix replaces `context.collection` with `context.child_collection` in all `permissions.can?` and `permissions.get_scope` calls across these three route handlers. Tests are added for each handler to verify that authorization and scope are evaluated on the related collection.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 91596a7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

## Behavior notes (from adversarial review)

- The parent `browse` check is **swapped** for the child check, not supplemented — same semantics as agent-nodejs since #823. Traversing from a parent record outside the caller's scope (`/user/999/relationships/orders`) remains possible on both agents; tracked separately (PRD-907 area).
- Deployments that relied on the parent's scope accidentally tenant-filtering the child (same-named field like `company_id`) must define the scope on the target collection — the buggy cross-collection filtering is gone.
- `count_related` now requires `browse` on the **target**, which is stricter than agent-nodejs HEAD (whose count-related still checks the parent — that's PRD-898).
