### PR TITLE
feat(agent): accept the Forest-Projection header on record routes

### DIFF
--- a/packages/forest_admin_agent/lib/forest_admin_agent/routes/capabilities/collections.rb
+++ b/packages/forest_admin_agent/lib/forest_admin_agent/routes/capabilities/collections.rb
@@ -65,6 +65,8 @@ module ForestAdminAgent
               nativeQueryConnections: connections,
               agentCapabilities: {
                 canUseProjectionOnGetOne: true,
+                canUseProjectionViaHeader: true,
+                canUseProjectionViaHeaderOnList: true,
                 canUseMultipleFieldsProjectionOnRelation: true
               }
             },

--- a/packages/forest_admin_agent/lib/forest_admin_agent/routes/resources/csv.rb
+++ b/packages/forest_admin_agent/lib/forest_admin_agent/routes/resources/csv.rb
@@ -37,7 +37,7 @@ module ForestAdminAgent
             sort: QueryStringParser.parse_sort(context.collection, args),
             segment: QueryStringParser.parse_segment(context.collection, args)
           )
-          projection = QueryStringParser.parse_projection(context.collection, args)
+          projection = QueryStringParser.parse_projection_from_request(context.collection, args)
           filename = args[:params][:filename] || args[:params]['collection_name']
           filename += '.csv' unless /\.csv$/i.match?(filename)
           header = args[:params][:header]

--- a/packages/forest_admin_agent/lib/forest_admin_agent/routes/resources/related/csv_related.rb
+++ b/packages/forest_admin_agent/lib/forest_admin_agent/routes/resources/related/csv_related.rb
@@ -32,8 +32,9 @@ module ForestAdminAgent
                 ]
               )
             )
-            projection = ForestAdminAgent::Utils::QueryStringParser.parse_projection_with_pks(context.child_collection,
-                                                                                              args)
+            projection = ForestAdminAgent::Utils::QueryStringParser.parse_projection_from_request(
+              context.child_collection, args
+            )
 
             # Get the parent record primary keys
             primary_key_values = Utils::Id.unpack_id(context.collection, args[:params]['id'], with_key: true)

--- a/packages/forest_admin_agent/lib/forest_admin_agent/utils/query_string_parser.rb
+++ b/packages/forest_admin_agent/lib/forest_admin_agent/utils/query_string_parser.rb
@@ -52,7 +52,7 @@ module ForestAdminAgent
 
         return if header.nil? || header.empty?
 
-        projection_fields = build_header_projection_fields(collection, header.split(',').map(&:strip))
+        projection_fields = build_header_projection_fields(collection, header.split(',', -1).map(&:strip))
 
         ForestAdminDatasourceToolkit::Validations::ProjectionValidator.validate?(collection, projection_fields)
 
@@ -102,15 +102,23 @@ module ForestAdminAgent
       end
 
       def self.build_header_projection_fields(collection, requested_paths)
+        if requested_paths.any? { |path| path.empty? || path.split(':', -1).any?(&:empty?) }
+          raise ForestAdminDatasourceToolkit::Exceptions::ValidationError, 'The projection contains an empty field.'
+        end
+
         root_field_names = requested_paths.map { |path| path.split(':').first }
         root_field_names_with_types = root_field_names.dup
         add_polymorphic_type_fields(collection, root_field_names_with_types)
 
         projection_fields = requested_paths.map do |path|
-          field_name = path.split(':').first
+          field_name, nested_path = path.split(':', 2)
           field = get_field(collection, field_name)
 
-          field.type == 'PolymorphicManyToOne' ? "#{field_name}:*" : path
+          if field.type == 'PolymorphicManyToOne' && (nested_path.nil? || nested_path == '*')
+            "#{field_name}:*"
+          else
+            path
+          end
         end
 
         projection_fields | (root_field_names_with_types - root_field_names)

--- a/packages/forest_admin_agent/lib/forest_admin_agent/utils/query_string_parser.rb
+++ b/packages/forest_admin_agent/lib/forest_admin_agent/utils/query_string_parser.rb
@@ -47,6 +47,24 @@ module ForestAdminAgent
         raise BadRequestError, "Invalid projection: #{e.message}"
       end
 
+      def self.parse_projection_from_header(collection, args)
+        header = args.dig(:headers, 'HTTP_FOREST_PROJECTION')&.to_s&.strip
+
+        return if header.nil? || header.empty?
+
+        projection_fields = build_header_projection_fields(collection, header.split(',').map(&:strip))
+
+        ForestAdminDatasourceToolkit::Validations::ProjectionValidator.validate?(collection, projection_fields)
+
+        Projection.new(projection_fields)
+      rescue ForestAdminDatasourceToolkit::Exceptions::ForestException => e
+        raise BadRequestError, "Invalid Forest-Projection header: #{e.message}"
+      end
+
+      def self.parse_projection_from_request(collection, args)
+        parse_projection_from_header(collection, args) || parse_projection(collection, args)
+      end
+
       def self.add_polymorphic_type_fields(collection, requested_field_names)
         polymorphic_relations = collection.schema[:fields].select { |_, field| field.type == 'PolymorphicManyToOne' }
 
@@ -83,6 +101,21 @@ module ForestAdminAgent
         end
       end
 
+      def self.build_header_projection_fields(collection, requested_paths)
+        root_field_names = requested_paths.map { |path| path.split(':').first }
+        root_field_names_with_types = root_field_names.dup
+        add_polymorphic_type_fields(collection, root_field_names_with_types)
+
+        projection_fields = requested_paths.map do |path|
+          field_name = path.split(':').first
+          field = get_field(collection, field_name)
+
+          field.type == 'PolymorphicManyToOne' ? "#{field_name}:*" : path
+        end
+
+        projection_fields | (root_field_names_with_types - root_field_names)
+      end
+
       def self.get_field(collection, field_name)
         field = collection.schema[:fields][field_name]
         return field unless field.nil?
@@ -93,12 +126,11 @@ module ForestAdminAgent
               "Available fields are: [#{available_fields}]. " \
               'Please check if the field name is correct.'
       end
-      private_class_method :add_polymorphic_type_fields, :build_projection_fields, :get_field
+      private_class_method :add_polymorphic_type_fields, :build_projection_fields,
+                           :build_header_projection_fields, :get_field
 
       def self.parse_projection_with_pks(collection, args)
-        projection = parse_projection(collection, args)
-
-        projection.with_pks(collection)
+        parse_projection_from_request(collection, args).with_pks(collection)
       end
 
       def self.parse_pagination(args)

--- a/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/capabilities/collections_spec.rb
+++ b/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/capabilities/collections_spec.rb
@@ -84,7 +84,12 @@ module ForestAdminAgent
 
           it 'returns agentCapabilities' do
             expect(result[:content][:agentCapabilities]).to eq(
-              { canUseProjectionOnGetOne: true, canUseMultipleFieldsProjectionOnRelation: true }
+              {
+                canUseProjectionOnGetOne: true,
+                canUseProjectionViaHeader: true,
+                canUseProjectionViaHeaderOnList: true,
+                canUseMultipleFieldsProjectionOnRelation: true
+              }
             )
           end
         end
@@ -131,7 +136,12 @@ module ForestAdminAgent
 
           it 'returns agentCapabilities' do
             expect(result[:content][:agentCapabilities]).to eq(
-              { canUseProjectionOnGetOne: true, canUseMultipleFieldsProjectionOnRelation: true }
+              {
+                canUseProjectionOnGetOne: true,
+                canUseProjectionViaHeader: true,
+                canUseProjectionViaHeaderOnList: true,
+                canUseMultipleFieldsProjectionOnRelation: true
+              }
             )
           end
         end

--- a/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/resources/csv_spec.rb
+++ b/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/resources/csv_spec.rb
@@ -76,6 +76,30 @@ module ForestAdminAgent
             expect(result[:content][:headers]['Content-Disposition']).to match(/attachment; filename="user_export_\d{8}_\d{6}\.csv"/)
           end
 
+          it 'exports the projection read from the Forest-Projection header, without adding the primary keys' do
+            mock_enumerator = ["first_name\n", "foo\n"].to_enum
+            allow(csv_generator_stream).to receive(:stream).and_return(mock_enumerator)
+
+            args[:headers]['HTTP_FOREST_PROJECTION'] = 'first_name'
+            args[:params][:fields] = { 'user' => 'last_name' }
+            args[:params][:header] = 'first_name'
+            csv.handle_request(args)
+
+            expect(csv_generator_stream).to have_received(:stream) do |_header, _filter, projection, _list, _limit|
+              expect(projection).to eq(%w[first_name])
+            end
+          end
+
+          it 'does not fall back to the fields params when the header is invalid' do
+            args[:headers]['HTTP_FOREST_PROJECTION'] = 'field-that-do-not-exist'
+            args[:params][:fields] = { 'user' => 'last_name' }
+
+            expect { csv.handle_request(args) }.to raise_error(
+              Http::Exceptions::BadRequestError,
+              /Invalid Forest-Projection header:/
+            )
+          end
+
           it 'with a filename should return an export csv with the filename provided' do
             mock_enumerator = ["id,first_name,last_name\n", "1,foo,foo\n"].to_enum
             allow(csv_generator_stream).to receive(:stream).and_return(mock_enumerator)

--- a/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/resources/csv_spec.rb
+++ b/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/resources/csv_spec.rb
@@ -82,11 +82,12 @@ module ForestAdminAgent
 
             args[:headers]['HTTP_FOREST_PROJECTION'] = 'first_name'
             args[:params][:fields] = { 'user' => 'last_name' }
-            args[:params][:header] = 'first_name'
+            args[:params][:header] = 'First name'
             csv.handle_request(args)
 
-            expect(csv_generator_stream).to have_received(:stream) do |_header, _filter, projection, _list, _limit|
+            expect(csv_generator_stream).to have_received(:stream) do |header, _filter, projection, _list, _limit|
               expect(projection).to eq(%w[first_name])
+              expect(header).to eq('First name')
             end
           end
 

--- a/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/resources/list_spec.rb
+++ b/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/resources/list_spec.rb
@@ -96,6 +96,37 @@ module ForestAdminAgent
           )
         end
 
+        context 'when the Forest-Projection header is sent' do
+          it 'call list with the projection read from the header' do
+            args[:headers]['HTTP_FOREST_PROJECTION'] = 'first_name'
+            list.handle_request(args)
+
+            expect(@datasource.get_collection('user')).to have_received(:list) do |_caller, _filter, projection|
+              expect(projection).to eq(%w[first_name id])
+            end
+          end
+
+          it 'gives precedence to the header over the fields params' do
+            args[:headers]['HTTP_FOREST_PROJECTION'] = 'first_name'
+            args[:params][:fields] = { 'user' => 'last_name' }
+            list.handle_request(args)
+
+            expect(@datasource.get_collection('user')).to have_received(:list) do |_caller, _filter, projection|
+              expect(projection).to eq(%w[first_name id])
+            end
+          end
+
+          it 'does not fall back to the fields params when the header is invalid' do
+            args[:headers]['HTTP_FOREST_PROJECTION'] = 'field-that-do-not-exist'
+            args[:params][:fields] = { 'user' => 'last_name' }
+
+            expect { list.handle_request(args) }.to raise_error(
+              Http::Exceptions::BadRequestError,
+              /Invalid Forest-Projection header:/
+            )
+          end
+        end
+
         context 'when call list with simple condition tree leaf' do
           it 'call list with expected filters arg' do
             args[:params][:filters] = JSON.generate({ field: 'id', operator: 'greater_than', value: 7 })

--- a/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/resources/list_spec.rb
+++ b/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/resources/list_spec.rb
@@ -97,15 +97,6 @@ module ForestAdminAgent
         end
 
         context 'when the Forest-Projection header is sent' do
-          it 'call list with the projection read from the header' do
-            args[:headers]['HTTP_FOREST_PROJECTION'] = 'first_name'
-            list.handle_request(args)
-
-            expect(@datasource.get_collection('user')).to have_received(:list) do |_caller, _filter, projection|
-              expect(projection).to eq(%w[first_name id])
-            end
-          end
-
           it 'gives precedence to the header over the fields params' do
             args[:headers]['HTTP_FOREST_PROJECTION'] = 'first_name'
             args[:params][:fields] = { 'user' => 'last_name' }

--- a/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/resources/related/csv_related_spec.rb
+++ b/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/resources/related/csv_related_spec.rb
@@ -158,7 +158,42 @@ module ForestAdminAgent
               result = captured_lambda.call(mock_filter)
 
               expect(result).to eq([Category.new(1, 'bar')])
-              expect(ForestAdminDatasourceToolkit::Utils::Collection).to have_received(:list_relation)
+              expect(ForestAdminDatasourceToolkit::Utils::Collection).to have_received(:list_relation).with(
+                having_attributes(name: 'user'),
+                { 'id' => 1 },
+                'category',
+                instance_of(ForestAdminDatasourceToolkit::Components::Caller),
+                mock_filter,
+                %w[id label]
+              )
+            end
+
+            it 'exports the projection read from the Forest-Projection header, without adding the primary keys' do
+              args[:params]['relation_name'] = 'category'
+              args[:params]['id'] = 1
+              args[:headers]['HTTP_FOREST_PROJECTION'] = 'label'
+              args[:params][:fields] = { 'category' => 'id' }
+
+              captured_projection = nil
+              allow(csv_generator_stream).to receive(:stream) do |_header, _filter, projection, _list_records, _limit|
+                captured_projection = projection
+                ["label\n"].to_enum
+              end
+
+              csv.handle_request(args)
+
+              expect(captured_projection).to eq(%w[label])
+            end
+
+            it 'validates the header against the foreign collection, not the parent' do
+              args[:params]['relation_name'] = 'category'
+              args[:params]['id'] = 1
+              args[:headers]['HTTP_FOREST_PROJECTION'] = 'first_name'
+
+              expect { csv.handle_request(args) }.to raise_error(
+                ForestAdminAgent::Http::Exceptions::BadRequestError,
+                /Invalid Forest-Projection header:.*category\.first_name/
+              )
             end
           end
         end

--- a/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/resources/related/list_related_spec.rb
+++ b/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/resources/related/list_related_spec.rb
@@ -105,6 +105,35 @@ module ForestAdminAgent
             end
           end
 
+          context 'when the Forest-Projection header is sent' do
+            it 'call list_relation with the projection read from the header' do
+              args[:params]['relation_name'] = 'category'
+              args[:params]['id'] = 1
+              args[:headers]['HTTP_FOREST_PROJECTION'] = 'label'
+              args[:params][:fields] = { 'category' => 'id' }
+              allow(ForestAdminDatasourceToolkit::Utils::Collection).to receive(:list_relation).and_return([])
+
+              list.handle_request(args)
+
+              expect(ForestAdminDatasourceToolkit::Utils::Collection).to have_received(:list_relation) do
+              |_collection, _id, _relation_name, _caller, _foreign_filter, projection|
+                expect(projection).to eq(%w[label id])
+              end
+            end
+
+            it 'validates the header against the foreign collection, not the parent' do
+              args[:params]['relation_name'] = 'category'
+              args[:params]['id'] = 1
+              args[:headers]['HTTP_FOREST_PROJECTION'] = 'first_name'
+              allow(ForestAdminDatasourceToolkit::Utils::Collection).to receive(:list_relation).and_return([])
+
+              expect { list.handle_request(args) }.to raise_error(
+                ForestAdminAgent::Http::Exceptions::BadRequestError,
+                /Invalid Forest-Projection header:.*category\.first_name/
+              )
+            end
+          end
+
           context 'when checking permissions and scope' do
             it 'authorizes and scopes on the related collection, not the parent' do
               args[:params]['relation_name'] = 'category'

--- a/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/resources/show_spec.rb
+++ b/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/resources/show_spec.rb
@@ -115,6 +115,28 @@ module ForestAdminAgent
             end
           end
 
+          it 'call collection.list with the projection read from the Forest-Projection header' do
+            args[:params]['id'] = 1
+            args[:headers]['HTTP_FOREST_PROJECTION'] = 'first_name'
+            args[:params][:fields] = { 'user' => 'last_name' }
+            show.handle_request(args)
+
+            expect(@datasource.get_collection('user')).to have_received(:list) do |_caller, _filter, projection|
+              expect(projection).to eq(%w[first_name id])
+            end
+          end
+
+          it 'does not fall back to the query params when the Forest-Projection header is invalid' do
+            args[:params]['id'] = 1
+            args[:headers]['HTTP_FOREST_PROJECTION'] = 'field-that-do-not-exist'
+            args[:params][:fields] = { 'user' => 'last_name' }
+
+            expect { show.handle_request(args) }.to raise_error(
+              ForestAdminAgent::Http::Exceptions::BadRequestError,
+              /Invalid Forest-Projection header:/
+            )
+          end
+
           it 'raises NotFoundError when collection does not exist' do
             args[:params]['collection_name'] = 'non_existent_collection'
             args[:params]['id'] = 1

--- a/packages/forest_admin_agent/spec/lib/forest_admin_agent/utils/query_string_parser_spec.rb
+++ b/packages/forest_admin_agent/spec/lib/forest_admin_agent/utils/query_string_parser_spec.rb
@@ -312,6 +312,148 @@ module ForestAdminAgent
         end
       end
 
+      describe 'parse_projection_from_header' do
+        context 'when the collection has no polymorphic relation' do
+          let(:collection) do
+            datasource = Datasource.new
+            collection_person = Collection.new(datasource, 'Person')
+            collection_person.add_fields(
+              {
+                'id' => ColumnSchema.new(column_type: 'Number', is_primary_key: true),
+                'name' => ColumnSchema.new(column_type: 'String')
+              }
+            )
+            collection = Collection.new(datasource, 'Book')
+            collection.add_fields(
+              {
+                'id' => ColumnSchema.new(column_type: 'Number', is_primary_key: true),
+                'title' => ColumnSchema.new(column_type: 'String'),
+                'author_id' => ColumnSchema.new(column_type: 'Number'),
+                'author' => Relations::ManyToOneSchema.new(
+                  foreign_key: 'author_id',
+                  foreign_key_target: 'id',
+                  foreign_collection: 'Person'
+                )
+              }
+            )
+
+            datasource.add_collection(collection)
+            datasource.add_collection(collection_person)
+
+            return collection
+          end
+
+          it 'return nil when the header is missing' do
+            args = { headers: {}, params: { fields: { 'Book' => 'title' } } }
+
+            expect(described_class.parse_projection_from_header(collection, args)).to be_nil
+          end
+
+          it 'return nil when the header is empty' do
+            args = { headers: { 'HTTP_FOREST_PROJECTION' => '' }, params: {} }
+
+            expect(described_class.parse_projection_from_header(collection, args)).to be_nil
+          end
+
+          it 'return nil when the header only contains whitespace' do
+            args = { headers: { 'HTTP_FOREST_PROJECTION' => '  ' }, params: {} }
+
+            expect(described_class.parse_projection_from_header(collection, args)).to be_nil
+          end
+
+          it 'convert the header to a valid projection' do
+            args = { headers: { 'HTTP_FOREST_PROJECTION' => 'title,author:name' }, params: {} }
+
+            expect(described_class.parse_projection_from_header(collection, args)).to eq(
+              Projection.new(%w[title author:name])
+            )
+          end
+
+          it 'strip the whitespace around each field' do
+            args = { headers: { 'HTTP_FOREST_PROJECTION' => ' title , author:name ' }, params: {} }
+
+            expect(described_class.parse_projection_from_header(collection, args)).to eq(
+              Projection.new(%w[title author:name])
+            )
+          end
+
+          it 'raise a dedicated error when the header contains an unknown field' do
+            args = { headers: { 'HTTP_FOREST_PROJECTION' => 'field-that-do-not-exist' }, params: {} }
+
+            expect do
+              described_class.parse_projection_from_header(collection, args)
+            end.to raise_error(
+              Http::Exceptions::BadRequestError,
+              /Invalid Forest-Projection header:/
+            )
+          end
+        end
+
+        context 'when the collection has a PolymorphicManyToOne' do
+          let(:collection) do
+            datasource = Datasource.new
+            collection = Collection.new(datasource, 'Address')
+            collection.add_fields(
+              {
+                'id' => ColumnSchema.new(column_type: 'Number', is_primary_key: true),
+                'addressable_id' => ColumnSchema.new(column_type: 'Number'),
+                'addressable_type' => ColumnSchema.new(column_type: 'String'),
+                'addressable' => Relations::PolymorphicManyToOneSchema.new(
+                  foreign_key_type_field: 'addressable_type',
+                  foreign_collections: ['User'],
+                  foreign_key_targets: { 'User' => 'id' },
+                  foreign_key: 'addressable_id'
+                )
+              }
+            )
+            collection_user = Collection.new(datasource, 'User')
+            collection_user.add_fields(
+              {
+                'id' => ColumnSchema.new(column_type: 'Number', is_primary_key: true),
+                'email' => ColumnSchema.new(column_type: 'String')
+              }
+            )
+
+            datasource.add_collection(collection)
+            datasource.add_collection(collection_user)
+
+            return collection
+          end
+
+          it 'convert the polymorphic relation to polymorphic_relation:* and add the type field' do
+            args = { headers: { 'HTTP_FOREST_PROJECTION' => 'id,addressable' }, params: {} }
+
+            expect(described_class.parse_projection_from_header(collection, args)).to eq(
+              Projection.new(%w[id addressable:* addressable_type])
+            )
+          end
+
+          it 'automatically adds the type field when the foreign key is requested' do
+            args = { headers: { 'HTTP_FOREST_PROJECTION' => 'id,addressable_id' }, params: {} }
+
+            expect(described_class.parse_projection_from_header(collection, args)).to eq(
+              Projection.new(%w[id addressable_id addressable_type])
+            )
+          end
+
+          it 'does not duplicate the type field if already requested' do
+            args = { headers: { 'HTTP_FOREST_PROJECTION' => 'id,addressable_id,addressable_type' }, params: {} }
+
+            expect(described_class.parse_projection_from_header(collection, args)).to eq(
+              Projection.new(%w[id addressable_id addressable_type])
+            )
+          end
+
+          it 'ignore any nested field asked under a polymorphic relation' do
+            args = { headers: { 'HTTP_FOREST_PROJECTION' => 'id,addressable:email' }, params: {} }
+
+            expect(described_class.parse_projection_from_header(collection, args)).to eq(
+              Projection.new(%w[id addressable:* addressable_type])
+            )
+          end
+        end
+      end
+
       describe 'parse_projection_with_pks' do
         let(:collection) do
           datasource = Datasource.new
@@ -386,6 +528,49 @@ module ForestAdminAgent
 
           expect(described_class.parse_projection_with_pks(collection,
                                                            args)).to eq(Projection.new(%w[id author:id author:name]))
+        end
+
+        it 'gives precedence to the Forest-Projection header over the fields params' do
+          args = {
+            headers: { 'HTTP_FOREST_PROJECTION' => 'title' },
+            params: { fields: { 'Book' => 'author_id' } }
+          }
+
+          expect(described_class.parse_projection_with_pks(collection, args)).to eq(Projection.new(%w[title id]))
+        end
+
+        it 'falls back to the fields params when the header is empty' do
+          args = {
+            headers: { 'HTTP_FOREST_PROJECTION' => '' },
+            params: { fields: { 'Book' => 'title' } }
+          }
+
+          expect(described_class.parse_projection_with_pks(collection, args)).to eq(Projection.new(%w[title id]))
+        end
+
+        it 'adds the primary keys of the collection and of its relations to a header projection' do
+          args = {
+            headers: { 'HTTP_FOREST_PROJECTION' => 'title,author:name' },
+            params: {}
+          }
+
+          expect(described_class.parse_projection_with_pks(collection, args)).to eq(
+            Projection.new(%w[title author:name id author:id])
+          )
+        end
+
+        it 'does not fall back to the fields params when the header is invalid' do
+          args = {
+            headers: { 'HTTP_FOREST_PROJECTION' => 'field-that-do-not-exist' },
+            params: { fields: { 'Book' => 'title' } }
+          }
+
+          expect do
+            described_class.parse_projection_with_pks(collection, args)
+          end.to raise_error(
+            Http::Exceptions::BadRequestError,
+            /Invalid Forest-Projection header:/
+          )
         end
       end
 

--- a/packages/forest_admin_agent/spec/lib/forest_admin_agent/utils/query_string_parser_spec.rb
+++ b/packages/forest_admin_agent/spec/lib/forest_admin_agent/utils/query_string_parser_spec.rb
@@ -387,6 +387,91 @@ module ForestAdminAgent
               /Invalid Forest-Projection header:/
             )
           end
+
+          it 'raise when a nested field does not exist on the foreign collection' do
+            args = { headers: { 'HTTP_FOREST_PROJECTION' => 'author:nope' }, params: {} }
+
+            expect do
+              described_class.parse_projection_from_header(collection, args)
+            end.to raise_error(
+              Http::Exceptions::BadRequestError,
+              /Invalid Forest-Projection header:.*Person\.nope/
+            )
+          end
+
+          it 'raise when a nested field is requested under a column' do
+            args = { headers: { 'HTTP_FOREST_PROJECTION' => 'title:sub' }, params: {} }
+
+            expect do
+              described_class.parse_projection_from_header(collection, args)
+            end.to raise_error(
+              Http::Exceptions::BadRequestError,
+              /Invalid Forest-Projection header:.*Book\.title/
+            )
+          end
+
+          it 'raise when a relation is requested without any subfield' do
+            args = { headers: { 'HTTP_FOREST_PROJECTION' => 'author' }, params: {} }
+
+            expect do
+              described_class.parse_projection_from_header(collection, args)
+            end.to raise_error(
+              Http::Exceptions::BadRequestError,
+              /Invalid Forest-Projection header:/
+            )
+          end
+
+          it 'raise when the header only contains separators instead of returning an empty projection' do
+            args = { headers: { 'HTTP_FOREST_PROJECTION' => ',' }, params: { fields: { 'Book' => 'title' } } }
+
+            expect do
+              described_class.parse_projection_from_header(collection, args)
+            end.to raise_error(
+              Http::Exceptions::BadRequestError,
+              /Invalid Forest-Projection header: The projection contains an empty field/
+            )
+          end
+
+          it 'raise when a field is empty' do
+            args = { headers: { 'HTTP_FOREST_PROJECTION' => 'title,,id' }, params: {} }
+
+            expect do
+              described_class.parse_projection_from_header(collection, args)
+            end.to raise_error(
+              Http::Exceptions::BadRequestError,
+              /Invalid Forest-Projection header: The projection contains an empty field/
+            )
+          end
+
+          it 'raise when the header ends with a separator' do
+            args = { headers: { 'HTTP_FOREST_PROJECTION' => 'title,' }, params: {} }
+
+            expect do
+              described_class.parse_projection_from_header(collection, args)
+            end.to raise_error(
+              Http::Exceptions::BadRequestError,
+              /Invalid Forest-Projection header: The projection contains an empty field/
+            )
+          end
+
+          it 'raise when a path has an empty segment' do
+            args = { headers: { 'HTTP_FOREST_PROJECTION' => 'author:' }, params: {} }
+
+            expect do
+              described_class.parse_projection_from_header(collection, args)
+            end.to raise_error(
+              Http::Exceptions::BadRequestError,
+              /Invalid Forest-Projection header: The projection contains an empty field/
+            )
+          end
+
+          it 'deduplicate repeated fields' do
+            args = { headers: { 'HTTP_FOREST_PROJECTION' => 'title,title,author:name,author:name' }, params: {} }
+
+            expect(described_class.parse_projection_from_header(collection, args)).to eq(
+              Projection.new(%w[title author:name])
+            )
+          end
         end
 
         context 'when the collection has a PolymorphicManyToOne' do
@@ -444,11 +529,30 @@ module ForestAdminAgent
             )
           end
 
-          it 'ignore any nested field asked under a polymorphic relation' do
-            args = { headers: { 'HTTP_FOREST_PROJECTION' => 'id,addressable:email' }, params: {} }
+          it 'keep an explicit polymorphic_relation:* as is and add the type field' do
+            args = { headers: { 'HTTP_FOREST_PROJECTION' => 'id,addressable:*' }, params: {} }
 
             expect(described_class.parse_projection_from_header(collection, args)).to eq(
               Projection.new(%w[id addressable:* addressable_type])
+            )
+          end
+
+          it 'deduplicate a polymorphic relation asked both bare and with the star' do
+            args = { headers: { 'HTTP_FOREST_PROJECTION' => 'id,addressable,addressable:*' }, params: {} }
+
+            expect(described_class.parse_projection_from_header(collection, args)).to eq(
+              Projection.new(%w[id addressable:* addressable_type])
+            )
+          end
+
+          it 'raise instead of silently widening a nested field asked under a polymorphic relation' do
+            args = { headers: { 'HTTP_FOREST_PROJECTION' => 'id,addressable:email' }, params: {} }
+
+            expect do
+              described_class.parse_projection_from_header(collection, args)
+            end.to raise_error(
+              Http::Exceptions::BadRequestError,
+              /Invalid Forest-Projection header:.*Unexpected nested field email under generic relation/
             )
           end
         end


### PR DESCRIPTION
## What

Ruby counterpart of agent-nodejs#1813 (get-one) and agent-nodejs#1822 (list, relationship, csv). Until now the Ruby agent had **no** `Forest-Projection` support at all, and did not announce the capability.

The get-one, list, relationship list and csv export routes now read the projection from the `Forest-Projection` header (format `field,relation:subField`), taking precedence over the `fields[...]` query params. Relationship and list URLs observed in production routinely approach the 2KB AWS WAF `SizeRestrictions_QUERYSTRING` default, and header-based projections are a prerequisite for projecting workspaces.

## How

`QueryStringParser.parse_projection_from_header` reads `HTTP_FOREST_PROJECTION` (the Rails controller already forwards `request.headers.to_h`), and `parse_projection_from_request` implements the header-then-query-string precedence.

Four of the five routes already went through `parse_projection_with_pks`, so they pick the header up for free. The two csv routes deliberately do not add primary keys — the exported columns must match the `header` label row — so both call `parse_projection_from_request` directly.

The header fails closed: an invalid one raises `Invalid Forest-Projection header:` instead of falling back to the query string, and empty segments (`,` `a,` `a,,b` `a:` `:b`) are rejected rather than producing an empty projection.

## Polymorphism

The header path reproduces the query-string semantics rather than bypassing them:

- a `PolymorphicManyToOne` asked bare, or with an explicit `:*`, is projected as `relation:*`;
- a nested field asked under it (`addressable:email`) is rejected by `FieldValidator` instead of being silently widened;
- the discriminant type field is added whenever the polymorphic relation or its foreign key is requested, without duplicating it if the caller already asked for it.

## Capabilities

The agent now announces `canUseProjectionViaHeader` and `canUseProjectionViaHeaderOnList`, matching the Node agent so the frontend can gate on the same flags across both stacks. Query-string parsing and `canUseMultipleFieldsProjectionOnRelation` are untouched, so older frontends keep working unchanged.

## Notes

- CORS: nothing to do, the Rails engine echoes `Access-Control-Request-Headers`.
- The Rails controller is the only entry point building route args, so the header reaches every deployment. The RPC agent passes no `:headers` key and takes its projection from the body; it is unaffected.
- `csv_related` no longer adds primary keys, aligning it with `csv` and with agent-nodejs: the extra column had no matching label in the header row.
- The spec suite has a pre-existing, unrelated flakiness (a filesystem race in `spec_helper`'s cache cleanup) that can redden arbitrary examples.

fixes PRD-928