### PR TITLE
feat(datasource-pylon): filters, search and PK short-circuit hardening

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -358,6 +358,7 @@ Metrics/BlockLength:
 Metrics/ClassLength:
   Exclude:
     - 'packages/forest_admin_datasource_zendesk/lib/forest_admin_datasource_zendesk/collections/base_collection.rb'
+    - 'packages/forest_admin_datasource_pylon/lib/forest_admin_datasource_pylon/collections/base_collection.rb'
     - 'packages/forest_admin_datasource_snowflake/lib/forest_admin_datasource_snowflake/collection.rb'
     - 'packages/forest_admin_datasource_snowflake/lib/forest_admin_datasource_snowflake/datasource.rb'
     - 'packages/forest_admin_datasource_snowflake/lib/forest_admin_datasource_snowflake/utils/query.rb'

--- a/packages/forest_admin_datasource_pylon/lib/forest_admin_datasource_pylon/collections/base_collection.rb
+++ b/packages/forest_admin_datasource_pylon/lib/forest_admin_datasource_pylon/collections/base_collection.rb
@@ -21,6 +21,11 @@ module ForestAdminDatasourcePylon
                              Operators::LONGER_THAN, Operators::SHORTER_THAN, Operators::INCLUDES_ALL,
                              Operators::NOT_IN, Operators::NOT_EQUAL, Operators::NOT_CONTAINS].freeze
 
+      # The operators `ConditionTreeLeaf#match` evaluates by dereferencing the
+      # column value without a nil guard, unlike the string operators which all
+      # test `is_a?(String)` first. They need the guard added here.
+      NIL_UNSAFE_OPERATORS = [Operators::LESS_THAN, Operators::GREATER_THAN, Operators::INCLUDES_ALL].freeze
+
       attr_reader :custom_fields
 
       # Template method: subclasses implement `define_schema` and
@@ -56,13 +61,28 @@ module ForestAdminDatasourcePylon
 
         residual = ConditionTreeFactory.intersect(conditions.reject.with_index { |_, index| index == id_index })
         ensure_residual_appliable!(residual)
-        IdLookup.new(ids: id_values(conditions[id_index]), residual: residual)
+        IdLookup.new(ids: id_values(conditions[id_index]), residual: guard_nil_comparisons(residual))
+      end
+
+      # Pylon runs the free-text search inside its search endpoint, which the
+      # primary-key short-circuit does not go through, and neither the fields it
+      # covers nor its fuzziness can be reproduced in memory. Answering with the
+      # unsearched record would be the very thing this datasource refuses: a
+      # result that looks filtered and is not.
+      def ensure_searchless_lookup!(filter)
+        search = filter&.search
+        return if search.nil? || search.to_s.strip.empty?
+
+        raise UnsupportedOperatorError,
+              "A search cannot be combined with a filter on 'id': Pylon searches through its search endpoint, " \
+              'which cannot filter on id, while an id is read through its own endpoint, which cannot search. ' \
+              'Clear the search or drop the id condition.'
       end
 
       def build_pylon_filter(caller, filter)
-        Query::ConditionTreeTranslator.call(filter&.condition_tree,
-                                            api_filters: api_filters,
-                                            timezone: timezone_for(caller))
+        tree = filter&.condition_tree
+        ensure_no_stray_id!(tree)
+        Query::ConditionTreeTranslator.call(tree, api_filters: api_filters, timezone: timezone_for(caller))
       end
 
       # Overridden by collections whose endpoint can filter server-side.
@@ -158,6 +178,22 @@ module ForestAdminDatasourcePylon
         node.is_a?(Branch) && node.aggregator.to_s.casecmp('and').zero?
       end
 
+      # An `id` the short-circuit could not take out of the tree has no
+      # translation left: Pylon filters no id server-side, and an id under an OR
+      # cannot be narrowed to a lookup because the other side of the union would
+      # bring in records the lookup never fetched. The UI does offer both an
+      # `id equals` filter and the or/and toggle, so this is worth an error an
+      # operator can act on rather than the translator's "add it to api_filters".
+      def ensure_no_stray_id!(node)
+        return if node.nil?
+        return unless node.some_leaf { |leaf| leaf.field == 'id' }
+
+        raise UnsupportedOperatorError,
+              "A filter on 'id' has to be combined with 'and' conditions only: Pylon cannot filter on id, so the " \
+              'agent reads the records by id and applies the rest in memory, which an id inside an `or` would ' \
+              'silently widen. Rewrite the filter with `and`, or filter on another field.'
+      end
+
       def clamp_custom_field_operators(column_name, schema)
         declared = Array(schema.filter_operators)
         dropped  = declared - allowed_custom_field_operators
@@ -187,6 +223,21 @@ module ForestAdminDatasourcePylon
         return false if column.nil? || column.column_type == 'Json'
 
         Equivalent.equivalent_tree?(leaf.operator, IN_MEMORY_OPERATORS, column.column_type)
+      end
+
+      # `ConditionTreeLeaf#match` compares with a bare `<` / `>`, which raises a
+      # NoMethodError on a column Pylon leaves null -- `resolution_time` on an
+      # unresolved issue, for one. Pairing the comparison with a presence check
+      # reproduces what a database does with NULL, excluding the record, and
+      # rides on the in-memory equivalence PRESENT already has for every type.
+      def guard_nil_comparisons(node)
+        return nil if node.nil?
+
+        node.replace_leafs do |leaf|
+          next leaf unless NIL_UNSAFE_OPERATORS.include?(leaf.operator)
+
+          ConditionTreeFactory.intersect([Leaf.new(leaf.field, Operators::PRESENT), leaf])
+        end
       end
 
       def raise_unappliable_residual(leaf)

--- a/packages/forest_admin_datasource_pylon/lib/forest_admin_datasource_pylon/collections/base_collection.rb
+++ b/packages/forest_admin_datasource_pylon/lib/forest_admin_datasource_pylon/collections/base_collection.rb
@@ -6,10 +6,20 @@ module ForestAdminDatasourcePylon
       Branch               = ForestAdminDatasourceToolkit::Components::Query::ConditionTree::Nodes::ConditionTreeBranch
       Leaf                 = ForestAdminDatasourceToolkit::Components::Query::ConditionTree::Nodes::ConditionTreeLeaf
       ConditionTreeFactory = ForestAdminDatasourceToolkit::Components::Query::ConditionTree::ConditionTreeFactory
+      Equivalent           = ForestAdminDatasourceToolkit::Components::Query::ConditionTree::ConditionTreeEquivalent
+      SortFactory          = ForestAdminDatasourceToolkit::Components::Query::SortUtils::SortFactory
 
       # `residual` holds the conditions left over once the primary-key leaf has
       # been taken out of the tree, for the caller to apply in memory.
       IdLookup = Struct.new(:ids, :residual, keyword_init: true)
+
+      # Mirrors the operators `ConditionTreeLeaf#match` evaluates natively; any
+      # other operator needs an equivalence for the column's type to be
+      # evaluable in memory.
+      IN_MEMORY_OPERATORS = [Operators::IN, Operators::EQUAL, Operators::LESS_THAN, Operators::GREATER_THAN,
+                             Operators::MATCH, Operators::STARTS_WITH, Operators::ENDS_WITH,
+                             Operators::LONGER_THAN, Operators::SHORTER_THAN, Operators::INCLUDES_ALL,
+                             Operators::NOT_IN, Operators::NOT_EQUAL, Operators::NOT_CONTAINS].freeze
 
       attr_reader :custom_fields
 
@@ -44,8 +54,9 @@ module ForestAdminDatasourcePylon
         id_index = conditions.index { |condition| id_values(condition) }
         return nil if id_index.nil?
 
-        residual = conditions.reject.with_index { |_, index| index == id_index }
-        IdLookup.new(ids: id_values(conditions[id_index]), residual: ConditionTreeFactory.intersect(residual))
+        residual = ConditionTreeFactory.intersect(conditions.reject.with_index { |_, index| index == id_index })
+        ensure_residual_appliable!(residual)
+        IdLookup.new(ids: id_values(conditions[id_index]), residual: residual)
       end
 
       def build_pylon_filter(caller, filter)
@@ -69,6 +80,13 @@ module ForestAdminDatasourcePylon
         return [nil, nil] unless pylon_field
 
         [pylon_field, ascending ? 'asc' : 'desc']
+      end
+
+      # The agent injects an ascending primary-key sort whenever the request
+      # asks for no order, so the default cannot be told apart from a chosen
+      # order by presence alone.
+      def default_pk_sort?(sort)
+        normalized_sort_clauses(sort) == normalized_sort_clauses(SortFactory.by_primary_keys(self))
       end
 
       def timezone_for(caller)
@@ -95,22 +113,33 @@ module ForestAdminDatasourcePylon
       end
 
       # Adds custom fields, skipping any whose column name collides with a
-      # field already declared on the collection. Returns the subset actually
-      # added so callers can keep their serializer in sync with the schema.
+      # field already declared on the collection, and clamping the declared
+      # operators to those the API accepts on a custom field — so the schema
+      # never advertises a filter the translator would then refuse. Returns
+      # the subset actually added, carrying the clamped schemas, so callers
+      # can keep their serializer and api_filters in sync with the schema.
       def add_custom_fields(custom_fields)
-        custom_fields.reject do |cf|
+        custom_fields.filter_map do |cf|
           column_name = cf[:column_name]
           if schema[:fields].key?(column_name)
             ForestAdminDatasourcePylon.logger.warn(
               "[forest_admin_datasource_pylon] Custom field '#{column_name}' on collection " \
               "'#{name}' conflicts with an existing field; skipping."
             )
-            true
+            nil
           else
-            add_field(column_name, cf[:schema])
-            false
+            clamped = clamp_custom_field_operators(column_name, cf[:schema])
+            add_field(column_name, clamped)
+            cf.merge(schema: clamped)
           end
         end
+      end
+
+      # Operators a custom field may advertise. The empty default matches the
+      # empty `api_filters`: a collection that filters nothing server-side
+      # must not advertise custom-field filters either.
+      def allowed_custom_field_operators
+        []
       end
 
       private
@@ -129,12 +158,57 @@ module ForestAdminDatasourcePylon
         node.is_a?(Branch) && node.aggregator.to_s.casecmp('and').zero?
       end
 
+      def clamp_custom_field_operators(column_name, schema)
+        declared = Array(schema.filter_operators)
+        dropped  = declared - allowed_custom_field_operators
+        return schema if dropped.empty?
+
+        ForestAdminDatasourcePylon.logger.warn(
+          "[forest_admin_datasource_pylon] Custom field '#{column_name}' on collection '#{name}' declares " \
+          "operators the API cannot honour on a custom field (#{dropped.join(", ")}); they are not advertised."
+        )
+        schema.dup.tap { |clamped| clamped.filter_operators = declared - dropped }
+      end
+
+      # A residual is evaluated by `ConditionTree#apply`, which compares scalar
+      # values: a Json column holds a list whose Pylon membership semantics
+      # have no in-memory counterpart, and an operator without an equivalence
+      # for the column's type has no in-memory evaluation at all. Both would
+      # silently corrupt the lookup's result, so they are refused instead.
+      def ensure_residual_appliable!(node)
+        case node
+        when Branch then node.conditions.each { |condition| ensure_residual_appliable!(condition) }
+        when Leaf   then raise_unappliable_residual(node) unless residual_leaf_appliable?(node)
+        end
+      end
+
+      def residual_leaf_appliable?(leaf)
+        column = schema[:fields][leaf.field]
+        return false if column.nil? || column.column_type == 'Json'
+
+        Equivalent.equivalent_tree?(leaf.operator, IN_MEMORY_OPERATORS, column.column_type)
+      end
+
+      def raise_unappliable_residual(leaf)
+        raise UnsupportedOperatorError,
+              "Operator '#{leaf.operator}' on field '#{leaf.field}' cannot be combined with a primary-key " \
+              'lookup: Pylon cannot filter on id server-side, so the other conditions run in memory, ' \
+              'which this one does not support.'
+      end
+
       def sort_field_and_direction(entry)
         return [entry.field, entry.ascending] if entry.respond_to?(:field)
 
         field     = entry.key?(:field)     ? entry[:field]     : entry['field']
         ascending = entry.key?(:ascending) ? entry[:ascending] : entry['ascending']
         [field, ascending]
+      end
+
+      def normalized_sort_clauses(sort)
+        Array(sort).map do |entry|
+          field, ascending = sort_field_and_direction(entry)
+          [field.to_s, ascending]
+        end
       end
     end
   end

--- a/packages/forest_admin_datasource_pylon/lib/forest_admin_datasource_pylon/collections/base_collection.rb
+++ b/packages/forest_admin_datasource_pylon/lib/forest_admin_datasource_pylon/collections/base_collection.rb
@@ -1,15 +1,15 @@
 module ForestAdminDatasourcePylon
   module Collections
     class BaseCollection < ForestAdminDatasourceToolkit::Collection
-      ColumnSchema = ForestAdminDatasourceToolkit::Schema::ColumnSchema
-      Operators    = ForestAdminDatasourceToolkit::Components::Query::ConditionTree::Operators
-      Leaf         = ForestAdminDatasourceToolkit::Components::Query::ConditionTree::Nodes::ConditionTreeLeaf
+      ColumnSchema         = ForestAdminDatasourceToolkit::Schema::ColumnSchema
+      Operators            = ForestAdminDatasourceToolkit::Components::Query::ConditionTree::Operators
+      Branch               = ForestAdminDatasourceToolkit::Components::Query::ConditionTree::Nodes::ConditionTreeBranch
+      Leaf                 = ForestAdminDatasourceToolkit::Components::Query::ConditionTree::Nodes::ConditionTreeLeaf
+      ConditionTreeFactory = ForestAdminDatasourceToolkit::Components::Query::ConditionTree::ConditionTreeFactory
 
-      STRING_OPS = [Operators::EQUAL, Operators::NOT_EQUAL, Operators::IN, Operators::NOT_IN,
-                    Operators::PRESENT, Operators::BLANK].freeze
-      NUMBER_OPS = (STRING_OPS + [Operators::GREATER_THAN, Operators::LESS_THAN]).freeze
-      DATE_OPS   = [Operators::EQUAL, Operators::BEFORE, Operators::AFTER,
-                    Operators::PRESENT, Operators::BLANK].freeze
+      # `residual` holds the conditions left over once the primary-key leaf has
+      # been taken out of the tree, for the caller to apply in memory.
+      IdLookup = Struct.new(:ids, :residual, keyword_init: true)
 
       attr_reader :custom_fields
 
@@ -31,12 +31,51 @@ module ForestAdminDatasourcePylon
       # Pylon has no `id` filter operator on /issues/search, so collections
       # short-circuit primary-key lookups to /resource/{id}. Ids are UUID
       # strings — unlike Zendesk, nothing has to be coerced to an integer.
+      #
+      # The leaf is also pulled out of a top-level AND, because Forest sends
+      # `AND(id equal X, <scope>)` on a record detail as soon as a scope or a
+      # segment is set, and `id` is not a field Pylon can filter on.
       def extract_id_lookup(node)
-        return nil unless node.is_a?(Leaf) && node.field == 'id'
+        ids = id_values(node)
+        return IdLookup.new(ids: ids, residual: nil) if ids
+        return nil unless and_branch?(node)
 
-        return unless [Operators::EQUAL, Operators::IN].include?(node.operator)
+        conditions = Array(node.conditions)
+        id_index = conditions.index { |condition| id_values(condition) }
+        return nil if id_index.nil?
 
-        Array(node.value).map(&:to_s).reject(&:empty?)
+        residual = conditions.reject.with_index { |_, index| index == id_index }
+        IdLookup.new(ids: id_values(conditions[id_index]), residual: ConditionTreeFactory.intersect(residual))
+      end
+
+      def build_pylon_filter(caller, filter)
+        Query::ConditionTreeTranslator.call(filter&.condition_tree,
+                                            api_filters: api_filters,
+                                            timezone: timezone_for(caller))
+      end
+
+      # Overridden by collections whose endpoint can filter server-side.
+      def api_filters
+        {}
+      end
+
+      # An unknown field silently disables sorting: a Pylon endpoint only honours
+      # the fixed allow-list its collection declares.
+      def translate_sort(sort, allow_list)
+        return [nil, nil] if sort.nil? || sort.empty?
+
+        field, ascending = sort_field_and_direction(sort.first)
+        pylon_field = allow_list[field.to_s]
+        return [nil, nil] unless pylon_field
+
+        [pylon_field, ascending ? 'asc' : 'desc']
+      end
+
+      def timezone_for(caller)
+        return 'UTC' unless caller.respond_to?(:timezone)
+
+        timezone = caller.timezone
+        timezone.nil? || timezone.to_s.empty? ? 'UTC' : timezone
       end
 
       def project(record, projection)
@@ -78,6 +117,25 @@ module ForestAdminDatasourcePylon
 
       def define_schema    = raise(NotImplementedError, "#{self.class} did not implement define_schema")
       def define_relations = raise(NotImplementedError, "#{self.class} did not implement define_relations")
+
+      def id_values(node)
+        return nil unless node.is_a?(Leaf) && node.field == 'id'
+        return nil unless [Operators::EQUAL, Operators::IN].include?(node.operator)
+
+        Array(node.value).map(&:to_s).reject(&:empty?)
+      end
+
+      def and_branch?(node)
+        node.is_a?(Branch) && node.aggregator.to_s.casecmp('and').zero?
+      end
+
+      def sort_field_and_direction(entry)
+        return [entry.field, entry.ascending] if entry.respond_to?(:field)
+
+        field     = entry.key?(:field)     ? entry[:field]     : entry['field']
+        ascending = entry.key?(:ascending) ? entry[:ascending] : entry['ascending']
+        [field, ascending]
+      end
     end
   end
 end

--- a/packages/forest_admin_datasource_pylon/lib/forest_admin_datasource_pylon/collections/issue.rb
+++ b/packages/forest_admin_datasource_pylon/lib/forest_admin_datasource_pylon/collections/issue.rb
@@ -83,19 +83,21 @@ module ForestAdminDatasourcePylon
         records[offset, limit] || []
       end
 
-      # A record the operator can no longer reach — deleted, or outside the
-      # token's scope — reads as "no record" rather than as a failed page.
       def fetch_by_ids(ids)
         wanted = ids.first(MAX_ID_LOOKUPS)
         warn_truncated_lookup(ids.size) if ids.size > wanted.size
 
-        wanted.filter_map do |id|
-          datasource.client.fetch_issue(id)
-        rescue APIError => e
-          raise unless e.status == 404
+        wanted.filter_map { |id| fetch_issue(id) }
+      end
 
-          nil
-        end
+      # A record the operator can no longer reach — deleted, or outside the
+      # token's scope — reads as "no record" rather than as a failed page.
+      def fetch_issue(id)
+        datasource.client.fetch_issue(id)
+      rescue APIError => e
+        raise unless e.status == 404
+
+        nil
       end
 
       def warn_truncated_lookup(asked)

--- a/packages/forest_admin_datasource_pylon/lib/forest_admin_datasource_pylon/collections/issue.rb
+++ b/packages/forest_admin_datasource_pylon/lib/forest_admin_datasource_pylon/collections/issue.rb
@@ -4,25 +4,59 @@ module ForestAdminDatasourcePylon
       include SchemaDefinition
       include Serializer
 
+      # `/issues/search` exposes no sort parameter, so the allow-list is empty and
+      # every requested order is reported instead of being silently swallowed.
+      # The mechanism stays in place for the collections whose endpoint sorts.
+      PYLON_SORTABLE = {}.freeze
+
       def initialize(datasource, custom_fields: [])
-        super(datasource, 'PylonIssue', custom_fields: custom_fields)
+        super(datasource, 'PylonIssue', custom_fields: custom_fields, searchable: true)
       end
 
-      def list(_caller, filter, projection)
-        fetch_records(filter).map { |issue| project(serialize(issue), projection) }
+      def list(caller, filter, projection)
+        fetch_records(caller, filter).map { |record| project(record, projection) }
+      end
+
+      protected
+
+      # A custom field is filtered through its Pylon slug, with the operators the
+      # integrator declared on the column.
+      def api_filters
+        @api_filters ||= custom_fields.each_with_object(ApiFilters::API_FILTERS.dup) do |cf, filters|
+          filters[cf[:column_name]] = ApiFilters.for_custom_field(cf[:schema])
+        end
       end
 
       private
 
-      def fetch_records(filter)
-        ids = extract_id_lookup(filter&.condition_tree)
-        return page_window(fetch_by_ids(ids), filter) if ids
+      def fetch_records(caller, filter)
+        lookup = extract_id_lookup(filter&.condition_tree)
+        return page_window(records_by_id(caller, lookup), filter) if lookup
 
-        warn_ignored_filter(filter)
+        search_records(caller, filter)
+      end
+
+      def search_records(caller, filter)
+        warn_unsortable(filter&.sort)
+        pylon_filter  = build_pylon_filter(caller, filter)
+        search_text   = filter&.search
         offset, limit = translate_page(filter&.page)
-        walker.walk(offset: offset, limit: limit) do |batch, cursor|
-          datasource.client.search_issues(limit: batch, cursor: cursor)
+
+        issues = walker.walk(offset: offset, limit: limit) do |batch, cursor|
+          datasource.client.search_issues(limit: batch, cursor: cursor,
+                                          filter: pylon_filter, search_text: search_text)
         end
+        issues.map { |issue| serialize(issue) }
+      end
+
+      # The records are already narrowed to the ids the filter asked for, so
+      # applying the conditions left over by the short-circuit in memory cannot
+      # return a record the API would have excluded.
+      def records_by_id(caller, lookup)
+        records = fetch_by_ids(lookup.ids).map { |issue| serialize(issue) }
+        return records if lookup.residual.nil?
+
+        lookup.residual.apply(records, self, timezone_for(caller))
       end
 
       # Sliced after the lookup, not before, so ids that resolved to nothing
@@ -44,18 +78,13 @@ module ForestAdminDatasourcePylon
         end
       end
 
-      # Condition-tree translation and free-text search land in a later story.
-      # Until then a filter the collection cannot honour is dropped, which would
-      # otherwise silently return unfiltered rows.
-      def warn_ignored_filter(filter)
-        ignored = []
-        ignored << 'condition tree' unless filter&.condition_tree.nil?
-        ignored << 'search' unless filter&.search.nil? || filter.search.to_s.empty?
-        return if ignored.empty?
+      def warn_unsortable(sort)
+        return if sort.nil? || sort.empty?
+        return if translate_sort(sort, PYLON_SORTABLE).first
 
         ForestAdminDatasourcePylon.logger.warn(
-          "[forest_admin_datasource_pylon] PylonIssue ignored the #{ignored.join(" and ")} of this query; " \
-          'filtering is not implemented yet, so the returned records are unfiltered.'
+          '[forest_admin_datasource_pylon] PylonIssue cannot honour the requested order; ' \
+          'POST /issues/search always returns issues from the most recent to the oldest.'
         )
       end
 

--- a/packages/forest_admin_datasource_pylon/lib/forest_admin_datasource_pylon/collections/issue.rb
+++ b/packages/forest_admin_datasource_pylon/lib/forest_admin_datasource_pylon/collections/issue.rb
@@ -27,6 +27,12 @@ module ForestAdminDatasourcePylon
         end
       end
 
+      # Declarations outside this list are dropped at registration, so the
+      # schema never advertises an operator the translator would refuse.
+      def allowed_custom_field_operators
+        ApiFilters::CUSTOM_FIELD_OPS.keys
+      end
+
       private
 
       def fetch_records(caller, filter)
@@ -51,7 +57,9 @@ module ForestAdminDatasourcePylon
 
       # The records are already narrowed to the ids the filter asked for, so
       # applying the conditions left over by the short-circuit in memory cannot
-      # return a record the API would have excluded.
+      # return a record the API would have excluded. The reverse — dropping a
+      # record over a condition memory evaluates differently from Pylon — is
+      # ruled out by `extract_id_lookup`, which refuses such residuals.
       def records_by_id(caller, lookup)
         records = fetch_by_ids(lookup.ids).map { |issue| serialize(issue) }
         return records if lookup.residual.nil?
@@ -79,7 +87,7 @@ module ForestAdminDatasourcePylon
       end
 
       def warn_unsortable(sort)
-        return if sort.nil? || sort.empty?
+        return if sort.nil? || sort.empty? || default_pk_sort?(sort)
         return if translate_sort(sort, PYLON_SORTABLE).first
 
         ForestAdminDatasourcePylon.logger.warn(

--- a/packages/forest_admin_datasource_pylon/lib/forest_admin_datasource_pylon/collections/issue.rb
+++ b/packages/forest_admin_datasource_pylon/lib/forest_admin_datasource_pylon/collections/issue.rb
@@ -9,6 +9,14 @@ module ForestAdminDatasourcePylon
       # The mechanism stays in place for the collections whose endpoint sorts.
       PYLON_SORTABLE = {}.freeze
 
+      # A primary-key lookup spends one `GET /issues/{id}` per id, against the
+      # same 20 requests/minute budget the cursor walk is capped for, and the
+      # retry policy only absorbs three 429s. The fan-out is therefore bounded
+      # like the walk: truncated with a warning rather than turned into a rate
+      # limit error halfway through the page. Story 9 (EXT-13) owns the
+      # throttling that would let this cap grow.
+      MAX_ID_LOOKUPS = 20
+
       def initialize(datasource, custom_fields: [])
         super(datasource, 'PylonIssue', custom_fields: custom_fields, searchable: true)
       end
@@ -36,14 +44,15 @@ module ForestAdminDatasourcePylon
       private
 
       def fetch_records(caller, filter)
+        warn_unsortable(filter&.sort)
         lookup = extract_id_lookup(filter&.condition_tree)
-        return page_window(records_by_id(caller, lookup), filter) if lookup
+        return search_records(caller, filter) unless lookup
 
-        search_records(caller, filter)
+        ensure_searchless_lookup!(filter)
+        page_window(records_by_id(caller, lookup), filter)
       end
 
       def search_records(caller, filter)
-        warn_unsortable(filter&.sort)
         pylon_filter  = build_pylon_filter(caller, filter)
         search_text   = filter&.search
         offset, limit = translate_page(filter&.page)
@@ -77,13 +86,24 @@ module ForestAdminDatasourcePylon
       # A record the operator can no longer reach — deleted, or outside the
       # token's scope — reads as "no record" rather than as a failed page.
       def fetch_by_ids(ids)
-        ids.filter_map do |id|
+        wanted = ids.first(MAX_ID_LOOKUPS)
+        warn_truncated_lookup(ids.size) if ids.size > wanted.size
+
+        wanted.filter_map do |id|
           datasource.client.fetch_issue(id)
         rescue APIError => e
           raise unless e.status == 404
 
           nil
         end
+      end
+
+      def warn_truncated_lookup(asked)
+        ForestAdminDatasourcePylon.logger.warn(
+          "[forest_admin_datasource_pylon] Asked for #{asked} issues by id, reading the first " \
+          "#{MAX_ID_LOOKUPS}: one request per id would exhaust the rate limit of the agent. " \
+          'Narrow the selection to reach the records past this point.'
+        )
       end
 
       def warn_unsortable(sort)

--- a/packages/forest_admin_datasource_pylon/lib/forest_admin_datasource_pylon/collections/issue/api_filters.rb
+++ b/packages/forest_admin_datasource_pylon/lib/forest_admin_datasource_pylon/collections/issue/api_filters.rb
@@ -26,11 +26,14 @@ module ForestAdminDatasourcePylon
         TIME = { Operators::GREATER_THAN => 'time_is_after',
                  Operators::LESS_THAN => 'time_is_before' }.freeze
 
-        # Pylon exposes a single substring operator, so both Forest spellings of
-        # "contains" map onto it.
+        # Pylon exposes a single substring operator per direction and documents
+        # no case semantics for either, so both Forest spellings map onto the
+        # one operator -- in both directions, or the UI would offer a
+        # case-insensitive "contains" with no way to negate it.
         FULL_TEXT = { Operators::CONTAINS => 'string_contains',
                       Operators::I_CONTAINS => 'string_contains',
-                      Operators::NOT_CONTAINS => 'string_does_not_contain' }.freeze
+                      Operators::NOT_CONTAINS => 'string_does_not_contain',
+                      Operators::NOT_I_CONTAINS => 'string_does_not_contain' }.freeze
 
         # `tags` holds a list: `contains` asks whether one tag belongs to it,
         # while `in` matches it against several candidates at once.

--- a/packages/forest_admin_datasource_pylon/lib/forest_admin_datasource_pylon/collections/issue/api_filters.rb
+++ b/packages/forest_admin_datasource_pylon/lib/forest_admin_datasource_pylon/collections/issue/api_filters.rb
@@ -1,0 +1,75 @@
+module ForestAdminDatasourcePylon
+  module Collections
+    class Issue < BaseCollection
+      # The allow-list of `POST /issues/search`, transcribed from the API
+      # reference: a field absent from this table cannot be filtered at all, and
+      # an operator absent from a field's map is rejected by Pylon.
+      #
+      # It is the single source of truth for filtering — `define_schema` derives
+      # every column's `filter_operators` from it, so the schema cannot
+      # advertise a filter the translator would then refuse.
+      module ApiFilters
+        Operators = BaseCollection::Operators
+
+        # `not_equal` is deliberately absent: the toolkit derives it from
+        # `not_in`, so declaring it would only add a second spelling.
+        EQUALITY = { Operators::EQUAL => 'equals',
+                     Operators::IN => 'in',
+                     Operators::NOT_IN => 'not_in' }.freeze
+
+        PRESENCE = { Operators::PRESENT => 'is_set',
+                     Operators::BLANK => 'is_unset' }.freeze
+
+        # Declaring the bare comparisons rather than before/after is what lets
+        # the toolkit rewrite Today / PreviousWeek / ... into a pair of bounds,
+        # which is also why `time_range` never has to be emitted.
+        TIME = { Operators::GREATER_THAN => 'time_is_after',
+                 Operators::LESS_THAN => 'time_is_before' }.freeze
+
+        # Pylon exposes a single substring operator, so both Forest spellings of
+        # "contains" map onto it.
+        FULL_TEXT = { Operators::CONTAINS => 'string_contains',
+                      Operators::I_CONTAINS => 'string_contains',
+                      Operators::NOT_CONTAINS => 'string_does_not_contain' }.freeze
+
+        # `tags` holds a list: `contains` asks whether one tag belongs to it,
+        # while `in` matches it against several candidates at once.
+        MEMBERSHIP = { Operators::CONTAINS => 'contains',
+                       Operators::NOT_CONTAINS => 'does_not_contain',
+                       Operators::IN => 'in',
+                       Operators::NOT_IN => 'not_in' }.freeze
+
+        # `param` carries the read-to-filter renames: an issue is read with
+        # `type` / `resolution_time` / `latest_message_time` but filtered on
+        # `issue_type` / `resolved_at` / `latest_message_activity_at`.
+        API_FILTERS = {
+          'state' => { ops: EQUALITY },
+          'type' => { param: 'issue_type', ops: EQUALITY.merge(PRESENCE) },
+          'account_id' => { ops: EQUALITY.merge(PRESENCE) },
+          'requester_id' => { ops: EQUALITY.merge(PRESENCE) },
+          'assignee_id' => { ops: EQUALITY.merge(PRESENCE) },
+          'team_id' => { ops: EQUALITY },
+          'title' => { ops: FULL_TEXT },
+          'body_html' => { ops: FULL_TEXT },
+          'tags' => { ops: MEMBERSHIP },
+          'created_at' => { ops: TIME },
+          'updated_at' => { ops: TIME },
+          'resolution_time' => { param: 'resolved_at', ops: TIME },
+          'latest_message_time' => { param: 'latest_message_activity_at', ops: TIME }
+        }.freeze
+
+        # A custom field is filtered through its slug, so the operators come
+        # from the column the integrator declared rather than from a table.
+        CUSTOM_FIELD_OPS = EQUALITY.merge(PRESENCE).merge(TIME).merge(FULL_TEXT).freeze
+
+        def self.forest_operators(field)
+          API_FILTERS.dig(field, :ops)&.keys || []
+        end
+
+        def self.for_custom_field(schema)
+          { ops: CUSTOM_FIELD_OPS.slice(*Array(schema&.filter_operators)) }
+        end
+      end
+    end
+  end
+end

--- a/packages/forest_admin_datasource_pylon/lib/forest_admin_datasource_pylon/collections/issue/schema_definition.rb
+++ b/packages/forest_admin_datasource_pylon/lib/forest_admin_datasource_pylon/collections/issue/schema_definition.rb
@@ -1,17 +1,19 @@
 module ForestAdminDatasourcePylon
   module Collections
     class Issue < BaseCollection
-      # Every column is read-only and non-sortable in this story: writes land in
-      # a later story, and `/issues/search` exposes no sort parameter at all —
-      # results always come back ordered by `created_at` descending, so
+      # Every column is read-only in this story: writes land in a later one. No
+      # column is sortable either — `/issues/search` exposes no sort parameter at
+      # all, results always come back ordered by `created_at` descending, so
       # advertising a sortable column would let the UI ask for an order the API
       # cannot honour.
+      #
+      # Filter operators are not chosen here: they come from
+      # `ApiFilters::API_FILTERS`, which mirrors the allow-list of the API. A
+      # column missing from that table gets no operator, so the UI never offers
+      # a filter Pylon would refuse.
       module SchemaDefinition
         ColumnSchema = BaseCollection::ColumnSchema
         Operators    = BaseCollection::Operators
-        STRING_OPS   = BaseCollection::STRING_OPS
-        NUMBER_OPS   = BaseCollection::NUMBER_OPS
-        DATE_OPS     = BaseCollection::DATE_OPS
 
         private
 
@@ -28,47 +30,48 @@ module ForestAdminDatasourcePylon
 
         def define_identity_fields
           # Only equal/in: these are the two the primary-key short-circuit can
-          # actually serve through GET /issues/{id}.
+          # actually serve through GET /issues/{id}. `id` is not part of the
+          # search allow-list, so it never reaches the translator.
           add_field('id', ColumnSchema.new(column_type: 'String',
                                            filter_operators: [Operators::EQUAL, Operators::IN],
                                            is_primary_key: true, is_read_only: true))
-          add_field('number', column('Number', NUMBER_OPS))
-          add_field('link', column('String', []))
+          add_column('number', 'Number')
+          add_column('link', 'String')
         end
 
         def define_content_fields
-          add_field('title', column('String', STRING_OPS))
-          add_field('body_html', column('String', []))
+          add_column('title', 'String')
+          add_column('body_html', 'String')
           # Left as String rather than Enum: Pylon ships five built-in states
           # but organisations define their own on top of them.
-          add_field('state', column('String', STRING_OPS))
-          add_field('type', column('String', STRING_OPS))
-          add_field('source', column('String', STRING_OPS))
-          add_field('tags', column('Json', []))
-          add_field('customer_portal_visible', column('Boolean', []))
-          add_field('author_unverified', column('Boolean', []))
-          add_field('number_of_touches', column('Number', NUMBER_OPS))
+          add_column('state', 'String')
+          add_column('type', 'String')
+          add_column('source', 'String')
+          add_column('tags', 'Json')
+          add_column('customer_portal_visible', 'Boolean')
+          add_column('author_unverified', 'Boolean')
+          add_column('number_of_touches', 'Number')
         end
 
         # Flattened from the nested `{id: …}` objects Pylon returns. They stay
         # plain columns until the story that adds the related collections.
         def define_party_fields
-          %w[account_id requester_id assignee_id team_id].each do |field|
-            add_field(field, column('String', STRING_OPS))
-          end
+          %w[account_id requester_id assignee_id team_id].each { |field| add_column(field, 'String') }
         end
 
         def define_time_fields
           %w[first_response_time resolution_time latest_message_time created_at updated_at].each do |field|
-            add_field(field, column('Date', DATE_OPS))
+            add_column(field, 'Date')
           end
           %w[time_in_status_seconds business_hours_time_in_status_seconds].each do |field|
-            add_field(field, column('Json', []))
+            add_column(field, 'Json')
           end
         end
 
-        def column(type, operators)
-          ColumnSchema.new(column_type: type, filter_operators: operators, is_read_only: true)
+        def add_column(name, type)
+          add_field(name, ColumnSchema.new(column_type: type,
+                                           filter_operators: ApiFilters.forest_operators(name),
+                                           is_read_only: true))
         end
       end
     end

--- a/packages/forest_admin_datasource_pylon/lib/forest_admin_datasource_pylon/query/condition_tree_translator.rb
+++ b/packages/forest_admin_datasource_pylon/lib/forest_admin_datasource_pylon/query/condition_tree_translator.rb
@@ -1,0 +1,156 @@
+require 'active_support/core_ext/time/zones'
+
+module ForestAdminDatasourcePylon
+  module Query
+    # See https://docs.usepylon.com/pylon-docs/developer/api/api-reference/issues
+    #
+    # Translates a Forest condition tree into the structured JSON filter of
+    # `POST /issues/search`:
+    #
+    #   leaf   -> { 'field' => …, 'operator' => …, 'value' | 'values' => … }
+    #   branch -> { 'operator' => 'and' | 'or', 'subfilters' => [...] }
+    #
+    # Pylon nests sub-filters, so — unlike the Zendesk query string — OR is
+    # translated natively instead of being rejected.
+    #
+    # Anything the API cannot express raises UnsupportedOperatorError: a filter
+    # that is dropped returns unfiltered rows which look filtered.
+    class ConditionTreeTranslator
+      Operators = ForestAdminDatasourceToolkit::Components::Query::ConditionTree::Operators
+      Branch    = ForestAdminDatasourceToolkit::Components::Query::ConditionTree::Nodes::ConditionTreeBranch
+      Leaf      = ForestAdminDatasourceToolkit::Components::Query::ConditionTree::Nodes::ConditionTreeLeaf
+
+      # Pylon rejects sub-filters nested deeper than three levels.
+      MAX_DEPTH = 3
+
+      LIST_OPERATORS      = %w[in not_in].freeze
+      VALUELESS_OPERATORS = %w[is_set is_unset].freeze
+
+      def self.call(condition_tree, api_filters: {}, timezone: nil)
+        return nil if condition_tree.nil?
+
+        new(api_filters: api_filters, timezone: timezone).translate(condition_tree)
+      end
+
+      def initialize(api_filters: {}, timezone: nil)
+        @api_filters = api_filters || {}
+        @timezone = timezone.to_s.strip.empty? ? 'UTC' : timezone
+      end
+
+      def translate(node, depth = 1)
+        case node
+        when Branch then translate_branch(node, depth)
+        when Leaf   then translate_leaf(node)
+        else
+          raise UnsupportedOperatorError, "Unknown condition node: #{node.class}"
+        end
+      end
+
+      private
+
+      def translate_branch(branch, depth)
+        conditions = Array(branch.conditions)
+        if conditions.empty?
+          raise UnsupportedOperatorError, "Condition tree aggregator '#{branch.aggregator}' carries no condition."
+        end
+
+        # A lone condition needs no wrapper, and spending no nesting level on it
+        # keeps trees the agent builds one branch at a time under Pylon's cap.
+        return translate(conditions.first, depth) if conditions.size == 1
+
+        raise_too_deep(depth) if depth > MAX_DEPTH
+
+        { 'operator' => aggregator(branch),
+          'subfilters' => conditions.map { |condition| translate(condition, depth + 1) } }
+      end
+
+      def aggregator(branch)
+        value = branch.aggregator.to_s.downcase
+        return value if %w[and or].include?(value)
+
+        raise UnsupportedOperatorError,
+              "Unknown condition tree aggregator #{branch.aggregator.inspect}; expected 'And' or 'Or'."
+      end
+
+      def translate_leaf(leaf)
+        spec = @api_filters[leaf.field]
+        raise_unfilterable_field(leaf.field) unless spec
+
+        operator = spec[:ops][leaf.operator]
+        raise_unsupported_operator(leaf, spec) unless operator
+
+        with_value({ 'field' => (spec[:param] || leaf.field).to_s, 'operator' => operator }, operator, leaf)
+      end
+
+      def with_value(filter, operator, leaf)
+        return filter if VALUELESS_OPERATORS.include?(operator)
+        return filter.merge('values' => list_value(leaf)) if LIST_OPERATORS.include?(operator)
+
+        filter.merge('value' => single_value(leaf))
+      end
+
+      def single_value(leaf)
+        raise_nil_value(leaf.field) if leaf.value.nil?
+
+        format_value(leaf.value)
+      end
+
+      # An empty list would translate to a filter matching everything, turning
+      # "match nothing" into its exact opposite.
+      def list_value(leaf)
+        values = Array(leaf.value).reject { |value| value.nil? || value.to_s.empty? }
+        if values.empty?
+          raise UnsupportedOperatorError,
+                "Operator '#{leaf.operator}' on field '#{leaf.field}' was given an empty list; " \
+                'pass at least one value, or use the PRESENT / BLANK operators.'
+        end
+
+        values.map { |value| format_value(value) }
+      end
+
+      # Numbers and booleans travel as they are: the filter is JSON, not a query
+      # string, so only the date types need a wire format.
+      def format_value(value)
+        case value
+        when Time, DateTime then value.to_time.utc.iso8601
+        when Date           then format_date(value)
+        else                     value
+        end
+      end
+
+      def format_date(value)
+        Time.use_zone(@timezone) { Time.zone.local(value.year, value.month, value.day).utc.iso8601 }
+      rescue ArgumentError
+        ForestAdminDatasourcePylon.logger.warn(
+          "[forest_admin_datasource_pylon] unknown timezone '#{@timezone}', falling back to UTC"
+        )
+        value.strftime('%Y-%m-%dT00:00:00Z')
+      end
+
+      def raise_too_deep(depth)
+        raise UnsupportedOperatorError,
+              "Pylon rejects a filter nested deeper than #{MAX_DEPTH} levels (reached #{depth}); " \
+              'flatten the segment or the filter.'
+      end
+
+      def raise_unfilterable_field(field)
+        raise UnsupportedOperatorError,
+              "Pylon cannot filter on '#{field}'; add it to the collection's api_filters " \
+              'after checking it against the Pylon API reference.'
+      end
+
+      def raise_unsupported_operator(leaf, spec)
+        raise UnsupportedOperatorError,
+              "Operator '#{leaf.operator}' is not supported on field '#{leaf.field}'. " \
+              "Supported: #{spec[:ops].keys.join(", ")}."
+      end
+
+      # A filter carrying a nil value reads as a presence check on most APIs,
+      # which is silently the wrong query.
+      def raise_nil_value(field)
+        raise UnsupportedOperatorError,
+              "Filter value on '#{field}' is nil; use the PRESENT or BLANK operator to filter for absence."
+      end
+    end
+  end
+end

--- a/packages/forest_admin_datasource_pylon/lib/forest_admin_datasource_pylon/query/condition_tree_translator.rb
+++ b/packages/forest_admin_datasource_pylon/lib/forest_admin_datasource_pylon/query/condition_tree_translator.rb
@@ -1,5 +1,3 @@
-require 'active_support/core_ext/time/zones'
-
 module ForestAdminDatasourcePylon
   module Query
     # See https://docs.usepylon.com/pylon-docs/developer/api/api-reference/issues
@@ -14,11 +12,11 @@ module ForestAdminDatasourcePylon
     # translated natively instead of being rejected.
     #
     # Anything the API cannot express raises UnsupportedOperatorError: a filter
-    # that is dropped returns unfiltered rows which look filtered.
+    # that is dropped returns unfiltered rows which look filtered. The wire
+    # format of the values, and the refusals that go with it, live in FilterValue.
     class ConditionTreeTranslator
-      Operators = ForestAdminDatasourceToolkit::Components::Query::ConditionTree::Operators
-      Branch    = ForestAdminDatasourceToolkit::Components::Query::ConditionTree::Nodes::ConditionTreeBranch
-      Leaf      = ForestAdminDatasourceToolkit::Components::Query::ConditionTree::Nodes::ConditionTreeLeaf
+      Branch = ForestAdminDatasourceToolkit::Components::Query::ConditionTree::Nodes::ConditionTreeBranch
+      Leaf   = ForestAdminDatasourceToolkit::Components::Query::ConditionTree::Nodes::ConditionTreeLeaf
 
       # Pylon rejects sub-filters nested deeper than three levels.
       MAX_DEPTH = 3
@@ -34,7 +32,7 @@ module ForestAdminDatasourcePylon
 
       def initialize(api_filters: {}, timezone: nil)
         @api_filters = api_filters || {}
-        @timezone = timezone.to_s.strip.empty? ? 'UTC' : timezone
+        @value = FilterValue.new(timezone: timezone)
       end
 
       def translate(node, depth = 1)
@@ -54,13 +52,17 @@ module ForestAdminDatasourcePylon
           raise UnsupportedOperatorError, "Condition tree aggregator '#{branch.aggregator}' carries no condition."
         end
 
+        # Validated before the unwrap below, so a branch is refused on the
+        # aggregator it carries rather than on how many conditions it holds.
+        operator = aggregator(branch)
+
         # A lone condition needs no wrapper, and spending no nesting level on it
         # keeps trees the agent builds one branch at a time under Pylon's cap.
         return translate(conditions.first, depth) if conditions.size == 1
 
         raise_too_deep(depth) if depth > MAX_DEPTH
 
-        { 'operator' => aggregator(branch),
+        { 'operator' => operator,
           'subfilters' => conditions.map { |condition| translate(condition, depth + 1) } }
       end
 
@@ -84,47 +86,9 @@ module ForestAdminDatasourcePylon
 
       def with_value(filter, operator, leaf)
         return filter if VALUELESS_OPERATORS.include?(operator)
-        return filter.merge('values' => list_value(leaf)) if LIST_OPERATORS.include?(operator)
+        return filter.merge('values' => @value.list(leaf)) if LIST_OPERATORS.include?(operator)
 
-        filter.merge('value' => single_value(leaf))
-      end
-
-      def single_value(leaf)
-        raise_nil_value(leaf.field) if leaf.value.nil?
-
-        format_value(leaf.value)
-      end
-
-      # An empty list would translate to a filter matching everything, turning
-      # "match nothing" into its exact opposite.
-      def list_value(leaf)
-        values = Array(leaf.value).reject { |value| value.nil? || value.to_s.empty? }
-        if values.empty?
-          raise UnsupportedOperatorError,
-                "Operator '#{leaf.operator}' on field '#{leaf.field}' was given an empty list; " \
-                'pass at least one value, or use the PRESENT / BLANK operators.'
-        end
-
-        values.map { |value| format_value(value) }
-      end
-
-      # Numbers and booleans travel as they are: the filter is JSON, not a query
-      # string, so only the date types need a wire format.
-      def format_value(value)
-        case value
-        when Time, DateTime then value.to_time.utc.iso8601
-        when Date           then format_date(value)
-        else                     value
-        end
-      end
-
-      def format_date(value)
-        Time.use_zone(@timezone) { Time.zone.local(value.year, value.month, value.day).utc.iso8601 }
-      rescue ArgumentError
-        ForestAdminDatasourcePylon.logger.warn(
-          "[forest_admin_datasource_pylon] unknown timezone '#{@timezone}', falling back to UTC"
-        )
-        value.strftime('%Y-%m-%dT00:00:00Z')
+        filter.merge('value' => @value.single(leaf))
       end
 
       def raise_too_deep(depth)
@@ -143,13 +107,6 @@ module ForestAdminDatasourcePylon
         raise UnsupportedOperatorError,
               "Operator '#{leaf.operator}' is not supported on field '#{leaf.field}'. " \
               "Supported: #{spec[:ops].keys.join(", ")}."
-      end
-
-      # A filter carrying a nil value reads as a presence check on most APIs,
-      # which is silently the wrong query.
-      def raise_nil_value(field)
-        raise UnsupportedOperatorError,
-              "Filter value on '#{field}' is nil; use the PRESENT or BLANK operator to filter for absence."
       end
     end
   end

--- a/packages/forest_admin_datasource_pylon/lib/forest_admin_datasource_pylon/query/filter_value.rb
+++ b/packages/forest_admin_datasource_pylon/lib/forest_admin_datasource_pylon/query/filter_value.rb
@@ -1,0 +1,78 @@
+require 'active_support/core_ext/time/zones'
+
+module ForestAdminDatasourcePylon
+  module Query
+    # How a Forest filter value reaches the wire, and every way it can fail to.
+    # Split from the translator, which knows the shape of the condition tree but
+    # not the format of what the leaves carry.
+    class FilterValue
+      def initialize(timezone: nil)
+        @timezone = timezone.to_s.strip.empty? ? 'UTC' : timezone
+      end
+
+      def single(leaf)
+        raise_nil_value(leaf.field) if leaf.value.nil?
+
+        format(leaf.value)
+      end
+
+      # Dropping the blanks would silently answer a different question: `not_in
+      # [nil, 'open']` was asked to exclude the blank records and would come
+      # back including them. An empty list is just as bad the other way round,
+      # translating to a filter matching everything.
+      def list(leaf)
+        values = Array(leaf.value)
+        raise_blank_in_list(leaf) if values.any? { |value| value.nil? || value.to_s.empty? }
+        raise_empty_list(leaf) if values.empty?
+
+        values.map { |value| format(value) }
+      end
+
+      private
+
+      # Numbers and booleans travel as they are: the filter is JSON, not a query
+      # string, so only the date types need a wire format.
+      def format(value)
+        case value
+        when Time, DateTime then value.to_time.utc.iso8601
+        when Date           then format_date(value)
+        else                     value
+        end
+      end
+
+      # Only reached by a condition tree built in Ruby -- a segment or a scope
+      # written as code. Everything coming through HTTP arrives as an ISO8601
+      # string, already expressed in the timezone of the caller: the agent casts
+      # a date filter with `value.to_s`, and the toolkit formats the bounds it
+      # derives from Today / Previous* itself.
+      def format_date(value)
+        Time.use_zone(@timezone) { Time.zone.local(value.year, value.month, value.day).utc.iso8601 }
+      rescue ArgumentError
+        ForestAdminDatasourcePylon.logger.warn(
+          "[forest_admin_datasource_pylon] unknown timezone '#{@timezone}', falling back to UTC"
+        )
+        value.strftime('%Y-%m-%dT00:00:00Z')
+      end
+
+      # A filter carrying a nil value reads as a presence check on most APIs,
+      # which is silently the wrong query.
+      def raise_nil_value(field)
+        raise UnsupportedOperatorError,
+              "Filter value on '#{field}' is nil; use the PRESENT or BLANK operator to filter for absence."
+      end
+
+      def raise_blank_in_list(leaf)
+        raise UnsupportedOperatorError,
+              "Operator '#{leaf.operator}' on field '#{leaf.field}' was given a list holding a blank value; " \
+              'Pylon matches an absent value through is_set / is_unset only, so filter for absence with the ' \
+              'PRESENT or BLANK operator rather than listing nil or an empty string.'
+      end
+
+      def raise_empty_list(leaf)
+        raise UnsupportedOperatorError,
+              "Operator '#{leaf.operator}' on field '#{leaf.field}' was given an empty list; " \
+              'pass at least one value.'
+      end
+    end
+  end
+end

--- a/packages/forest_admin_datasource_pylon/spec/forest_admin_datasource_pylon/collections/base_collection_spec.rb
+++ b/packages/forest_admin_datasource_pylon/spec/forest_admin_datasource_pylon/collections/base_collection_spec.rb
@@ -31,11 +31,20 @@ module ForestAdminDatasourcePylon
 
     let(:subclass) do
       Class.new(described_class) do
-        def define_schema; end
+        # Minimal schema: the residual guard looks the columns up, and the
+        # default-sort check needs a primary key to compare against.
+        def define_schema
+          column = Collections::BaseCollection::ColumnSchema
+          add_field('id', column.new(column_type: 'String', is_primary_key: true))
+          add_field('state', column.new(column_type: 'String'))
+          add_field('type', column.new(column_type: 'String'))
+          add_field('tags', column.new(column_type: 'Json'))
+        end
+
         def define_relations; end
 
         public :extract_id_lookup, :project, :translate_page, :add_custom_fields,
-               :translate_sort, :timezone_for, :build_pylon_filter, :api_filters
+               :translate_sort, :timezone_for, :build_pylon_filter, :api_filters, :default_pk_sort?
       end
     end
 
@@ -142,6 +151,34 @@ module ForestAdminDatasourcePylon
         node = branch('And', [leaf('state', operators::EQUAL, 'new'), leaf('type', operators::EQUAL, 'ticket')])
 
         expect(collection.extract_id_lookup(node)).to be_nil
+      end
+
+      # A Json column holds a list whose Pylon membership semantics have no
+      # in-memory counterpart: the lookup is refused rather than mis-filtered.
+      it 'refuses a lookup whose residual it cannot evaluate in memory' do
+        node = branch('And', [leaf('id', operators::EQUAL, 'uuid-1'), leaf('tags', operators::CONTAINS, 'vip')])
+
+        expect { collection.extract_id_lookup(node) }
+          .to raise_error(UnsupportedOperatorError, /cannot be combined with a primary-key lookup/)
+      end
+
+      it 'refuses a residual on a field the schema does not declare' do
+        node = branch('And', [leaf('id', operators::EQUAL, 'uuid-1'), leaf('ghost', operators::EQUAL, 'x')])
+
+        expect { collection.extract_id_lookup(node) }
+          .to raise_error(UnsupportedOperatorError, /field 'ghost'/)
+      end
+    end
+
+    describe '#default_pk_sort?' do
+      # The agent injects this exact sort whenever the request asks for no order.
+      it 'recognises the ascending primary-key sort the agent injects' do
+        expect(collection.default_pk_sort?(sort('id'))).to be(true)
+      end
+
+      it 'does not mistake a chosen order for the default' do
+        expect(collection.default_pk_sort?(sort('id', ascending: false))).to be(false)
+        expect(collection.default_pk_sort?(sort('state'))).to be(false)
       end
     end
 
@@ -258,6 +295,33 @@ module ForestAdminDatasourcePylon
 
         expect(added).to be_empty
         expect(ForestAdminDatasourcePylon.logger).to have_received(:warn).with(/conflicts with an existing field/)
+      end
+
+      # The safe default matches the empty api_filters: a collection that
+      # filters nothing server-side must not advertise custom-field filters
+      # either, or the translator would refuse at query time what the schema
+      # offered.
+      it 'clamps the declared operators to the collection allow-list and warns' do
+        allow(ForestAdminDatasourcePylon.logger).to receive(:warn)
+        declared = ForestAdminDatasourceToolkit::Schema::ColumnSchema
+                   .new(column_type: 'String', filter_operators: [operators::EQUAL])
+
+        added = collection.add_custom_fields([{ column_name: 'severity', schema: declared }])
+
+        expect(collection.fields['severity'].filter_operators).to eq([])
+        expect(added.first[:schema].filter_operators).to eq([])
+        expect(ForestAdminDatasourcePylon.logger)
+          .to have_received(:warn).with(/cannot honour on a custom field \(equal\)/)
+      end
+
+      it 'clamps a copy, leaving the integrator schema object untouched' do
+        allow(ForestAdminDatasourcePylon.logger).to receive(:warn)
+        declared = ForestAdminDatasourceToolkit::Schema::ColumnSchema
+                   .new(column_type: 'String', filter_operators: [operators::EQUAL])
+
+        collection.add_custom_fields([{ column_name: 'severity', schema: declared }])
+
+        expect(declared.filter_operators).to eq([operators::EQUAL])
       end
     end
   end

--- a/packages/forest_admin_datasource_pylon/spec/forest_admin_datasource_pylon/collections/base_collection_spec.rb
+++ b/packages/forest_admin_datasource_pylon/spec/forest_admin_datasource_pylon/collections/base_collection_spec.rb
@@ -5,8 +5,21 @@ module ForestAdminDatasourcePylon
         .new(field, operator, value)
     end
 
+    def branch(aggregator, conditions)
+      ForestAdminDatasourceToolkit::Components::Query::ConditionTree::Nodes::ConditionTreeBranch
+        .new(aggregator, conditions)
+    end
+
+    def filter(condition_tree: nil)
+      ForestAdminDatasourceToolkit::Components::Query::Filter.new(condition_tree: condition_tree)
+    end
+
     def page(offset, limit)
       ForestAdminDatasourceToolkit::Components::Query::Page.new(offset: offset, limit: limit)
+    end
+
+    def sort(field, ascending: true)
+      ForestAdminDatasourceToolkit::Components::Query::Sort.new([{ field: field, ascending: ascending }])
     end
 
     let(:operators) { ForestAdminDatasourceToolkit::Components::Query::ConditionTree::Operators }
@@ -21,7 +34,8 @@ module ForestAdminDatasourcePylon
         def define_schema; end
         def define_relations; end
 
-        public :extract_id_lookup, :project, :translate_page, :add_custom_fields
+        public :extract_id_lookup, :project, :translate_page, :add_custom_fields,
+               :translate_sort, :timezone_for, :build_pylon_filter, :api_filters
       end
     end
 
@@ -41,8 +55,8 @@ module ForestAdminDatasourcePylon
     end
 
     describe 'search/count flags' do
-      # Inverted from the Zendesk template: free-text search and Count land in
-      # a later story, so a collection has to opt in rather than opt out.
+      # Inverted from the Zendesk template: only the endpoints that really carry
+      # `search_text` opt in, and Count has no Pylon equivalent at all.
       it 'leaves search and count disabled by default' do
         expect(collection.is_searchable?).to be(false)
         expect(collection.is_countable?).to be(false)
@@ -58,22 +72,25 @@ module ForestAdminDatasourcePylon
 
     describe '#extract_id_lookup' do
       it 'extracts a single id from an equality leaf' do
-        expect(collection.extract_id_lookup(leaf('id', operators::EQUAL, 'uuid-1'))).to eq(['uuid-1'])
+        lookup = collection.extract_id_lookup(leaf('id', operators::EQUAL, 'uuid-1'))
+
+        expect(lookup.ids).to eq(['uuid-1'])
+        expect(lookup.residual).to be_nil
       end
 
       it 'extracts every id from an in leaf' do
         node = leaf('id', operators::IN, %w[uuid-1 uuid-2])
 
-        expect(collection.extract_id_lookup(node)).to eq(%w[uuid-1 uuid-2])
+        expect(collection.extract_id_lookup(node).ids).to eq(%w[uuid-1 uuid-2])
       end
 
       # Pylon ids are uuids: unlike Zendesk's integer ids, nothing is coerced.
       it 'keeps the id as an opaque string' do
-        expect(collection.extract_id_lookup(leaf('id', operators::EQUAL, 42))).to eq(['42'])
+        expect(collection.extract_id_lookup(leaf('id', operators::EQUAL, 42)).ids).to eq(['42'])
       end
 
       it 'drops empty values' do
-        expect(collection.extract_id_lookup(leaf('id', operators::IN, ['uuid-1', '']))).to eq(['uuid-1'])
+        expect(collection.extract_id_lookup(leaf('id', operators::IN, ['uuid-1', ''])).ids).to eq(['uuid-1'])
       end
 
       it 'ignores a leaf on another field' do
@@ -86,6 +103,102 @@ module ForestAdminDatasourcePylon
 
       it 'ignores a nil condition tree' do
         expect(collection.extract_id_lookup(nil)).to be_nil
+      end
+
+      # Forest sends `AND(id equal X, <scope>)` on a record detail as soon as a
+      # scope or a segment is set, and `id` is not a Pylon filter field.
+      it 'pulls the id out of a top-level and, returning the other conditions' do
+        scope = leaf('state', operators::EQUAL, 'new')
+        lookup = collection.extract_id_lookup(branch('And', [leaf('id', operators::EQUAL, 'uuid-1'), scope]))
+
+        expect(lookup.ids).to eq(['uuid-1'])
+        expect(lookup.residual.to_h).to eq(scope.to_h)
+      end
+
+      it 'keeps the remaining conditions grouped when more than one is left' do
+        conditions = [leaf('id', operators::IN, %w[uuid-1]), leaf('state', operators::EQUAL, 'new'),
+                      leaf('type', operators::EQUAL, 'ticket')]
+
+        residual = collection.extract_id_lookup(branch('And', conditions)).residual
+
+        expect(residual.to_h).to eq(aggregator: 'And', conditions: conditions.drop(1).map(&:to_h))
+      end
+
+      it 'reports no residual when the and carries the id alone' do
+        lookup = collection.extract_id_lookup(branch('And', [leaf('id', operators::EQUAL, 'uuid-1')]))
+
+        expect(lookup.residual).to be_nil
+      end
+
+      # An OR cannot be narrowed to the ids: the other side of the union would
+      # bring in records the short-circuit never fetched.
+      it 'ignores an id nested in an or' do
+        node = branch('Or', [leaf('id', operators::EQUAL, 'uuid-1'), leaf('state', operators::EQUAL, 'new')])
+
+        expect(collection.extract_id_lookup(node)).to be_nil
+      end
+
+      it 'ignores an and carrying no id condition' do
+        node = branch('And', [leaf('state', operators::EQUAL, 'new'), leaf('type', operators::EQUAL, 'ticket')])
+
+        expect(collection.extract_id_lookup(node)).to be_nil
+      end
+    end
+
+    describe '#translate_sort' do
+      let(:allow_list) { { 'created_at' => 'created_at' } }
+
+      it 'maps an allowed field to its api name and direction' do
+        expect(collection.translate_sort(sort('created_at'), allow_list)).to eq(%w[created_at asc])
+        expect(collection.translate_sort(sort('created_at', ascending: false), allow_list))
+          .to eq(%w[created_at desc])
+      end
+
+      it 'reports no sort for a field outside the allow-list' do
+        expect(collection.translate_sort(sort('title'), allow_list)).to eq([nil, nil])
+      end
+
+      it 'reports no sort when Forest asks for none' do
+        expect(collection.translate_sort(nil, allow_list)).to eq([nil, nil])
+        expect(collection.translate_sort([], allow_list)).to eq([nil, nil])
+      end
+
+      it 'reads a plain hash clause as well as a Sort entry' do
+        expect(collection.translate_sort([{ field: 'created_at', ascending: false }], allow_list))
+          .to eq(%w[created_at desc])
+        expect(collection.translate_sort([{ 'field' => 'created_at', 'ascending' => true }], allow_list))
+          .to eq(%w[created_at asc])
+      end
+    end
+
+    describe '#timezone_for' do
+      it 'falls back to UTC when the caller carries no timezone' do
+        expect(collection.timezone_for(nil)).to eq('UTC')
+        expect(collection.timezone_for(instance_double(ForestAdminDatasourceToolkit::Components::Caller,
+                                                       timezone: nil))).to eq('UTC')
+        expect(collection.timezone_for(instance_double(ForestAdminDatasourceToolkit::Components::Caller,
+                                                       timezone: ''))).to eq('UTC')
+      end
+
+      it 'uses the timezone of the caller' do
+        caller = instance_double(ForestAdminDatasourceToolkit::Components::Caller, timezone: 'Europe/Paris')
+
+        expect(collection.timezone_for(caller)).to eq('Europe/Paris')
+      end
+    end
+
+    describe '#build_pylon_filter' do
+      # A collection that declares nothing filterable is the safe default: every
+      # predicate is refused rather than silently dropped.
+      it 'declares no server-side filter by default' do
+        expect(collection.api_filters).to eq({})
+        expect { collection.build_pylon_filter(nil, filter(condition_tree: leaf('state', operators::EQUAL, 'new'))) }
+          .to raise_error(ForestAdminDatasourcePylon::UnsupportedOperatorError, /cannot filter on 'state'/)
+      end
+
+      it 'returns no filter when there is no condition tree' do
+        expect(collection.build_pylon_filter(nil, filter)).to be_nil
+        expect(collection.build_pylon_filter(nil, nil)).to be_nil
       end
     end
 

--- a/packages/forest_admin_datasource_pylon/spec/forest_admin_datasource_pylon/collections/base_collection_spec.rb
+++ b/packages/forest_admin_datasource_pylon/spec/forest_admin_datasource_pylon/collections/base_collection_spec.rb
@@ -10,8 +10,8 @@ module ForestAdminDatasourcePylon
         .new(aggregator, conditions)
     end
 
-    def filter(condition_tree: nil)
-      ForestAdminDatasourceToolkit::Components::Query::Filter.new(condition_tree: condition_tree)
+    def filter(condition_tree: nil, search: nil)
+      ForestAdminDatasourceToolkit::Components::Query::Filter.new(condition_tree: condition_tree, search: search)
     end
 
     def page(offset, limit)
@@ -39,12 +39,14 @@ module ForestAdminDatasourcePylon
           add_field('state', column.new(column_type: 'String'))
           add_field('type', column.new(column_type: 'String'))
           add_field('tags', column.new(column_type: 'Json'))
+          add_field('resolved_at', column.new(column_type: 'Date'))
         end
 
         def define_relations; end
 
         public :extract_id_lookup, :project, :translate_page, :add_custom_fields,
-               :translate_sort, :timezone_for, :build_pylon_filter, :api_filters, :default_pk_sort?
+               :translate_sort, :timezone_for, :build_pylon_filter, :api_filters, :default_pk_sort?,
+               :ensure_searchless_lookup!
       end
     end
 
@@ -168,6 +170,59 @@ module ForestAdminDatasourcePylon
         expect { collection.extract_id_lookup(node) }
           .to raise_error(UnsupportedOperatorError, /field 'ghost'/)
       end
+
+      # `ConditionTreeLeaf#match` compares with a bare `>`, which raises a
+      # NoMethodError on the nil Pylon returns for an unresolved issue. The
+      # guard pairs the comparison with a presence check, the way a database
+      # excludes a NULL row from a comparison.
+      describe 'guarding a comparison against a null column' do
+        let(:comparison) { leaf('resolved_at', operators::GREATER_THAN, '2026-01-01T00:00:00Z') }
+        let(:residual) do
+          collection.extract_id_lookup(branch('And', [leaf('id', operators::EQUAL, 'uuid-1'), comparison])).residual
+        end
+
+        it 'pairs the comparison with a presence check' do
+          expect(residual.to_h).to eq(
+            aggregator: 'And',
+            conditions: [{ field: 'resolved_at', operator: operators::PRESENT, value: nil }, comparison.to_h]
+          )
+        end
+
+        it 'excludes the record instead of raising when the column is null' do
+          expect { residual.apply([{ 'id' => 'uuid-1', 'resolved_at' => nil }], collection, 'UTC') }
+            .not_to raise_error
+          expect(residual.apply([{ 'id' => 'uuid-1', 'resolved_at' => nil }], collection, 'UTC')).to eq([])
+        end
+
+        it 'still keeps a record the comparison matches' do
+          record = { 'id' => 'uuid-1', 'resolved_at' => '2026-08-07T13:06:22Z' }
+
+          expect(residual.apply([record], collection, 'UTC')).to eq([record])
+        end
+
+        it 'leaves an operator that needs no guard untouched' do
+          equality = leaf('state', operators::EQUAL, 'new')
+          node = branch('And', [leaf('id', operators::EQUAL, 'uuid-1'), equality])
+
+          expect(collection.extract_id_lookup(node).residual.to_h).to eq(equality.to_h)
+        end
+      end
+    end
+
+    describe '#ensure_searchless_lookup!' do
+      # Pylon searches through its search endpoint, which cannot filter on id,
+      # and reads an id through its own, which cannot search: honouring both at
+      # once is impossible, and honouring one silently is what this refuses.
+      it 'refuses a lookup carrying a free-text search' do
+        expect { collection.ensure_searchless_lookup!(filter(search: 'boom')) }
+          .to raise_error(UnsupportedOperatorError, /search cannot be combined with a filter on 'id'/)
+      end
+
+      it 'accepts a lookup carrying no search' do
+        expect { collection.ensure_searchless_lookup!(filter) }.not_to raise_error
+        expect { collection.ensure_searchless_lookup!(nil) }.not_to raise_error
+        expect { collection.ensure_searchless_lookup!(filter(search: '  ')) }.not_to raise_error
+      end
     end
 
     describe '#default_pk_sort?' do
@@ -236,6 +291,16 @@ module ForestAdminDatasourcePylon
       it 'returns no filter when there is no condition tree' do
         expect(collection.build_pylon_filter(nil, filter)).to be_nil
         expect(collection.build_pylon_filter(nil, nil)).to be_nil
+      end
+
+      # The UI offers both an `id equals` filter and the and/or toggle, so this
+      # is reachable by an operator and deserves better than the translator's
+      # "add it to the collection's api_filters".
+      it 'reports an id the short-circuit could not reach with an actionable error' do
+        node = branch('Or', [leaf('id', operators::EQUAL, 'uuid-1'), leaf('state', operators::EQUAL, 'new')])
+
+        expect { collection.build_pylon_filter(nil, filter(condition_tree: node)) }
+          .to raise_error(UnsupportedOperatorError, /has to be combined with 'and' conditions only/)
       end
     end
 

--- a/packages/forest_admin_datasource_pylon/spec/forest_admin_datasource_pylon/collections/issue_spec.rb
+++ b/packages/forest_admin_datasource_pylon/spec/forest_admin_datasource_pylon/collections/issue_spec.rb
@@ -96,7 +96,7 @@ module ForestAdminDatasourcePylon
         expect(collection.fields['assignee_id'].filter_operators)
           .to eq([operators::EQUAL, operators::IN, operators::NOT_IN, operators::PRESENT, operators::BLANK])
         expect(collection.fields['title'].filter_operators)
-          .to eq([operators::CONTAINS, operators::I_CONTAINS, operators::NOT_CONTAINS])
+          .to eq([operators::CONTAINS, operators::I_CONTAINS, operators::NOT_CONTAINS, operators::NOT_I_CONTAINS])
       end
 
       # Declaring the bare comparisons is what lets the toolkit rewrite Today /
@@ -376,6 +376,70 @@ module ForestAdminDatasourcePylon
           .to raise_error(UnsupportedOperatorError, /cannot be combined with a primary-key lookup/)
         expect(WebMock).not_to have_requested(:get, "#{base}/issues/i1")
       end
+
+      # An unresolved issue carries `resolution_time: nil`, and a bare `nil >
+      # value` raises: a scope or a segment dated on that column used to turn
+      # every record detail it did not match into a 500.
+      it 'excludes the record instead of raising when a dated condition meets a null column' do
+        stub_request(:get, "#{base}/issues/i1").to_return(json('data' => issue_payload('i1')))
+        tree = branch('And', [id_leaf(operators::EQUAL, 'i1'),
+                              leaf('resolution_time', operators::GREATER_THAN, '2026-01-01T00:00:00Z')])
+
+        expect(collection.list(nil, filter(condition_tree: tree), %w[id])).to eq([])
+      end
+
+      it 'keeps the record when the dated condition matches' do
+        stub_request(:get, "#{base}/issues/i1")
+          .to_return(json('data' => issue_payload('i1', 'resolution_time' => '2026-08-07T13:06:22Z')))
+        tree = branch('And', [id_leaf(operators::EQUAL, 'i1'),
+                              leaf('resolution_time', operators::GREATER_THAN, '2026-01-01T00:00:00Z')])
+
+        expect(collection.list(nil, filter(condition_tree: tree), %w[id])).to eq([{ 'id' => 'i1' }])
+      end
+    end
+
+    describe '#list on a primary-key lookup carrying a search' do
+      # The short-circuit never reaches /issues/search, so honouring the search
+      # is impossible: returning the record unsearched would be a result that
+      # looks searched and is not.
+      it 'refuses to answer rather than dropping the search' do
+        query = filter(condition_tree: id_leaf(operators::EQUAL, 'i1'), search: 'boom')
+
+        expect { collection.list(nil, query, %w[id]) }
+          .to raise_error(UnsupportedOperatorError, /search cannot be combined with a filter on 'id'/)
+        expect(WebMock).not_to have_requested(:get, "#{base}/issues/i1")
+      end
+
+      it 'still serves the lookup when the search is empty' do
+        stub_request(:get, "#{base}/issues/i1").to_return(json('data' => issue_payload('i1')))
+        query = filter(condition_tree: id_leaf(operators::EQUAL, 'i1'), search: '')
+
+        expect(collection.list(nil, query, %w[id])).to eq([{ 'id' => 'i1' }])
+      end
+    end
+
+    describe '#list on a primary-key lookup of many ids' do
+      # One GET per id against the same 20 req/min budget the cursor walk is
+      # capped for, so the fan-out is bounded the same way.
+      it 'reads at most the capped number of ids and warns' do
+        allow(ForestAdminDatasourcePylon.logger).to receive(:warn)
+        ids = Array.new(Collections::Issue::MAX_ID_LOOKUPS + 5) { |i| "i#{i}" }
+        ids.each { |id| stub_request(:get, "#{base}/issues/#{id}").to_return(json('data' => issue_payload(id))) }
+
+        rows = collection.list(nil, filter(condition_tree: id_leaf(operators::IN, ids)), %w[id])
+
+        expect(rows.size).to eq(Collections::Issue::MAX_ID_LOOKUPS)
+        expect(ForestAdminDatasourcePylon.logger).to have_received(:warn).with(/reading the first 20/)
+      end
+
+      it 'stays quiet and reads every id under the cap' do
+        allow(ForestAdminDatasourcePylon.logger).to receive(:warn)
+        %w[i1 i2].each { |id| stub_request(:get, "#{base}/issues/#{id}").to_return(json('data' => issue_payload(id))) }
+
+        collection.list(nil, filter(condition_tree: id_leaf(operators::IN, %w[i1 i2])), %w[id])
+
+        expect(ForestAdminDatasourcePylon.logger).not_to have_received(:warn)
+      end
     end
 
     describe '#list with a sort' do
@@ -415,6 +479,18 @@ module ForestAdminDatasourcePylon
         sort = ForestAdminDatasourceToolkit::Components::Query::Sort.new([{ field: 'id', ascending: false }])
 
         collection.list(nil, filter(sort: sort), %w[id])
+
+        expect(ForestAdminDatasourcePylon.logger).to have_received(:warn).with(/cannot honour the requested order/)
+      end
+
+      # The lookup returns the records in the order of the ids, so an order the
+      # operator chose is just as unhonoured there as on the search path.
+      it 'warns on the primary-key path too' do
+        stub_request(:get, "#{base}/issues/i1").to_return(json('data' => issue_payload('i1')))
+        sort = ForestAdminDatasourceToolkit::Components::Query::Sort
+               .new([{ field: 'created_at', ascending: true }])
+
+        collection.list(nil, filter(condition_tree: id_leaf(operators::EQUAL, 'i1'), sort: sort), %w[id])
 
         expect(ForestAdminDatasourcePylon.logger).to have_received(:warn).with(/cannot honour the requested order/)
       end

--- a/packages/forest_admin_datasource_pylon/spec/forest_admin_datasource_pylon/collections/issue_spec.rb
+++ b/packages/forest_admin_datasource_pylon/spec/forest_admin_datasource_pylon/collections/issue_spec.rb
@@ -284,6 +284,20 @@ module ForestAdminDatasourcePylon
         expect { collection.list(nil, filter(condition_tree: leaf('severity', operators::CONTAINS, 'hi')), %w[id]) }
           .to raise_error(UnsupportedOperatorError, /not supported on field 'severity'/)
       end
+
+      # Clamped at registration, so the schema never advertises an operator
+      # the translator would refuse at query time.
+      it 'drops a declared operator Pylon cannot honour on a custom field and warns' do
+        allow(ForestAdminDatasourcePylon.logger).to receive(:warn)
+        declared = ForestAdminDatasourceToolkit::Schema::ColumnSchema
+                   .new(column_type: 'String', filter_operators: [operators::EQUAL, operators::STARTS_WITH])
+
+        clamped = described_class.new(datasource, custom_fields: [{ column_name: 'severity', schema: declared }])
+
+        expect(clamped.fields['severity'].filter_operators).to eq([operators::EQUAL])
+        expect(ForestAdminDatasourcePylon.logger)
+          .to have_received(:warn).with(/cannot honour on a custom field \(starts_with\)/)
+      end
     end
 
     describe '#list with a filter' do
@@ -352,6 +366,16 @@ module ForestAdminDatasourcePylon
 
         expect(collection.list(nil, filter(condition_tree: tree), %w[id])).to eq([])
       end
+
+      # `tags` holds a list whose Pylon membership semantics have no in-memory
+      # counterpart: the lookup is refused rather than silently mis-filtered.
+      it 'refuses a leftover condition it cannot evaluate in memory' do
+        tree = branch('And', [id_leaf(operators::EQUAL, 'i1'), leaf('tags', operators::CONTAINS, 'urgent')])
+
+        expect { collection.list(nil, filter(condition_tree: tree), %w[id]) }
+          .to raise_error(UnsupportedOperatorError, /cannot be combined with a primary-key lookup/)
+        expect(WebMock).not_to have_requested(:get, "#{base}/issues/i1")
+      end
     end
 
     describe '#list with a sort' do
@@ -375,6 +399,24 @@ module ForestAdminDatasourcePylon
         collection.list(nil, filter, %w[id])
 
         expect(ForestAdminDatasourcePylon.logger).not_to have_received(:warn)
+      end
+
+      # The agent injects an ascending primary-key sort whenever the request
+      # asks for no order; only an order someone actually chose is reported.
+      it 'stays quiet on the default primary-key sort the agent injects' do
+        sort = ForestAdminDatasourceToolkit::Components::Query::Sort.new([{ field: 'id', ascending: true }])
+
+        collection.list(nil, filter(sort: sort), %w[id])
+
+        expect(ForestAdminDatasourcePylon.logger).not_to have_received(:warn)
+      end
+
+      it 'warns on a chosen order, even one on the primary key' do
+        sort = ForestAdminDatasourceToolkit::Components::Query::Sort.new([{ field: 'id', ascending: false }])
+
+        collection.list(nil, filter(sort: sort), %w[id])
+
+        expect(ForestAdminDatasourcePylon.logger).to have_received(:warn).with(/cannot honour the requested order/)
       end
     end
   end

--- a/packages/forest_admin_datasource_pylon/spec/forest_admin_datasource_pylon/collections/issue_spec.rb
+++ b/packages/forest_admin_datasource_pylon/spec/forest_admin_datasource_pylon/collections/issue_spec.rb
@@ -1,14 +1,19 @@
 module ForestAdminDatasourcePylon
   RSpec.describe Collections::Issue do
-    def filter(condition_tree: nil, search: nil, page: nil)
+    def filter(condition_tree: nil, search: nil, page: nil, sort: nil)
       ForestAdminDatasourceToolkit::Components::Query::Filter.new(
-        condition_tree: condition_tree, search: search, page: page
+        condition_tree: condition_tree, search: search, page: page, sort: sort
       )
     end
 
     def leaf(field, operator, value)
       ForestAdminDatasourceToolkit::Components::Query::ConditionTree::Nodes::ConditionTreeLeaf
         .new(field, operator, value)
+    end
+
+    def branch(aggregator, conditions)
+      ForestAdminDatasourceToolkit::Components::Query::ConditionTree::Nodes::ConditionTreeBranch
+        .new(aggregator, conditions)
     end
 
     def id_leaf(operator, value)
@@ -78,9 +83,36 @@ module ForestAdminDatasourcePylon
         expect(collection.fields.values.map(&:is_sortable).uniq).to eq([false])
       end
 
-      it 'leaves search and count disabled' do
-        expect(collection.is_searchable?).to be(false)
+      # `search_text` is native on /issues/search, while Pylon exposes neither a
+      # count endpoint nor a total, so Count stays out until it can be throttled.
+      it 'enables search and leaves count disabled' do
+        expect(collection.is_searchable?).to be(true)
         expect(collection.is_countable?).to be(false)
+      end
+
+      it 'advertises only the operators the search allow-list accepts' do
+        expect(collection.fields['state'].filter_operators).to eq([operators::EQUAL, operators::IN,
+                                                                   operators::NOT_IN])
+        expect(collection.fields['assignee_id'].filter_operators)
+          .to eq([operators::EQUAL, operators::IN, operators::NOT_IN, operators::PRESENT, operators::BLANK])
+        expect(collection.fields['title'].filter_operators)
+          .to eq([operators::CONTAINS, operators::I_CONTAINS, operators::NOT_CONTAINS])
+      end
+
+      # Declaring the bare comparisons is what lets the toolkit rewrite Today /
+      # PreviousWeek / ... into a pair of bounds Pylon understands.
+      it 'advertises the date columns with the two bounds Pylon accepts' do
+        expect(collection.fields['created_at'].filter_operators)
+          .to eq([operators::GREATER_THAN, operators::LESS_THAN])
+      end
+
+      # /issues/search cannot filter on them, so offering the filter would only
+      # produce an error once the operator used it.
+      it 'advertises no operator on the columns Pylon cannot filter' do
+        %w[number source number_of_touches first_response_time link
+           customer_portal_visible time_in_status_seconds].each do |field|
+          expect(collection.fields[field].filter_operators).to eq([])
+        end
       end
     end
 
@@ -212,7 +244,10 @@ module ForestAdminDatasourcePylon
     end
 
     describe 'custom fields' do
-      let(:column) { ForestAdminDatasourceToolkit::Schema::ColumnSchema.new(column_type: 'String') }
+      let(:column) do
+        ForestAdminDatasourceToolkit::Schema::ColumnSchema.new(column_type: 'String',
+                                                               filter_operators: [operators::EQUAL])
+      end
       let(:collection) do
         described_class.new(datasource, custom_fields: [{ column_name: 'severity', schema: column },
                                                         { column_name: 'zones', schema: column }])
@@ -232,44 +267,112 @@ module ForestAdminDatasourcePylon
 
         expect(collection.list(nil, filter, nil).first).to include('severity' => nil, 'zones' => nil)
       end
+
+      # Pylon accepts a custom-field slug as a filter field, with the operators
+      # the integrator declared on the column.
+      it 'filters a custom field through its slug' do
+        stub_request(:post, "#{base}/issues/search").to_return(json('data' => []))
+
+        collection.list(nil, filter(condition_tree: leaf('severity', operators::EQUAL, 'high')), %w[id])
+
+        expect(WebMock).to have_requested(:post, "#{base}/issues/search")
+          .with(body: hash_including('filter' => { 'field' => 'severity', 'operator' => 'equals',
+                                                   'value' => 'high' }))
+      end
+
+      it 'refuses an operator the custom field does not declare' do
+        expect { collection.list(nil, filter(condition_tree: leaf('severity', operators::CONTAINS, 'hi')), %w[id]) }
+          .to raise_error(UnsupportedOperatorError, /not supported on field 'severity'/)
+      end
     end
 
-    describe 'filters it cannot honour yet' do
+    describe '#list with a filter' do
+      before { stub_request(:post, "#{base}/issues/search").to_return(json('data' => [issue_payload('i1')])) }
+
+      it 'sends the translated condition tree to the search endpoint' do
+        collection.list(nil, filter(condition_tree: leaf('state', operators::EQUAL, 'closed')), %w[id])
+
+        expect(WebMock).to have_requested(:post, "#{base}/issues/search").with(
+          body: { 'limit' => Client::MAX_SEARCH_LIMIT,
+                  'filter' => { 'field' => 'state', 'operator' => 'equals', 'value' => 'closed' } }
+        )
+      end
+
+      it 'sends a free-text search as search_text, intersected with the filter' do
+        query = filter(condition_tree: leaf('team_id', operators::EQUAL, 'team-1'), search: 'boom')
+
+        collection.list(nil, query, %w[id])
+
+        expect(WebMock).to have_requested(:post, "#{base}/issues/search").with(
+          body: { 'limit' => Client::MAX_SEARCH_LIMIT, 'search_text' => 'boom',
+                  'filter' => { 'field' => 'team_id', 'operator' => 'equals', 'value' => 'team-1' } }
+        )
+      end
+
+      # The whole point of translating rather than dropping: a predicate Pylon
+      # cannot express fails loudly instead of returning unfiltered rows.
+      it 'raises rather than returning unfiltered rows for a predicate Pylon refuses' do
+        expect { collection.list(nil, filter(condition_tree: leaf('number', operators::EQUAL, 12)), %w[id]) }
+          .to raise_error(UnsupportedOperatorError, /cannot filter on 'number'/)
+        expect(WebMock).not_to have_requested(:post, "#{base}/issues/search")
+      end
+
+      it 'keeps the same filter across every page of the walk' do
+        stub_request(:post, "#{base}/issues/search")
+          .with(body: hash_including('limit' => 3))
+          .to_return(json('data' => [issue_payload('i1'), issue_payload('i2')],
+                          'pagination' => { 'cursor' => 'c1', 'has_next_page' => true }))
+        stub_request(:post, "#{base}/issues/search")
+          .with(body: hash_including('cursor' => 'c1'))
+          .to_return(json('data' => [issue_payload('i3')]))
+        query = filter(condition_tree: leaf('state', operators::EQUAL, 'new'), page: page(2, 1))
+
+        expect(collection.list(nil, query, %w[id])).to eq([{ 'id' => 'i3' }])
+        expect(WebMock).to have_requested(:post, "#{base}/issues/search")
+          .with(body: hash_including('filter' => { 'field' => 'state', 'operator' => 'equals',
+                                                   'value' => 'new' })).twice
+      end
+    end
+
+    describe '#list on a primary-key lookup carrying more conditions' do
+      # Forest sends `AND(id equal X, <scope>)` on a record detail as soon as a
+      # scope or a segment is set; `id` is not a Pylon filter field, so the
+      # lookup has to survive the extra conditions.
+      it 'reads the issue by id and applies the leftover conditions in memory' do
+        stub_request(:get, "#{base}/issues/i1").to_return(json('data' => issue_payload('i1')))
+        tree = branch('And', [id_leaf(operators::EQUAL, 'i1'), leaf('state', operators::EQUAL, 'new')])
+
+        expect(collection.list(nil, filter(condition_tree: tree), %w[id])).to eq([{ 'id' => 'i1' }])
+        expect(WebMock).not_to have_requested(:post, "#{base}/issues/search")
+      end
+
+      it 'drops the record when a leftover condition does not match' do
+        stub_request(:get, "#{base}/issues/i1").to_return(json('data' => issue_payload('i1')))
+        tree = branch('And', [id_leaf(operators::EQUAL, 'i1'), leaf('state', operators::EQUAL, 'closed')])
+
+        expect(collection.list(nil, filter(condition_tree: tree), %w[id])).to eq([])
+      end
+    end
+
+    describe '#list with a sort' do
       before do
         allow(ForestAdminDatasourcePylon.logger).to receive(:warn)
         stub_request(:post, "#{base}/issues/search").to_return(json('data' => [issue_payload('i1')]))
       end
 
-      it 'warns and returns unfiltered records for a non primary-key condition' do
-        tree = leaf('state', operators::EQUAL, 'closed')
+      # /issues/search has no sort parameter, so the order is reported instead of
+      # being silently swallowed.
+      it 'warns that the requested order cannot be honoured' do
+        sort = ForestAdminDatasourceToolkit::Components::Query::Sort
+               .new([{ field: 'created_at', ascending: true }])
 
-        expect(collection.list(nil, filter(condition_tree: tree), %w[id])).to eq([{ 'id' => 'i1' }])
-        expect(ForestAdminDatasourcePylon.logger).to have_received(:warn).with(/ignored the condition tree/)
+        collection.list(nil, filter(sort: sort), %w[id])
+
+        expect(ForestAdminDatasourcePylon.logger).to have_received(:warn).with(/cannot honour the requested order/)
       end
 
-      it 'warns when a free-text search is supplied' do
-        collection.list(nil, filter(search: 'boom'), %w[id])
-
-        expect(ForestAdminDatasourcePylon.logger).to have_received(:warn).with(/ignored the search/)
-      end
-
-      it 'names both when a condition tree and a search are supplied' do
-        tree = leaf('state', operators::EQUAL, 'closed')
-
-        collection.list(nil, filter(condition_tree: tree, search: 'boom'), %w[id])
-
-        expect(ForestAdminDatasourcePylon.logger)
-          .to have_received(:warn).with(/ignored the condition tree and search/)
-      end
-
-      it 'stays quiet when nothing was dropped' do
+      it 'stays quiet when Forest asks for no order' do
         collection.list(nil, filter, %w[id])
-
-        expect(ForestAdminDatasourcePylon.logger).not_to have_received(:warn)
-      end
-
-      it 'stays quiet on an empty search string' do
-        collection.list(nil, filter(search: ''), %w[id])
 
         expect(ForestAdminDatasourcePylon.logger).not_to have_received(:warn)
       end

--- a/packages/forest_admin_datasource_pylon/spec/forest_admin_datasource_pylon/query/condition_tree_translator_spec.rb
+++ b/packages/forest_admin_datasource_pylon/spec/forest_admin_datasource_pylon/query/condition_tree_translator_spec.rb
@@ -78,9 +78,14 @@ module ForestAdminDatasourcePylon
           .to eq('field' => 'body_html', 'operator' => 'string_contains', 'value' => 'boom')
       end
 
-      it 'translates not_contains to string_does_not_contain' do
+      # Symmetrically with contains: Pylon documents no case semantics for its
+      # single substring operator, so leaving not_i_contains out would offer a
+      # case-insensitive "contains" the UI could not negate.
+      it 'maps both spellings of not_contains onto the single negated operator' do
         expect(translate(leaf('title', operators::NOT_CONTAINS, 'boom')))
           .to eq('field' => 'title', 'operator' => 'string_does_not_contain', 'value' => 'boom')
+        expect(translate(leaf('body_html', operators::NOT_I_CONTAINS, 'boom')))
+          .to eq('field' => 'body_html', 'operator' => 'string_does_not_contain', 'value' => 'boom')
       end
 
       it 'refuses equal on a text field, which Pylon cannot match exactly' do
@@ -202,6 +207,13 @@ module ForestAdminDatasourcePylon
 
         expect { translate(tree) }.to raise_error(UnsupportedOperatorError, /Unknown condition tree aggregator/)
       end
+
+      # The toolkit validates no aggregator, so the unwrap is the one place an
+      # unknown one could have slipped through unnoticed.
+      it 'refuses an aggregator it does not know even when it carries a lone condition' do
+        expect { translate(branch('Xor', [leaf('state', operators::EQUAL, 'new')])) }
+          .to raise_error(UnsupportedOperatorError, /Unknown condition tree aggregator/)
+      end
     end
 
     describe 'guards' do
@@ -215,8 +227,24 @@ module ForestAdminDatasourcePylon
       it 'refuses an empty list of values' do
         expect { translate(leaf('state', operators::IN, [])) }
           .to raise_error(UnsupportedOperatorError, /was given an empty list/)
+      end
+
+      # Dropping the blanks would answer a different question: `not_in [nil,
+      # 'open']` was asked to exclude the blank records, and a narrowed
+      # `not_in ['open']` comes back including them.
+      it 'refuses a list holding a blank value rather than narrowing it' do
+        expect { translate(leaf('state', operators::IN, [nil, 'open'])) }
+          .to raise_error(UnsupportedOperatorError, /holding a blank value/)
+        expect { translate(leaf('state', operators::NOT_IN, ['open', ''])) }
+          .to raise_error(UnsupportedOperatorError, /holding a blank value/)
+      end
+
+      # `blank` on a String column is rewritten by the toolkit into `in [nil,
+      # '']`, so the message has to point at the presence operators rather than
+      # blame the caller for an empty list.
+      it 'points a list of blanks at the presence operators' do
         expect { translate(leaf('state', operators::IN, [nil, ''])) }
-          .to raise_error(UnsupportedOperatorError, /was given an empty list/)
+          .to raise_error(UnsupportedOperatorError, /PRESENT or BLANK operator/)
       end
 
       it 'refuses a nil value and points at the presence operators' do

--- a/packages/forest_admin_datasource_pylon/spec/forest_admin_datasource_pylon/query/condition_tree_translator_spec.rb
+++ b/packages/forest_admin_datasource_pylon/spec/forest_admin_datasource_pylon/query/condition_tree_translator_spec.rb
@@ -1,0 +1,247 @@
+module ForestAdminDatasourcePylon
+  RSpec.describe Query::ConditionTreeTranslator do
+    def leaf(field, operator, value = nil)
+      ForestAdminDatasourceToolkit::Components::Query::ConditionTree::Nodes::ConditionTreeLeaf
+        .new(field, operator, value)
+    end
+
+    def branch(aggregator, conditions)
+      ForestAdminDatasourceToolkit::Components::Query::ConditionTree::Nodes::ConditionTreeBranch
+        .new(aggregator, conditions)
+    end
+
+    # Nests `depth` multi-condition branches: the outermost sits at depth 1, so
+    # the innermost branch sits at depth `depth`.
+    def nested(depth)
+      (1..depth).reduce(leaf('state', operators::EQUAL, 'new')) do |tree, _|
+        branch('And', [tree, leaf('team_id', operators::EQUAL, 'team-1')])
+      end
+    end
+
+    def translate(tree, api_filters: default_filters, timezone: nil)
+      described_class.call(tree, api_filters: api_filters, timezone: timezone)
+    end
+
+    let(:operators) { ForestAdminDatasourceToolkit::Components::Query::ConditionTree::Operators }
+    let(:default_filters) { Collections::Issue::ApiFilters::API_FILTERS }
+
+    it 'translates a nil condition tree to no filter' do
+      expect(translate(nil)).to be_nil
+    end
+
+    it 'rejects a node that is neither a leaf nor a branch' do
+      expect { translate(Object.new) }
+        .to raise_error(UnsupportedOperatorError, /Unknown condition node/)
+    end
+
+    describe 'equality operators' do
+      it 'translates equal to a single-valued equals' do
+        expect(translate(leaf('state', operators::EQUAL, 'new')))
+          .to eq('field' => 'state', 'operator' => 'equals', 'value' => 'new')
+      end
+
+      it 'translates in and not_in to a values list' do
+        expect(translate(leaf('state', operators::IN, %w[new closed])))
+          .to eq('field' => 'state', 'operator' => 'in', 'values' => %w[new closed])
+        expect(translate(leaf('state', operators::NOT_IN, %w[closed])))
+          .to eq('field' => 'state', 'operator' => 'not_in', 'values' => %w[closed])
+      end
+
+      # The toolkit rewrites not_equal into not_in, so the translator never has
+      # to spell the same filter twice.
+      it 'refuses not_equal, which the toolkit derives from not_in' do
+        expect { translate(leaf('state', operators::NOT_EQUAL, 'new')) }
+          .to raise_error(UnsupportedOperatorError, /Supported: equal, in, not_in/)
+      end
+    end
+
+    describe 'presence operators' do
+      it 'translates present and blank without carrying a value' do
+        expect(translate(leaf('assignee_id', operators::PRESENT)))
+          .to eq('field' => 'assignee_id', 'operator' => 'is_set')
+        expect(translate(leaf('assignee_id', operators::BLANK)))
+          .to eq('field' => 'assignee_id', 'operator' => 'is_unset')
+      end
+
+      # Pylon lists is_set / is_unset for the party ids and issue_type only.
+      it 'refuses presence on a field Pylon does not accept it for' do
+        expect { translate(leaf('state', operators::PRESENT)) }
+          .to raise_error(UnsupportedOperatorError, /Operator 'present' is not supported on field 'state'/)
+      end
+    end
+
+    describe 'text operators' do
+      it 'maps both spellings of contains onto the single Pylon substring operator' do
+        expect(translate(leaf('title', operators::CONTAINS, 'boom')))
+          .to eq('field' => 'title', 'operator' => 'string_contains', 'value' => 'boom')
+        expect(translate(leaf('body_html', operators::I_CONTAINS, 'boom')))
+          .to eq('field' => 'body_html', 'operator' => 'string_contains', 'value' => 'boom')
+      end
+
+      it 'translates not_contains to string_does_not_contain' do
+        expect(translate(leaf('title', operators::NOT_CONTAINS, 'boom')))
+          .to eq('field' => 'title', 'operator' => 'string_does_not_contain', 'value' => 'boom')
+      end
+
+      it 'refuses equal on a text field, which Pylon cannot match exactly' do
+        expect { translate(leaf('title', operators::EQUAL, 'Boom')) }
+          .to raise_error(UnsupportedOperatorError, /not supported on field 'title'/)
+      end
+
+      # `tags` holds a list, so membership has its own pair of operators.
+      it 'translates tag membership with the list operators' do
+        expect(translate(leaf('tags', operators::CONTAINS, 'urgent')))
+          .to eq('field' => 'tags', 'operator' => 'contains', 'value' => 'urgent')
+        expect(translate(leaf('tags', operators::NOT_CONTAINS, 'urgent')))
+          .to eq('field' => 'tags', 'operator' => 'does_not_contain', 'value' => 'urgent')
+        expect(translate(leaf('tags', operators::IN, %w[urgent vip])))
+          .to eq('field' => 'tags', 'operator' => 'in', 'values' => %w[urgent vip])
+      end
+    end
+
+    describe 'time operators' do
+      it 'translates the bare comparisons to the time bounds' do
+        expect(translate(leaf('created_at', operators::GREATER_THAN, '2026-08-01T00:00:00Z')))
+          .to eq('field' => 'created_at', 'operator' => 'time_is_after', 'value' => '2026-08-01T00:00:00Z')
+        expect(translate(leaf('updated_at', operators::LESS_THAN, '2026-08-01T00:00:00Z')))
+          .to eq('field' => 'updated_at', 'operator' => 'time_is_before', 'value' => '2026-08-01T00:00:00Z')
+      end
+
+      it 'formats a Time value as an UTC timestamp' do
+        expect(translate(leaf('created_at', operators::GREATER_THAN, Time.utc(2026, 8, 7, 13, 6, 22))))
+          .to include('value' => '2026-08-07T13:06:22Z')
+      end
+
+      it 'reads a bare Date as midnight in the timezone of the caller' do
+        filter = translate(leaf('created_at', operators::GREATER_THAN, Date.new(2026, 8, 7)),
+                           timezone: 'Europe/Paris')
+
+        expect(filter).to include('value' => '2026-08-06T22:00:00Z')
+      end
+
+      # Declaring only the bare comparisons on a Date column is enough: the
+      # toolkit rewrites every interval operator into the pair of bounds Pylon
+      # accepts, which is also why `time_range` never has to be emitted.
+      it 'translates an interval operator the toolkit rewrote into a pair of bounds' do
+        equivalent = ForestAdminDatasourceToolkit::Components::Query::ConditionTree::ConditionTreeEquivalent
+                     .get_equivalent_tree(leaf('created_at', operators::TODAY),
+                                          Collections::Issue::ApiFilters.forest_operators('created_at'),
+                                          'Date', 'UTC')
+
+        filter = translate(equivalent)
+
+        expect(filter['operator']).to eq('and')
+        expect(filter['subfilters'].map { |sub| sub['operator'] }).to eq(%w[time_is_after time_is_before])
+      end
+
+      it 'falls back to UTC and warns on a timezone it does not know' do
+        allow(ForestAdminDatasourcePylon.logger).to receive(:warn)
+
+        filter = translate(leaf('created_at', operators::GREATER_THAN, Date.new(2026, 8, 7)),
+                           timezone: 'Moon/Base')
+
+        expect(filter).to include('value' => '2026-08-07T00:00:00Z')
+        expect(ForestAdminDatasourcePylon.logger).to have_received(:warn).with(%r{unknown timezone 'Moon/Base'})
+      end
+    end
+
+    # An issue is read with `type` / `resolution_time` / `latest_message_time`
+    # but filtered on the names below.
+    describe 'field renames' do
+      it 'renames the columns Pylon spells differently in a filter' do
+        expect(translate(leaf('type', operators::EQUAL, 'ticket'))).to include('field' => 'issue_type')
+        expect(translate(leaf('resolution_time', operators::GREATER_THAN, '2026-08-01T00:00:00Z')))
+          .to include('field' => 'resolved_at')
+        expect(translate(leaf('latest_message_time', operators::LESS_THAN, '2026-08-01T00:00:00Z')))
+          .to include('field' => 'latest_message_activity_at')
+      end
+    end
+
+    describe 'branches' do
+      it 'translates an and into nested sub-filters' do
+        tree = branch('And', [leaf('state', operators::EQUAL, 'new'), leaf('team_id', operators::EQUAL, 'team-1')])
+
+        expect(translate(tree)).to eq(
+          'operator' => 'and',
+          'subfilters' => [{ 'field' => 'state', 'operator' => 'equals', 'value' => 'new' },
+                           { 'field' => 'team_id', 'operator' => 'equals', 'value' => 'team-1' }]
+        )
+      end
+
+      # Pylon nests sub-filters, so OR is expressed natively instead of being
+      # rejected the way the Zendesk query string forces.
+      it 'translates an or natively' do
+        tree = branch('Or', [leaf('state', operators::EQUAL, 'new'), leaf('title', operators::CONTAINS, 'boom')])
+
+        expect(translate(tree)['operator']).to eq('or')
+        expect(translate(tree)['subfilters'].size).to eq(2)
+      end
+
+      it 'unwraps a branch carrying a single condition' do
+        tree = branch('And', [leaf('state', operators::EQUAL, 'new')])
+
+        expect(translate(tree)).to eq('field' => 'state', 'operator' => 'equals', 'value' => 'new')
+      end
+
+      it 'accepts sub-filters nested up to the depth Pylon allows' do
+        expect(translate(nested(3))).to include('operator' => 'and')
+      end
+
+      it 'refuses sub-filters nested deeper than Pylon allows' do
+        expect { translate(nested(4)) }
+          .to raise_error(UnsupportedOperatorError, /nested deeper than 3 levels/)
+      end
+
+      it 'refuses a branch carrying no condition' do
+        expect { translate(branch('And', [])) }
+          .to raise_error(UnsupportedOperatorError, /carries no condition/)
+      end
+
+      it 'refuses an aggregator it does not know' do
+        tree = branch('Xor', [leaf('state', operators::EQUAL, 'new'), leaf('team_id', operators::EQUAL, 'team-1')])
+
+        expect { translate(tree) }.to raise_error(UnsupportedOperatorError, /Unknown condition tree aggregator/)
+      end
+    end
+
+    describe 'guards' do
+      it 'refuses a field Pylon cannot filter on' do
+        expect { translate(leaf('number', operators::EQUAL, 12)) }
+          .to raise_error(UnsupportedOperatorError, /Pylon cannot filter on 'number'/)
+      end
+
+      # An empty list would translate to a filter matching everything, turning
+      # "match nothing" into its exact opposite.
+      it 'refuses an empty list of values' do
+        expect { translate(leaf('state', operators::IN, [])) }
+          .to raise_error(UnsupportedOperatorError, /was given an empty list/)
+        expect { translate(leaf('state', operators::IN, [nil, ''])) }
+          .to raise_error(UnsupportedOperatorError, /was given an empty list/)
+      end
+
+      it 'refuses a nil value and points at the presence operators' do
+        expect { translate(leaf('state', operators::EQUAL, nil)) }
+          .to raise_error(UnsupportedOperatorError, /use the PRESENT or BLANK operator/)
+      end
+
+      it 'refuses every filter when the collection declares none' do
+        expect { translate(leaf('state', operators::EQUAL, 'new'), api_filters: {}) }
+          .to raise_error(UnsupportedOperatorError, /Pylon cannot filter on 'state'/)
+      end
+    end
+
+    # The filter travels as JSON, so only the date types need a wire format.
+    describe 'value types' do
+      let(:default_filters) do
+        { 'number_of_touches' => { ops: { operators::EQUAL => 'equals' } },
+          'customer_portal_visible' => { ops: { operators::EQUAL => 'equals' } } }
+      end
+
+      it 'passes numbers and booleans through untouched' do
+        expect(translate(leaf('number_of_touches', operators::EQUAL, 12))).to include('value' => 12)
+        expect(translate(leaf('customer_portal_visible', operators::EQUAL, false)))
+          .to include('value' => false)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Story 3 of [agent-ruby] Datasource Pylon — closes EXT-7, stacked on Story 2 (#347).

`PylonIssue` honoured no filter but the primary-key short-circuit: `warn_ignored_filter` logged a warning and returned unfiltered rows. A segment, a UI filter or a search therefore produced a wrong result that looked like a filtered one. This PR translates the Forest condition tree into the structured JSON filter of `POST /issues/search`, wires `filter.search` onto `search_text`, and aligns the schema with what the API can actually filter.

## What changed

**`Query::ConditionTreeTranslator`** (new) — condition tree to Pylon filter:

- leaf -> `{field, operator, value | values}`, branch -> `{operator: 'and' | 'or', subfilters: [...]}`
- **`or` is translated natively** through `subfilters` — the advantage over Zendesk Search, which has no general OR — with a guard on Pylon's max nesting depth of 3, and a single-condition branch unwrapped rather than wrapped
- timezone-aware date bounds, with the UTC fallback and warning on an unknown timezone
- anything the API cannot express **raises `UnsupportedOperatorError`** instead of being dropped: unknown field, operator outside a field's map, nil value (pointing at PRESENT / BLANK), empty `in []` (which would otherwise turn "match nothing" into "match everything"), unknown aggregator, nesting past depth 3

**`Issue::ApiFilters`** (new) — Pylon's per-field allow-list, transcribed from the API reference, and the single source of truth: `define_schema` derives every column's `filter_operators` from it, so the schema can no longer advertise a filter the translator would refuse. `not_equal` is not declared (the toolkit derives it from `not_in`), and date columns declare the bare `greater_than` / `less_than`, which is what lets the toolkit rewrite `Today` / `Previous*` into a pair of bounds — so `time_range` never has to be emitted.

**`BaseCollection`** — `build_pylon_filter`, plus `translate_sort` / `timezone_for` ported from the Zendesk base collection.

**`PylonIssue`** — `enable_search`, filters translated on every page of the walk, `warn_ignored_filter` removed.

## Two things beyond the story text

**A correctness fix.** `extract_id_lookup` now also pulls the `id` leaf out of a top-level `AND` and returns the leftover conditions, applied in memory via `ConditionTree#apply`. Forest sends `AND(id equal X, <scope>)` on a record detail as soon as a scope or a segment is set; `id` is not a Pylon filter field, so the previous bare-leaf-only short-circuit would have sent that tree to the translator and raised. The in-memory pass is safe because the record set is already narrowed to the requested ids. An `id` nested in an `OR` is deliberately not short-circuited — the other side of the union would bring in records the lookup never fetched.

**The schema had to be narrowed.** Pylon's allow-list is tighter than the operator sets Story 2 declared, and this is the only user-visible change:

| column | before | after |
| -- | -- | -- |
| `number`, `source`, `number_of_touches`, `first_response_time` | NUMBER_OPS / DATE_OPS | none — Pylon cannot filter them |
| `title` | equal, not_equal, in, not_in, present, blank | contains, i_contains, not_contains (`string_contains` only) |
| `body_html`, `tags` | none | filterable |
| `state`, `type`, party ids | STRING_OPS | tightened to the allow-list |
| dates | equal, before, after, present, blank | greater_than, less_than |

Three read-to-filter renames are carried by the table: an issue is read with `type` / `resolution_time` / `latest_message_time` but filtered on `issue_type` / `resolved_at` / `latest_message_activity_at`.

## Scope deviations

- **Count is not delivered here — it moves to Story 9 (EXT-13),** which owns throttling. Pylon exposes no count endpoint and no total in the `pagination` block, so a count means walking pages against a 20 req/min budget on every list view. `countable` stays `false` and `aggregate` is not ported. The remaining work is written up on EXT-13.
- **Sorting is scaffolding.** `/issues/search` has no sort parameter, so `PylonIssue`'s allow-list is empty and no column is sortable; a requested order is logged instead of being silently swallowed. `translate_sort` is in place for the Story 4 collections.
- **`normalize_id` has no Pylon counterpart** — primary keys are UUID strings, and `extract_id_lookup` already normalises with `to_s`. The Zendesk integer-coercion fix does not apply.
- Filterable on Pylon's side but not flat columns of the read payload, so left out: `ticket_form_id`, `follower_user_id`, `follower_contact_id`, `slack_channel_id`. They belong with Stories 4 / 5.

No client change was needed: `search_issues` already accepted `filter:` and `search_text:`. No repo-level registration file is touched — the gem was registered in Story 1, publication is Story 9.

## Tests

`176 examples, 0 failures`, 100% line coverage (92% branch), rubocop clean. The translator spec covers the operator matrix, the field renames, the branch shapes and every guard; one example runs a `Today` filter through the toolkit's equivalence engine to prove that declaring the bare comparisons is enough to reach Pylon as a pair of bounds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add server-side filters, search, and PK short-circuit hardening to the Pylon datasource
> - The `Issue` collection now supports server-side filtering and free-text search via `POST /issues/search`, with cursor-based pagination and field operator constraints derived from a new [`ApiFilters`](https://github.com/ForestAdmin/agent-ruby/pull/351/files#diff-1be1b9f3ef9ede25c4c7e9a77a99de1e6e2381f77ca0b30e650cc46ed85498cd) allow-list.
> - Primary-key lookups now support extracting an `id` leaf from a top-level AND condition, fetching records by id, and applying remaining conditions in memory with nil-safe comparisons; id lookups are capped at 20 per request.
> - A new [`ConditionTreeTranslator`](https://github.com/ForestAdmin/agent-ruby/pull/351/files#diff-27d169ce2d372bc7dce26f09c8d1cc171c29a93e647cef5d83db524d41b1f310) converts Forest condition trees to Pylon JSON filters, enforcing depth limits and raising clear errors for unsupported constructs.
> - [`BaseCollection`](https://github.com/ForestAdmin/agent-ruby/pull/351/files#diff-986a891cbf9bf31819e07d5d297aac63f71c38bc52e017a8d4f57fad195ea1da) gains residual validation, nil-safe guard helpers, sort translation against an allow-list, and operator clamping for custom fields.
> - Risk: fields not in the `ApiFilters` allow-list or operators without in-memory equivalents now raise explicit errors instead of silently passing through.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6814025.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->