### PR TITLE
fix(agent): scope and authorize related write routes on the mutated collection

### DIFF
--- a/packages/forest_admin_agent/lib/forest_admin_agent/routes/resources/related/associate_related.rb
+++ b/packages/forest_admin_agent/lib/forest_admin_agent/routes/resources/related/associate_related.rb
@@ -50,7 +50,7 @@ module ForestAdminAgent
               condition_tree: ConditionTree::ConditionTreeFactory.intersect(
                 [
                   ConditionTree::Nodes::ConditionTreeLeaf.new(id, 'Equal', value),
-                  context.permissions.get_scope(context.collection)
+                  context.permissions.get_scope(context.child_collection)
                 ]
               )
             )
@@ -67,7 +67,7 @@ module ForestAdminAgent
               condition_tree: ConditionTree::ConditionTreeFactory.intersect(
                 [
                   ConditionTree::Nodes::ConditionTreeLeaf.new(id, 'Equal', value),
-                  context.permissions.get_scope(context.collection)
+                  context.permissions.get_scope(context.child_collection)
                 ]
               )
             )

--- a/packages/forest_admin_agent/lib/forest_admin_agent/routes/resources/related/dissociate_related.rb
+++ b/packages/forest_admin_agent/lib/forest_admin_agent/routes/resources/related/dissociate_related.rb
@@ -29,7 +29,7 @@ module ForestAdminAgent
             if is_delete_mode
               context.permissions.can?(:delete, context.child_collection)
             else
-              context.permissions.can?(:edit, context.collection)
+              context.permissions.can?(:edit, context.child_collection)
             end
 
             filter = get_base_foreign_filter(args, context)

--- a/packages/forest_admin_agent/lib/forest_admin_agent/routes/resources/related/update_related.rb
+++ b/packages/forest_admin_agent/lib/forest_admin_agent/routes/resources/related/update_related.rb
@@ -22,7 +22,6 @@ module ForestAdminAgent
 
           def handle_request(args = {})
             context = build(args)
-            context.permissions.can?(:edit, context.collection)
 
             relation = context.collection.schema[:fields][args[:params]['relation_name']]
             parent_primary_key_values = Utils::Id.unpack_id(context.collection, args[:params]['id'])
@@ -48,16 +47,27 @@ module ForestAdminAgent
           private
 
           def update_many_to_one(relation, parent_primary_key_values, linked_primary_key_values, context)
+            context.permissions.can?(:edit, context.collection)
+
             foreign_value = if linked_primary_key_values
                               Collection.get_value(context.child_collection, context.caller, linked_primary_key_values,
                                                    relation.foreign_key_target)
                             end
             fk_owner = ConditionTree::ConditionTreeFactory.match_ids(context.collection, [parent_primary_key_values])
-            context.collection.update(context.caller, Filter.new(condition_tree: fk_owner),
-                                      { relation.foreign_key => foreign_value })
+            filter = Filter.new(
+              condition_tree: ConditionTree::ConditionTreeFactory.intersect(
+                [
+                  context.permissions.get_scope(context.collection),
+                  fk_owner
+                ]
+              )
+            )
+            context.collection.update(context.caller, filter, { relation.foreign_key => foreign_value })
           end
 
           def update_polymorphic_many_to_one(relation, parent_primary_key_values, linked_primary_key_values, context)
+            context.permissions.can?(:edit, context.collection)
+
             foreign_value = if linked_primary_key_values
                               Collection.get_value(
                                 context.child_collection,
@@ -69,9 +79,17 @@ module ForestAdminAgent
 
             polymorphic_type = context.child_collection.name.gsub('__', '::')
             fk_owner = ConditionTree::ConditionTreeFactory.match_ids(context.collection, [parent_primary_key_values])
+            filter = Filter.new(
+              condition_tree: ConditionTree::ConditionTreeFactory.intersect(
+                [
+                  context.permissions.get_scope(context.collection),
+                  fk_owner
+                ]
+              )
+            )
             context.collection.update(
               context.caller,
-              Filter.new(condition_tree: fk_owner),
+              filter,
               {
                 relation.foreign_key => foreign_value,
                 relation.foreign_key_type_field => polymorphic_type
@@ -80,6 +98,8 @@ module ForestAdminAgent
           end
 
           def update_polymorphic_one_to_one(relation, parent_primary_key_values, linked_primary_key_values, context)
+            context.permissions.can?(:edit, context.child_collection)
+
             origin_value = Collection.get_value(context.collection, context.caller, parent_primary_key_values,
                                                 relation.origin_key_target)
 
@@ -88,6 +108,8 @@ module ForestAdminAgent
           end
 
           def update_one_to_one(relation, parent_primary_key_values, linked_primary_key_values, context)
+            context.permissions.can?(:edit, context.child_collection)
+
             origin_value = Collection.get_value(context.collection, context.caller, parent_primary_key_values,
                                                 relation.origin_key_target)
 
@@ -101,7 +123,7 @@ module ForestAdminAgent
             old_fk_owner_filter = Filter.new(
               condition_tree: ConditionTree::ConditionTreeFactory.intersect(
                 [
-                  context.permissions.get_scope(context.collection),
+                  context.permissions.get_scope(context.child_collection),
                   ConditionTree::Nodes::ConditionTreeBranch.new(
                     'And',
                     [
@@ -150,7 +172,7 @@ module ForestAdminAgent
               Filter.new(
                 condition_tree: ConditionTree::ConditionTreeFactory.intersect(
                   [
-                    context.permissions.get_scope(context.collection), new_fk_owner
+                    context.permissions.get_scope(context.child_collection), new_fk_owner
                   ]
                 )
               ),
@@ -164,7 +186,7 @@ module ForestAdminAgent
             old_fk_owner_filter = Filter.new(
               condition_tree: ConditionTree::ConditionTreeFactory.intersect(
                 [
-                  context.permissions.get_scope(context.collection),
+                  context.permissions.get_scope(context.child_collection),
                   ConditionTree::Nodes::ConditionTreeLeaf.new(
                     relation.origin_key,
                     ConditionTree::Operators::EQUAL,
@@ -198,7 +220,7 @@ module ForestAdminAgent
               context.caller,
               Filter.new(condition_tree: ConditionTree::ConditionTreeFactory.intersect(
                 [
-                  context.permissions.get_scope(context.collection),
+                  context.permissions.get_scope(context.child_collection),
                   new_fk_owner
                 ]
               )),

--- a/packages/forest_admin_agent/lib/forest_admin_agent/routes/resources/related/update_related.rb
+++ b/packages/forest_admin_agent/lib/forest_admin_agent/routes/resources/related/update_related.rb
@@ -25,9 +25,7 @@ module ForestAdminAgent
 
             relation = context.collection.schema[:fields][args[:params]['relation_name']]
 
-            # Authorize on the collection the relation type mutates, before any
-            # id parsing, so unauthorized callers get a 403 rather than a
-            # validation error on their input.
+            # Must run before unpack_id: unauthorized callers get a 403, not a validation error
             context.permissions.can?(:edit, mutated_collection(relation, context))
 
             parent_primary_key_values = Utils::Id.unpack_id(context.collection, args[:params]['id'])

--- a/packages/forest_admin_agent/lib/forest_admin_agent/routes/resources/related/update_related.rb
+++ b/packages/forest_admin_agent/lib/forest_admin_agent/routes/resources/related/update_related.rb
@@ -24,6 +24,12 @@ module ForestAdminAgent
             context = build(args)
 
             relation = context.collection.schema[:fields][args[:params]['relation_name']]
+
+            # Authorize on the collection the relation type mutates, before any
+            # id parsing, so unauthorized callers get a 403 rather than a
+            # validation error on their input.
+            context.permissions.can?(:edit, mutated_collection(relation, context))
+
             parent_primary_key_values = Utils::Id.unpack_id(context.collection, args[:params]['id'])
 
             linked_primary_key_values = if (id = args.dig(:params, 'data', 'id'))
@@ -46,15 +52,16 @@ module ForestAdminAgent
 
           private
 
-          def update_many_to_one(relation, parent_primary_key_values, linked_primary_key_values, context)
-            context.permissions.can?(:edit, context.collection)
+          def mutated_collection(relation, context)
+            return context.child_collection if ['OneToOne', 'PolymorphicOneToOne'].include?(relation.type)
 
-            foreign_value = if linked_primary_key_values
-                              Collection.get_value(context.child_collection, context.caller, linked_primary_key_values,
-                                                   relation.foreign_key_target)
-                            end
+            context.collection
+          end
+
+          def scoped_fk_owner_filter(parent_primary_key_values, context)
             fk_owner = ConditionTree::ConditionTreeFactory.match_ids(context.collection, [parent_primary_key_values])
-            filter = Filter.new(
+
+            Filter.new(
               condition_tree: ConditionTree::ConditionTreeFactory.intersect(
                 [
                   context.permissions.get_scope(context.collection),
@@ -62,12 +69,19 @@ module ForestAdminAgent
                 ]
               )
             )
-            context.collection.update(context.caller, filter, { relation.foreign_key => foreign_value })
+          end
+
+          def update_many_to_one(relation, parent_primary_key_values, linked_primary_key_values, context)
+            foreign_value = if linked_primary_key_values
+                              Collection.get_value(context.child_collection, context.caller, linked_primary_key_values,
+                                                   relation.foreign_key_target)
+                            end
+
+            context.collection.update(context.caller, scoped_fk_owner_filter(parent_primary_key_values, context),
+                                      { relation.foreign_key => foreign_value })
           end
 
           def update_polymorphic_many_to_one(relation, parent_primary_key_values, linked_primary_key_values, context)
-            context.permissions.can?(:edit, context.collection)
-
             foreign_value = if linked_primary_key_values
                               Collection.get_value(
                                 context.child_collection,
@@ -78,18 +92,9 @@ module ForestAdminAgent
                             end
 
             polymorphic_type = context.child_collection.name.gsub('__', '::')
-            fk_owner = ConditionTree::ConditionTreeFactory.match_ids(context.collection, [parent_primary_key_values])
-            filter = Filter.new(
-              condition_tree: ConditionTree::ConditionTreeFactory.intersect(
-                [
-                  context.permissions.get_scope(context.collection),
-                  fk_owner
-                ]
-              )
-            )
             context.collection.update(
               context.caller,
-              filter,
+              scoped_fk_owner_filter(parent_primary_key_values, context),
               {
                 relation.foreign_key => foreign_value,
                 relation.foreign_key_type_field => polymorphic_type
@@ -98,8 +103,6 @@ module ForestAdminAgent
           end
 
           def update_polymorphic_one_to_one(relation, parent_primary_key_values, linked_primary_key_values, context)
-            context.permissions.can?(:edit, context.child_collection)
-
             origin_value = Collection.get_value(context.collection, context.caller, parent_primary_key_values,
                                                 relation.origin_key_target)
 
@@ -108,8 +111,6 @@ module ForestAdminAgent
           end
 
           def update_one_to_one(relation, parent_primary_key_values, linked_primary_key_values, context)
-            context.permissions.can?(:edit, context.child_collection)
-
             origin_value = Collection.get_value(context.collection, context.caller, parent_primary_key_values,
                                                 relation.origin_key_target)
 

--- a/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/resources/related/associate_related_spec.rb
+++ b/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/resources/related/associate_related_spec.rb
@@ -126,14 +126,25 @@ module ForestAdminAgent
               args[:params]['relation_name'] = 'address_users'
               args[:params]['data'] = [{ 'id' => 1 }]
               args[:params]['id'] = 1
+              allow(permissions).to receive(:get_scope)
+                .and_return(Nodes::ConditionTreeLeaf.new('user_id', Operators::NOT_EQUAL, 99))
               allow(@datasource.get_collection('user')).to receive(:list).and_return([User.new(1, 'foo')])
               allow(@datasource.get_collection('address_user')).to receive(:update).and_return(true)
               result = associate.handle_request(args)
 
+              expect(permissions).to have_received(:can?).with(:edit, having_attributes(name: 'user'))
+              expect(permissions).to have_received(:get_scope).with(having_attributes(name: 'address_user'))
+              expect(permissions).not_to have_received(:get_scope).with(having_attributes(name: 'user'))
               expect(@datasource.get_collection('address_user')).to have_received(:update) do |caller, filter, data|
                 expect(caller).to be_instance_of(Components::Caller)
                 expect(filter).to have_attributes(
-                  condition_tree: have_attributes(field: 'id', operator: Operators::EQUAL, value: 1),
+                  condition_tree: have_attributes(
+                    aggregator: 'And',
+                    conditions: [
+                      have_attributes(field: 'id', operator: Operators::EQUAL, value: 1),
+                      have_attributes(field: 'user_id', operator: Operators::NOT_EQUAL, value: 99)
+                    ]
+                  ),
                   page: nil,
                   search: nil,
                   search_extended: nil,
@@ -158,6 +169,8 @@ module ForestAdminAgent
               allow(@datasource.get_collection('address_user')).to receive(:create).and_return(true)
               result = associate.handle_request(args)
 
+              expect(permissions).to have_received(:can?).with(:edit, having_attributes(name: 'user'))
+              expect(permissions).not_to have_received(:get_scope)
               expect(@datasource.get_collection('address_user')).to have_received(:create) do |caller, data|
                 expect(caller).to be_instance_of(Components::Caller)
                 expect(data).to eq({ 'address_id' => 1, 'user_id' => 1 })
@@ -172,14 +185,25 @@ module ForestAdminAgent
               args[:params]['relation_name'] = 'addresses_poly'
               args[:params]['data'] = [{ 'id' => 1, 'type' => 'user' }]
               args[:params]['id'] = 1
+              allow(permissions).to receive(:get_scope)
+                .and_return(Nodes::ConditionTreeLeaf.new('location', Operators::EQUAL, 'paris'))
               allow(@datasource.get_collection('user')).to receive(:list).and_return([User.new(1, 'foo')])
               allow(@datasource.get_collection('address')).to receive(:update).and_return(true)
               result = associate.handle_request(args)
 
+              expect(permissions).to have_received(:can?).with(:edit, having_attributes(name: 'user'))
+              expect(permissions).to have_received(:get_scope).with(having_attributes(name: 'address'))
+              expect(permissions).not_to have_received(:get_scope).with(having_attributes(name: 'user'))
               expect(@datasource.get_collection('address')).to have_received(:update) do |caller, filter, data|
                 expect(caller).to be_instance_of(Components::Caller)
                 expect(filter).to have_attributes(
-                  condition_tree: have_attributes(field: 'id', operator: Operators::EQUAL, value: 1),
+                  condition_tree: have_attributes(
+                    aggregator: 'And',
+                    conditions: [
+                      have_attributes(field: 'id', operator: Operators::EQUAL, value: 1),
+                      have_attributes(field: 'location', operator: Operators::EQUAL, value: 'paris')
+                    ]
+                  ),
                   page: nil,
                   search: nil,
                   search_extended: nil,

--- a/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/resources/related/dissociate_related_spec.rb
+++ b/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/resources/related/dissociate_related_spec.rb
@@ -130,7 +130,8 @@ module ForestAdminAgent
 
               result = dissociate.handle_request(args)
 
-              expect(permissions).to have_received(:can?).with(:edit, @datasource.get_collection('user'))
+              expect(permissions).to have_received(:can?).with(:edit, @datasource.get_collection('address_user'))
+              expect(permissions).not_to have_received(:can?).with(:edit, @datasource.get_collection('user'))
               expect(@datasource.get_collection('address_user')).to have_received(:update) do |caller, filter, data|
                 expect(caller).to be_instance_of(Components::Caller)
                 expect(filter).to have_attributes(
@@ -249,7 +250,8 @@ module ForestAdminAgent
 
               result = dissociate.handle_request(args)
 
-              expect(permissions).to have_received(:can?).with(:edit, @datasource.get_collection('user'))
+              expect(permissions).to have_received(:can?).with(:edit, @datasource.get_collection('address'))
+              expect(permissions).not_to have_received(:can?).with(:edit, @datasource.get_collection('user'))
               expect(@datasource.get_collection('address_user')).to have_received(:delete) do |caller, filter|
                 expect(caller).to be_instance_of(Components::Caller)
                 expect(filter).to have_attributes(
@@ -333,7 +335,8 @@ module ForestAdminAgent
 
                 result = dissociate.handle_request(args)
 
-                expect(permissions).to have_received(:can?).with(:edit, @datasource.get_collection('user'))
+                expect(permissions).to have_received(:can?).with(:edit, @datasource.get_collection('address'))
+                expect(permissions).not_to have_received(:can?).with(:edit, @datasource.get_collection('user'))
 
                 expect(@datasource.get_collection('address')).to have_received(:update) do |caller, filter, data|
                   expect(caller).to be_instance_of(Components::Caller)

--- a/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/resources/related/update_related_spec.rb
+++ b/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/resources/related/update_related_spec.rb
@@ -105,6 +105,21 @@ module ForestAdminAgent
               stub_const('Book', book_class)
             end
 
+            it 'checks the edit permission before parsing any id' do
+              allow(permissions).to receive(:can?)
+                .and_raise(ForestAdminAgent::Http::Exceptions::ForbiddenError)
+              allow(Utils::Id).to receive(:unpack_id)
+
+              args[:params]['collection_name'] = 'book'
+              args[:params]['relation_name'] = 'author'
+              args[:params]['data'] = { 'id' => 'malformed|id' }
+              args[:params]['id'] = 'malformed|id'
+
+              expect { update.handle_request(args) }
+                .to raise_error(ForestAdminAgent::Http::Exceptions::ForbiddenError)
+              expect(Utils::Id).not_to have_received(:unpack_id)
+            end
+
             it 'call handle_request on a many_to_one relation' do
               allow(permissions).to receive(:get_scope)
                 .and_return(Nodes::ConditionTreeLeaf.new('author_id', Operators::NOT_EQUAL, 99))

--- a/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/resources/related/update_related_spec.rb
+++ b/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/resources/related/update_related_spec.rb
@@ -106,6 +106,8 @@ module ForestAdminAgent
             end
 
             it 'call handle_request on a many_to_one relation' do
+              allow(permissions).to receive(:get_scope)
+                .and_return(Nodes::ConditionTreeLeaf.new('author_id', Operators::NOT_EQUAL, 99))
               allow(@datasource.get_collection('book')).to receive(:update).and_return(true)
 
               args[:params]['collection_name'] = 'book'
@@ -115,10 +117,20 @@ module ForestAdminAgent
 
               result = update.handle_request(args)
 
+              expect(permissions).to have_received(:can?).with(:edit, having_attributes(name: 'book'))
+              expect(permissions).not_to have_received(:can?).with(:edit, having_attributes(name: 'user'))
+              expect(permissions).to have_received(:get_scope).with(having_attributes(name: 'book'))
+              expect(permissions).not_to have_received(:get_scope).with(having_attributes(name: 'user'))
               expect(@datasource.get_collection('book')).to have_received(:update) do |caller, filter, data|
                 expect(caller).to be_instance_of(Components::Caller)
                 expect(filter).to have_attributes(
-                  condition_tree: have_attributes(field: 'id', operator: Operators::EQUAL, value: 1),
+                  condition_tree: have_attributes(
+                    aggregator: 'And',
+                    conditions: [
+                      have_attributes(field: 'author_id', operator: Operators::NOT_EQUAL, value: 99),
+                      have_attributes(field: 'id', operator: Operators::EQUAL, value: 1)
+                    ]
+                  ),
                   page: nil,
                   search: nil,
                   search_extended: nil,
@@ -131,6 +143,8 @@ module ForestAdminAgent
             end
 
             it 'call handle_request on a polymorphic_many_to_one relation' do
+              allow(permissions).to receive(:get_scope)
+                .and_return(Nodes::ConditionTreeLeaf.new('location', Operators::EQUAL, 'paris'))
               allow(@datasource.get_collection('address')).to receive(:update).and_return(true)
 
               args[:params]['collection_name'] = 'address'
@@ -140,10 +154,20 @@ module ForestAdminAgent
 
               result = update.handle_request(args)
 
+              expect(permissions).to have_received(:can?).with(:edit, having_attributes(name: 'address'))
+              expect(permissions).not_to have_received(:can?).with(:edit, having_attributes(name: 'user'))
+              expect(permissions).to have_received(:get_scope).with(having_attributes(name: 'address'))
+              expect(permissions).not_to have_received(:get_scope).with(having_attributes(name: 'user'))
               expect(@datasource.get_collection('address')).to have_received(:update) do |caller, filter, data|
                 expect(caller).to be_instance_of(Components::Caller)
                 expect(filter).to have_attributes(
-                  condition_tree: have_attributes(field: 'id', operator: Operators::EQUAL, value: 1),
+                  condition_tree: have_attributes(
+                    aggregator: 'And',
+                    conditions: [
+                      have_attributes(field: 'location', operator: Operators::EQUAL, value: 'paris'),
+                      have_attributes(field: 'id', operator: Operators::EQUAL, value: 1)
+                    ]
+                  ),
                   page: nil,
                   search: nil,
                   search_extended: nil,
@@ -156,6 +180,8 @@ module ForestAdminAgent
             end
 
             it 'call handle_request on a one_to_one relation' do
+              allow(permissions).to receive(:get_scope)
+                .and_return(Nodes::ConditionTreeLeaf.new('author_id', Operators::NOT_EQUAL, 99))
               allow(@datasource.get_collection('book')).to receive_messages(aggregate: [{ 'value' => 1 }], update: true)
 
               args[:params]['collection_name'] = 'user'
@@ -165,6 +191,11 @@ module ForestAdminAgent
 
               result = update.handle_request(args)
 
+              expect(permissions).to have_received(:can?).with(:edit, having_attributes(name: 'book'))
+              expect(permissions).not_to have_received(:can?).with(:edit, having_attributes(name: 'user'))
+              expect(permissions).to have_received(:get_scope).with(having_attributes(name: 'book')).at_least(:once)
+              expect(permissions).not_to have_received(:get_scope).with(having_attributes(name: 'user'))
+
               parameters = [
                 [
                   Components::Caller,
@@ -172,6 +203,7 @@ module ForestAdminAgent
                     condition_tree: have_attributes(
                       aggregator: 'And',
                       conditions: [
+                        have_attributes(field: 'author_id', operator: Operators::NOT_EQUAL, value: 99),
                         have_attributes(field: 'author_id', operator: Operators::EQUAL, value: 1),
                         have_attributes(field: 'id', operator: Operators::NOT_EQUAL, value: 1)
                       ]
@@ -187,7 +219,13 @@ module ForestAdminAgent
                 [
                   Components::Caller,
                   {
-                    condition_tree: have_attributes(field: 'id', operator: Operators::EQUAL, value: 1),
+                    condition_tree: have_attributes(
+                      aggregator: 'And',
+                      conditions: [
+                        have_attributes(field: 'author_id', operator: Operators::NOT_EQUAL, value: 99),
+                        have_attributes(field: 'id', operator: Operators::EQUAL, value: 1)
+                      ]
+                    ),
                     page: nil,
                     search: nil,
                     search_extended: nil,
@@ -209,6 +247,8 @@ module ForestAdminAgent
             end
 
             it 'call handle_request on a polymorphic_one_to_one relation' do
+              allow(permissions).to receive(:get_scope)
+                .and_return(Nodes::ConditionTreeLeaf.new('location', Operators::EQUAL, 'paris'))
               allow(@datasource.get_collection('address')).to receive_messages(aggregate: [{ 'value' => 1 }], update: true)
 
               args[:params]['collection_name'] = 'user'
@@ -218,6 +258,11 @@ module ForestAdminAgent
 
               result = update.handle_request(args)
 
+              expect(permissions).to have_received(:can?).with(:edit, having_attributes(name: 'address'))
+              expect(permissions).not_to have_received(:can?).with(:edit, having_attributes(name: 'user'))
+              expect(permissions).to have_received(:get_scope).with(having_attributes(name: 'address')).at_least(:once)
+              expect(permissions).not_to have_received(:get_scope).with(having_attributes(name: 'user'))
+
               parameters = [
                 [
                   Components::Caller,
@@ -225,6 +270,7 @@ module ForestAdminAgent
                     condition_tree: have_attributes(
                       aggregator: 'And',
                       conditions: [
+                        have_attributes(field: 'location', operator: Operators::EQUAL, value: 'paris'),
                         have_attributes(field: 'addressable_id', operator: Operators::EQUAL, value: 1),
                         have_attributes(field: 'addressable_type', operator: Operators::EQUAL, value: 'user'),
                         have_attributes(field: 'id', operator: Operators::NOT_EQUAL, value: 1)
@@ -241,7 +287,13 @@ module ForestAdminAgent
                 [
                   Components::Caller,
                   {
-                    condition_tree: have_attributes(field: 'id', operator: Operators::EQUAL, value: 1),
+                    condition_tree: have_attributes(
+                      aggregator: 'And',
+                      conditions: [
+                        have_attributes(field: 'location', operator: Operators::EQUAL, value: 'paris'),
+                        have_attributes(field: 'id', operator: Operators::EQUAL, value: 1)
+                      ]
+                    ),
                     page: nil,
                     search: nil,
                     search_extended: nil,


### PR DESCRIPTION
## Summary

Write-side counterpart of #348 (PRD-897), found during its adversarial review. The relation **write** routes intersected the **parent** collection's scope, unnested, into filters that mutate the **child** collection — and in two places skipped the permission check on the collection actually being updated. All changes mirror `agent-nodejs` (`associate-related.ts`, `update-relation.ts`, `dissociate-delete-related.ts`).

- **Associate (OneToMany / PolymorphicOneToMany)**: the child update filter now intersects `get_scope(child_collection)` instead of the parent's scope. The `edit` check stays on the parent, matching Node.
- **Update relation (OneToOne / PolymorphicOneToOne)**: the route-level `can?(:edit, parent)` moves into the branches; these check `can?(:edit, child_collection)` and use the child's scope in the break-old / create-new filters (aggregate included). Previously a role with `edit` on the parent but not the child could rewrite the child's foreign keys.
- **Update relation (ManyToOne / PolymorphicManyToOne)**: the parent fk-overwrite filter had no scope at all; it now intersects `get_scope(parent)`, so a caller can no longer re-point a parent record their scope excludes.
- **Dissociate (non-delete mode)**: checks `can?(:edit, child_collection)` — the child is the collection whose origin key is nulled. Delete mode was already correct.

Not included (parity with Node): the ManyToMany associate branch creates the through record with no scope on either agent; a negative `get_scope` assertion pins that behavior.

## Test plan

- Specs updated with the hardened pattern from #348: each test stubs a real scope tree, asserts it lands in the right filter, and adds positive/negative `get_scope` / `can?` assertions per collection — a regression re-intersecting the parent scope or checking the wrong collection fails the suite.
- `bundle exec rspec` (forest_admin_agent): 788 examples, 0 failures.
- `bundle exec rubocop` on changed files: no offenses.

PRD-908

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix permission scope checks on related write routes to use the mutated collection
> - In `AssociateRelated`, scope filters for one-to-many and polymorphic one-to-many now use `context.child_collection` instead of `context.collection`.
> - In `DissociateRelated`, the edit permission check in non-delete mode now targets `context.child_collection` instead of the parent.
> - In `UpdateRelated`, permission checks are moved from a single entry-point call into each relation-specific helper, applying `context.child_collection` for OneToOne/polymorphic-OneToOne writes and `context.collection` for ManyToOne writes.
> - Scope filters passed to `ConditionTree` intersections now consistently reference the collection being mutated, not the collection the route was entered through.
> - Risk: Any code relying on parent-collection scopes being applied to child-collection writes will now enforce stricter, relation-correct permissions.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #350 opened
>
> - Moved authorization check to occur before ID parsing in `ForestAdminAgent::Routes::Resources::Related::UpdateRelated.handle_request` and added `mutated_collection` helper method that returns `context.child_collection` for `OneToOne` and `PolymorphicOneToOne` relations or `context.collection` otherwise [72a09cc]
> - Removed inline authorization checks from `update_many_to_one`, `update_polymorphic_many_to_one`, `update_one_to_one`, and `update_polymorphic_one_to_one` methods in `ForestAdminAgent::Routes::Resources::Related::UpdateRelated` [72a09cc]
> - Extracted filter construction logic into `scoped_fk_owner_filter` helper method in `ForestAdminAgent::Routes::Resources::Related::UpdateRelated` and updated `update_many_to_one` and `update_polymorphic_many_to_one` to use it [72a09cc]
> - Added test coverage verifying authorization occurs before ID parsing in `ForestAdminAgent::Routes::Resources::Related::UpdateRelated` [72a09cc]
> - Updated inline comment documentation in `ForestAdminAgent::Routes::Resources::Related::UpdateRelated.handle_request` method [1884010]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 385aa62. 3 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->