### PR TITLE
fix(security): enforce authentication and IP whitelist on private routes [PRD-896]

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,6 +71,7 @@ jobs:
           - forest_admin_datasource_active_record
           - forest_admin_datasource_customizer
           - forest_admin_datasource_toolkit
+          - forest_admin_rails
           - forest_admin_datasource_mongoid
           - forest_admin_rpc_agent
           - forest_admin_datasource_rpc
@@ -145,7 +146,7 @@ jobs:
         with:
           verbose: true
           oidc: true
-          files: ${{ github.workspace }}/reports/${{ matrix.ruby-version }}-forest_admin_agent/coverage.json,${{ github.workspace }}/reports/${{ matrix.ruby-version }}-forest_admin_datasource_active_record/coverage.json,${{ github.workspace }}/reports/${{ matrix.ruby-version }}-forest_admin_datasource_customizer/coverage.json,${{ github.workspace }}/reports/${{ matrix.ruby-version }}-forest_admin_datasource_toolkit/coverage.json,${{ github.workspace }}/reports/${{ matrix.ruby-version }}-forest_admin_datasource_mongoid/coverage.json,${{ github.workspace }}/reports/${{ matrix.ruby-version }}-forest_admin_rpc_agent/coverage.json,${{ github.workspace }}/reports/${{ matrix.ruby-version }}-forest_admin_datasource_rpc/coverage.json,${{ github.workspace }}/reports/${{ matrix.ruby-version }}-forest_admin_datasource_zendesk/coverage.json,${{ github.workspace }}/reports/${{ matrix.ruby-version }}-forest_admin_datasource_snowflake/coverage.json,${{ github.workspace }}/reports/${{ matrix.ruby-version }}-forest_admin_datasource_mambu_payments/coverage.json,${{ github.workspace }}/reports/${{ matrix.ruby-version }}-forest_admin_datasource_graphql_hasura/coverage.json
+          files: ${{ github.workspace }}/reports/${{ matrix.ruby-version }}-forest_admin_agent/coverage.json,${{ github.workspace }}/reports/${{ matrix.ruby-version }}-forest_admin_datasource_active_record/coverage.json,${{ github.workspace }}/reports/${{ matrix.ruby-version }}-forest_admin_datasource_customizer/coverage.json,${{ github.workspace }}/reports/${{ matrix.ruby-version }}-forest_admin_datasource_toolkit/coverage.json,${{ github.workspace }}/reports/${{ matrix.ruby-version }}-forest_admin_rails/coverage.json,${{ github.workspace }}/reports/${{ matrix.ruby-version }}-forest_admin_datasource_mongoid/coverage.json,${{ github.workspace }}/reports/${{ matrix.ruby-version }}-forest_admin_rpc_agent/coverage.json,${{ github.workspace }}/reports/${{ matrix.ruby-version }}-forest_admin_datasource_rpc/coverage.json,${{ github.workspace }}/reports/${{ matrix.ruby-version }}-forest_admin_datasource_zendesk/coverage.json,${{ github.workspace }}/reports/${{ matrix.ruby-version }}-forest_admin_datasource_snowflake/coverage.json,${{ github.workspace }}/reports/${{ matrix.ruby-version }}-forest_admin_datasource_mambu_payments/coverage.json,${{ github.workspace }}/reports/${{ matrix.ruby-version }}-forest_admin_datasource_graphql_hasura/coverage.json
 
   deploy:
     name: Release package

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -131,7 +131,10 @@ jobs:
     needs: [test]
     strategy:
       matrix:
-        ruby-version: ["3.4"]
+        # Must match the ruby-version the test job uploads artifacts for
+        # (the `if` on its "Upload coverage" step), or every file path below
+        # resolves to nothing and qlty silently sends zero coverage.
+        ruby-version: ["4.0"]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/packages/forest_admin_agent/lib/forest_admin_agent/routes/capabilities/collections.rb
+++ b/packages/forest_admin_agent/lib/forest_admin_agent/routes/capabilities/collections.rb
@@ -2,7 +2,7 @@ require 'json'
 module ForestAdminAgent
   module Routes
     module Capabilities
-      class Collections < AbstractRoute
+      class Collections < AbstractAuthenticatedRoute
         include ForestAdminDatasourceToolkit::Schema
         include ForestAdminDatasourceToolkit::Schema::Relations
 
@@ -16,6 +16,7 @@ module ForestAdminAgent
         end
 
         def handle_request(args = {})
+          build(args)
           datasource = ForestAdminAgent::Facades::Container.datasource
           collections = args[:params]['collectionNames'] || []
 

--- a/packages/forest_admin_agent/lib/forest_admin_agent/routes/capabilities/collections.rb
+++ b/packages/forest_admin_agent/lib/forest_admin_agent/routes/capabilities/collections.rb
@@ -16,8 +16,8 @@ module ForestAdminAgent
         end
 
         def handle_request(args = {})
-          build(args)
-          datasource = ForestAdminAgent::Facades::Container.datasource
+          context = build(args)
+          datasource = context.datasource
           collections = args[:params]['collectionNames'] || []
 
           connections = datasource.live_query_connections.keys.map { |connection_name| { name: connection_name } }

--- a/packages/forest_admin_agent/lib/forest_admin_agent/routes/charts/api_chart_datasource.rb
+++ b/packages/forest_admin_agent/lib/forest_admin_agent/routes/charts/api_chart_datasource.rb
@@ -37,14 +37,13 @@ module ForestAdminAgent
         end
 
         def handle_api_chart(args = {})
-          caller = Utils::QueryStringParser.parse_caller(args)
+          context = build(args)
           parameters = Utils::QueryStringParser.parse_chart_parameters(args)
-          datasource = ForestAdminAgent::Facades::Container.datasource
 
           {
             content: Serializer::ForestChartSerializer.serialize(
-              datasource.render_chart(
-                caller,
+              context.datasource.render_chart(
+                context.caller,
                 @chart_name,
                 parameters
               )
@@ -53,13 +52,12 @@ module ForestAdminAgent
         end
 
         def handle_smart_chart(args = {})
-          caller = Utils::QueryStringParser.parse_caller(args)
+          context = build(args)
           parameters = Utils::QueryStringParser.parse_chart_parameters(args)
-          datasource = ForestAdminAgent::Facades::Container.datasource
 
           {
-            content: datasource.render_chart(
-              caller,
+            content: context.datasource.render_chart(
+              context.caller,
               @chart_name,
               parameters
             )

--- a/packages/forest_admin_agent/lib/forest_admin_agent/routes/security/scope_invalidation.rb
+++ b/packages/forest_admin_agent/lib/forest_admin_agent/routes/security/scope_invalidation.rb
@@ -1,7 +1,7 @@
 module ForestAdminAgent
   module Routes
     module Security
-      class ScopeInvalidation < AbstractRoute
+      class ScopeInvalidation < AbstractAuthenticatedRoute
         include ForestAdminAgent::Builder
         include ForestAdminAgent::Services
 
@@ -17,8 +17,7 @@ module ForestAdminAgent
         end
 
         def handle_request(args)
-          # Check if user is logged
-          Utils::QueryStringParser.parse_caller(args)
+          build(args)
           Permissions.invalidate_cache('forest.rendering')
 
           { content: nil, status: 204 }

--- a/packages/forest_admin_agent/lib/forest_admin_agent/utils/caller_parser.rb
+++ b/packages/forest_admin_agent/lib/forest_admin_agent/utils/caller_parser.rb
@@ -51,6 +51,8 @@ module ForestAdminAgent
           true,
           { algorithm: 'HS256' }
         )[0].tap { |data| data.delete('exp') }
+      rescue JWT::DecodeError
+        raise Http::Exceptions::UnauthorizedError, 'Invalid or expired authentication token.'
       end
 
       def extract_forest_context

--- a/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/capabilities/collections_spec.rb
+++ b/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/capabilities/collections_spec.rb
@@ -237,6 +237,50 @@ module ForestAdminAgent
           end
         end
 
+        context 'when the request is not authenticated' do
+          let(:args) do
+            {
+              headers: {},
+              params: {
+                'collectionNames' => ['user'],
+                'timezone' => 'Europe/Paris'
+              }
+            }
+          end
+
+          it 'rejects the request with no Authorization header' do
+            expect { capabilities_collections.handle_request(args) }.to raise_error(
+              ForestAdminAgent::Http::Exceptions::UnauthorizedError,
+              'You must be logged in to access at this resource.'
+            )
+          end
+
+          it 'does not instantiate permissions' do
+            expect { capabilities_collections.handle_request(args) }.to raise_error(
+              ForestAdminAgent::Http::Exceptions::UnauthorizedError
+            )
+            expect(ForestAdminAgent::Services::Permissions).not_to have_received(:new)
+          end
+        end
+
+        context 'when the request carries a remote ip' do
+          let(:args) do
+            {
+              headers: { 'HTTP_AUTHORIZATION' => bearer, 'action_dispatch.remote_ip' => '10.0.0.1' },
+              params: {
+                'collectionNames' => [],
+                'timezone' => 'Europe/Paris'
+              }
+            }
+          end
+
+          it 'checks the ip against the whitelist' do
+            allow(ForestAdminAgent::Facades::Whitelist).to receive(:check_ip)
+            capabilities_collections.handle_request(args)
+            expect(ForestAdminAgent::Facades::Whitelist).to have_received(:check_ip).with('10.0.0.1')
+          end
+        end
+
         it 'throws an error when th collection does not exist' do
           args = {
             headers: { 'HTTP_AUTHORIZATION' => bearer },

--- a/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/charts/api_chart_datasource_spec.rb
+++ b/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/charts/api_chart_datasource_spec.rb
@@ -33,6 +33,7 @@ module ForestAdminAgent
               render_chart: { countCurrent: 12 }
             )
             ForestAdminAgent::Facades::Container.instance.register(:datasource, datasource)
+            allow(ForestAdminAgent::Services::Permissions).to receive(:new).and_return(permissions)
           end
 
           it 'adds the routes' do
@@ -77,6 +78,50 @@ module ForestAdminAgent
               }
               expect(result).to have_key(:content)
               expect(result[:content]).to eq({ countCurrent: 12 })
+            end
+          end
+
+          describe 'when the request is not authenticated' do
+            let(:args) do
+              {
+                headers: {},
+                params: { 'timezone' => 'Europe/Paris' }
+              }
+            end
+
+            it 'rejects handle_api_chart with no Authorization header' do
+              expect { described_class.new('my_chart').handle_api_chart(args) }.to raise_error(
+                ForestAdminAgent::Http::Exceptions::UnauthorizedError
+              )
+            end
+
+            it 'rejects handle_smart_chart with no Authorization header' do
+              expect { described_class.new('my_chart').handle_smart_chart(args) }.to raise_error(
+                ForestAdminAgent::Http::Exceptions::UnauthorizedError
+              )
+            end
+          end
+
+          describe 'when the request carries a remote ip' do
+            let(:args) do
+              {
+                headers: { 'HTTP_AUTHORIZATION' => bearer, 'action_dispatch.remote_ip' => '10.0.0.1' },
+                params: { 'timezone' => 'Europe/Paris' }
+              }
+            end
+
+            before do
+              allow(ForestAdminAgent::Facades::Whitelist).to receive(:check_ip)
+            end
+
+            it 'checks the ip against the whitelist on handle_api_chart' do
+              described_class.new('my_chart').handle_api_chart(args)
+              expect(ForestAdminAgent::Facades::Whitelist).to have_received(:check_ip).with('10.0.0.1')
+            end
+
+            it 'checks the ip against the whitelist on handle_smart_chart' do
+              described_class.new('my_chart').handle_smart_chart(args)
+              expect(ForestAdminAgent::Facades::Whitelist).to have_received(:check_ip).with('10.0.0.1')
             end
           end
         end

--- a/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/security/scope_invalidation_spec.rb
+++ b/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/security/scope_invalidation_spec.rb
@@ -20,7 +20,6 @@ module ForestAdminAgent
             {
               headers: { 'HTTP_AUTHORIZATION' => bearer },
               params: {
-                'collection_name' => 'user',
                 'timezone' => 'Europe/Paris'
               }
             }
@@ -28,6 +27,7 @@ module ForestAdminAgent
           let(:permissions) { class_double(ForestAdminAgent::Services::Permissions).as_stubbed_const }
 
           before do
+            allow(permissions).to receive(:new).and_return(instance_double(ForestAdminAgent::Services::Permissions))
             allow(permissions).to receive(:invalidate_cache).with(any_args).and_return(nil)
           end
 
@@ -41,6 +41,21 @@ module ForestAdminAgent
             scope_invalidation.handle_request(args)
 
             expect(permissions).to have_received(:invalidate_cache).with('forest.rendering')
+          end
+
+          it 'rejects the request with no Authorization header' do
+            expect { scope_invalidation.handle_request(args.merge(headers: {})) }.to raise_error(
+              ForestAdminAgent::Http::Exceptions::UnauthorizedError
+            )
+            expect(permissions).not_to have_received(:invalidate_cache)
+          end
+
+          it 'checks the ip against the whitelist when the request carries a remote ip' do
+            allow(ForestAdminAgent::Facades::Whitelist).to receive(:check_ip)
+            scope_invalidation.handle_request(
+              args.merge(headers: args[:headers].merge('action_dispatch.remote_ip' => '10.0.0.1'))
+            )
+            expect(ForestAdminAgent::Facades::Whitelist).to have_received(:check_ip).with('10.0.0.1')
           end
         end
       end

--- a/packages/forest_admin_agent/spec/lib/forest_admin_agent/utils/query_string_parser_spec.rb
+++ b/packages/forest_admin_agent/spec/lib/forest_admin_agent/utils/query_string_parser_spec.rb
@@ -71,6 +71,46 @@ module ForestAdminAgent
             'You must be logged in to access at this resource.'
           )
         end
+
+        it 'raise an unauthorized error if the token is signed with the wrong secret' do
+          forged = JWT.encode({ 'id' => '1', 'email' => 'foo@bar.com' }, 'not-the-auth-secret', 'HS256')
+          args = {
+            headers: {
+              'HTTP_AUTHORIZATION' => "Bearer #{forged}"
+            },
+            params: {
+              'timezone' => 'Europe/Paris'
+            }
+          }
+          expect do
+            described_class.parse_caller(args)
+          end.to raise_error(
+            Http::Exceptions::UnauthorizedError,
+            'Invalid or expired authentication token.'
+          )
+        end
+
+        it 'raise an unauthorized error if the token is expired' do
+          expired = JWT.encode(
+            { 'id' => '1', 'email' => 'foo@bar.com', 'exp' => Time.now.to_i - 3600 },
+            'cba803d01a4d43b55010cab41fa1ea1f1f51a95e',
+            'HS256'
+          )
+          args = {
+            headers: {
+              'HTTP_AUTHORIZATION' => "Bearer #{expired}"
+            },
+            params: {
+              'timezone' => 'Europe/Paris'
+            }
+          }
+          expect do
+            described_class.parse_caller(args)
+          end.to raise_error(
+            Http::Exceptions::UnauthorizedError,
+            'Invalid or expired authentication token.'
+          )
+        end
       end
 
       describe 'parse_projection' do

--- a/packages/forest_admin_rails/Gemfile-test
+++ b/packages/forest_admin_rails/Gemfile-test
@@ -7,6 +7,7 @@ group :development, :test do
   gem 'forest_admin_agent', path: '../forest_admin_agent'
   gem 'forest_admin_datasource_customizer', path: '../forest_admin_datasource_customizer'
   gem 'forest_admin_datasource_active_record', path: '../forest_admin_datasource_active_record'
+  gem 'forest_admin_datasource_toolkit', path: '../forest_admin_datasource_toolkit'
   gem 'rspec-rails', '~> 6.0.0'
   gem 'rubocop', '1.86.1'
   gem 'rubocop-performance', '1.26.1'

--- a/packages/forest_admin_rails/spec/controllers/forest_admin_rails/forest_controller_spec.rb
+++ b/packages/forest_admin_rails/spec/controllers/forest_admin_rails/forest_controller_spec.rb
@@ -150,21 +150,7 @@ module ForestAdminRails
 
       context 'when exception does not have name attribute' do
         it 'uses exception class name as fallback' do
-          # rubocop:disable RSpec/VerifiedDoubles
-          exception = double(
-            'GenericError',
-            message: 'Something went wrong',
-            respond_to?: false,
-            class: StandardError
-          )
-          # rubocop:enable RSpec/VerifiedDoubles
-          allow(exception.class).to receive(:name).and_return('StandardError')
-          allow(exception).to receive(:try).with(:status).and_return(nil)
-          allow(exception).to receive(:try).with(:data).and_return(nil)
-          allow(exception).to receive(:is_a?).with(ForestAdminAgent::Http::Exceptions::HttpException).and_return(false)
-          allow(exception).to receive(:is_a?).with(ForestAdminAgent::Http::Exceptions::BusinessError).and_return(false)
-          allow(exception).to receive(:is_a?).with(ForestAdminAgent::Http::Exceptions::AuthenticationOpenIdClient).and_return(false)
-          allow(exception).to receive(:is_a?).with(OpenIDConnect::Exception).and_return(false)
+          exception = StandardError.new('Something went wrong')
           allow(exception).to receive(:full_message).and_return('Full error')
 
           controller.send(:exception_handler, exception)
@@ -178,21 +164,7 @@ module ForestAdminRails
 
       context 'when exception has no status' do
         it 'returns errors format with 500 status' do
-          # rubocop:disable RSpec/VerifiedDoubles
-          exception = double(
-            'GenericError',
-            message: 'Generic error',
-            respond_to?: false,
-            class: StandardError
-          )
-          # rubocop:enable RSpec/VerifiedDoubles
-          allow(exception.class).to receive(:name).and_return('StandardError')
-          allow(exception).to receive(:try).with(:status).and_return(nil)
-          allow(exception).to receive(:try).with(:data).and_return(nil)
-          allow(exception).to receive(:is_a?).with(ForestAdminAgent::Http::Exceptions::HttpException).and_return(false)
-          allow(exception).to receive(:is_a?).with(ForestAdminAgent::Http::Exceptions::BusinessError).and_return(false)
-          allow(exception).to receive(:is_a?).with(ForestAdminAgent::Http::Exceptions::AuthenticationOpenIdClient).and_return(false)
-          allow(exception).to receive(:is_a?).with(OpenIDConnect::Exception).and_return(false)
+          exception = StandardError.new('Generic error')
           allow(exception).to receive(:full_message).and_return('Full error')
 
           controller.send(:exception_handler, exception)
@@ -207,21 +179,7 @@ module ForestAdminRails
 
       context 'when exception has no data' do
         it 'returns errors format with nil data' do
-          # rubocop:disable RSpec/VerifiedDoubles
-          exception = double(
-            'GenericError',
-            message: 'Generic error',
-            respond_to?: false,
-            class: StandardError
-          )
-          # rubocop:enable RSpec/VerifiedDoubles
-          allow(exception.class).to receive(:name).and_return('StandardError')
-          allow(exception).to receive(:try).with(:status).and_return(nil)
-          allow(exception).to receive(:try).with(:data).and_return(nil)
-          allow(exception).to receive(:is_a?).with(ForestAdminAgent::Http::Exceptions::HttpException).and_return(false)
-          allow(exception).to receive(:is_a?).with(ForestAdminAgent::Http::Exceptions::BusinessError).and_return(false)
-          allow(exception).to receive(:is_a?).with(ForestAdminAgent::Http::Exceptions::AuthenticationOpenIdClient).and_return(false)
-          allow(exception).to receive(:is_a?).with(OpenIDConnect::Exception).and_return(false)
+          exception = StandardError.new('Generic error')
           allow(exception).to receive(:full_message).and_return('Full error')
 
           controller.send(:exception_handler, exception)
@@ -231,49 +189,28 @@ module ForestAdminRails
         end
       end
 
-      context 'with production and non-production modes' do
-        it 'logs exception in non-production mode' do
-          # rubocop:disable RSpec/VerifiedDoubles
-          exception = double(
-            'GenericError',
-            message: 'Test error',
-            respond_to?: false,
-            class: StandardError
-          )
-          # rubocop:enable RSpec/VerifiedDoubles
-          allow(exception.class).to receive(:name).and_return('StandardError')
-          allow(exception).to receive(:try).with(:status).and_return(nil)
-          allow(exception).to receive(:try).with(:data).and_return(nil)
-          allow(exception).to receive(:is_a?).with(ForestAdminAgent::Http::Exceptions::HttpException).and_return(false)
-          allow(exception).to receive(:is_a?).with(ForestAdminAgent::Http::Exceptions::BusinessError).and_return(false)
-          allow(exception).to receive(:is_a?).with(ForestAdminAgent::Http::Exceptions::AuthenticationOpenIdClient).and_return(false)
-          allow(exception).to receive(:is_a?).with(OpenIDConnect::Exception).and_return(false)
+      context 'with exception logging' do
+        it 'logs the full message when the translated status is 500' do
+          exception = StandardError.new('Test error')
           allow(exception).to receive(:full_message).and_return('Full error trace')
-          allow(ForestAdminAgent::Facades::Container).to receive(:cache).with(:is_production).and_return(false)
 
           controller.send(:exception_handler, exception)
 
           expect(logger).to have_received(:log).with('Error', 'Full error trace')
         end
 
-        it 'does not log exception in production mode' do
-          # rubocop:disable RSpec/VerifiedDoubles
-          exception = double(
-            'GenericError',
-            message: 'Test error',
-            respond_to?: false,
-            class: StandardError
-          )
-          # rubocop:enable RSpec/VerifiedDoubles
-          allow(exception.class).to receive(:name).and_return('StandardError')
-          allow(exception).to receive(:try).with(:status).and_return(nil)
-          allow(exception).to receive(:try).with(:data).and_return(nil)
-          allow(exception).to receive(:is_a?).with(ForestAdminAgent::Http::Exceptions::HttpException).and_return(false)
-          allow(exception).to receive(:is_a?).with(ForestAdminAgent::Http::Exceptions::BusinessError).and_return(false)
-          allow(exception).to receive(:is_a?).with(ForestAdminAgent::Http::Exceptions::AuthenticationOpenIdClient).and_return(false)
-          allow(exception).to receive(:is_a?).with(OpenIDConnect::Exception).and_return(false)
+        it 'logs 500 errors even in production mode' do
+          exception = StandardError.new('Test error')
           allow(exception).to receive(:full_message).and_return('Full error trace')
           allow(ForestAdminAgent::Facades::Container).to receive(:cache).with(:is_production).and_return(true)
+
+          controller.send(:exception_handler, exception)
+
+          expect(logger).to have_received(:log).with('Error', 'Full error trace')
+        end
+
+        it 'does not log when the translated status is below 500' do
+          exception = ForestAdminAgent::Http::Exceptions::ForbiddenError.new('Access denied')
 
           controller.send(:exception_handler, exception)
 


### PR DESCRIPTION
## Summary

Fixes [PRD-896](https://linear.app/forestadmin/issue/PRD-896/agent-ruby-internalcapabilities-skips-both-authentication-and-the-ip): `POST /forest/_internal/capabilities` answered with **no token verification and no IP whitelist check** — reachable by any anonymous caller. The route inherited from `AbstractRoute` and never called `build(args)`, which is the only place both controls run (there is no auth middleware in agent-ruby).

An adversarial review of the fix extended the scope (documented in the ticket):

- **`Capabilities::Collections`** — inherits `AbstractAuthenticatedRoute` and calls `build(args)`, like every other private route. Note: the ticket's suggested one-liner (base class change alone) is not sufficient — without the `build(args)` call the inheritance protects nothing.
- **`Charts::ApiChartDatasource`** (both handlers) and **`Security::ScopeInvalidation`** — same class of bug: they verified the JWT via `parse_caller` but skipped the IP whitelist. Now aligned on the `build(args)` pattern.
- **`CallerParser`** — a forged, malformed, or expired JWT raised an unrescued `JWT::DecodeError` → 500 "Unexpected error". The front only re-authenticates on 401 (which is what agent-nodejs returns via koa-jwt), so an expired agent token silently degraded capabilities for the whole session. Now rescued → `UnauthorizedError` → 401.
- **CI** — `forest_admin_rails` was linted but never tested (missing from the test matrix, broken `Gemfile-test`, 5 stale `exception_handler` specs asserting a no-log-in-production behaviour removed in #281). Repaired and added to the test matrix + coverage upload, so the controller dispatch and HTTP error mapping are covered again.

## Front-end compatibility

Verified against the front code: `?timezone=` and the `Authorization` header are added to every agent request (since ≥2021, with a `UTC` fallback), and the pre-auth 401 on the first capabilities call is the exact behaviour of agent-nodejs in production today — the front handles it by refetching on `authenticationSucceeded`. Expect a small uptick of "Agent logout: 401" warnings on Ruby agents after release, same as Node.

## Regression specs

- Capabilities / datasource charts / scope invalidation: 401 with no `Authorization` header, permissions never instantiated, `Whitelist.check_ip` invoked when the request carries `action_dispatch.remote_ip`.
- Mutation-tested: reverting the fix, dropping only the `build(args)` call, or keeping the call with the wrong base class each make the new specs fail.
- CallerParser: wrong-signature and expired JWTs → `UnauthorizedError`.

## Out of scope, tracked separately

- [PRD-914](https://linear.app/forestadmin/issue/PRD-914/agent-ruby-ip-whitelist-rejection-raises-a-module-instead-of-an): the whitelist rejection path raises a module (`Net::HTTPExceptions`) → `TypeError` → 500 instead of Node's 403 (fail-closed by accident, pre-existing on all routes).
- The proof spec on `feature/prd-904-security-audit-proof-suite` asserts the old unauthenticated behaviour and will need flipping when that branch lands.
- ~~Untestable locally: the MCP server token (`describe-collection`) against a Ruby agent~~ **Validated**: minted a token through the real compiled MCP-server code (`AuthService#getUserInfo` mapping — `team = teams[0]` is unconditional — plus `ForestOAuthProvider.toSnakeCaseKeys` and the verbatim payload construction, Forest server stubbed locally) and ran it through the real `CallerParser` and the authenticated capabilities route on this branch: caller parses with `team` intact, route answers 200, and the same request without the token gets 401. Ruby's `Caller.new` also swallows the MCP token's extra claims (`serverToken`, `scopes`, camelCase duplicates) via `**_extra_args`.

## Test plan

- [x] `forest_admin_agent`: 796 examples, 0 failures
- [x] `forest_admin_rails`: 110 examples, 0 failures (now also in CI)
- [x] `rubocop`: 802 files, no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enforce authentication and IP whitelist on capabilities, charts, and scope invalidation routes
> - Changes `Collections`, `ApiChartDatasource`, and `ScopeInvalidation` routes to extend `AbstractAuthenticatedRoute` and call `build(args)` in their handlers, applying authentication and IP whitelist checks that were previously skipped.
> - Adds a `JWT::DecodeError` rescue in [`CallerParser.decode_token`](https://github.com/ForestAdmin/agent-ruby/pull/349/files#diff-83e1f346dcd1d417b18f30cdf95cc3d0bb5f430845a5df7f42e504cd17940a1f) to raise a consistent `UnauthorizedError` with the message `'Invalid or expired authentication token.'` instead of propagating raw JWT exceptions.
> - Adds `forest_admin_rails` to the CI test matrix and updates coverage reporting to include it.
> - Behavioral Change: Requests to the capabilities, datasource chart, and scope invalidation endpoints without a valid token or from a non-whitelisted IP will now receive 401/403 responses rather than proceeding.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #349 opened
>
> - Refactored `ForestAdminAgent::Routes::Capabilities::Collections.handle_request` to retrieve datasource from context object [0cefea7]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1e1e75c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
