### PR TITLE
fix(agent): authorize create with a linked one-to-one on the foreign collection

### DIFF
--- a/packages/forest_admin_agent/lib/forest_admin_agent/routes/resources/store.rb
+++ b/packages/forest_admin_agent/lib/forest_admin_agent/routes/resources/store.rb
@@ -17,7 +17,7 @@ module ForestAdminAgent
         def handle_request(args = {})
           context = build(args)
           context.permissions.can?(:add, context.collection)
-          relations = resolve_linked_one_to_one_relations(args, context)
+          relations = authorized_linked_one_to_one_relations(args, context)
           data = format_attributes(args, context.collection)
           record = context.collection.create(context.caller, data)
           link_one_to_one_relations(relations, record, context)
@@ -40,14 +40,10 @@ module ForestAdminAgent
 
         private
 
-        # Everything the linking pass needs is authorized and resolved before the parent record is
-        # created: a denied edit, an unresolvable scope or a malformed linked id must leave no
-        # committed parent row behind.
-        def resolve_linked_one_to_one_relations(args, context)
+        def authorized_linked_one_to_one_relations(args, context)
           linked_one_to_one_relations(args, context).map do |relation|
             foreign_collection = relation[:foreign_collection]
 
-            # Must run before unpack_id: unauthorized callers get a 403, not a validation error
             context.permissions.can?(:edit, foreign_collection)
 
             relation.merge(
@@ -77,8 +73,6 @@ module ForestAdminAgent
           }
         end
 
-        # A foreign record excluded by the caller's scope matches no row, so the link is silently
-        # dropped, as on the update_related route and in agent-nodejs.
         def link_one_to_one_relations(relations, record, context)
           relations.each do |relation|
             schema = relation[:schema]

--- a/packages/forest_admin_agent/lib/forest_admin_agent/routes/resources/store.rb
+++ b/packages/forest_admin_agent/lib/forest_admin_agent/routes/resources/store.rb
@@ -17,9 +17,11 @@ module ForestAdminAgent
         def handle_request(args = {})
           context = build(args)
           context.permissions.can?(:add, context.collection)
+          relations = linked_one_to_one_relations(args, context)
+          assert_can_edit_linked_collections(relations, context)
           data = format_attributes(args, context.collection)
           record = context.collection.create(context.caller, data)
-          link_one_to_one_relations(args, record, context)
+          link_one_to_one_relations(relations, record, context)
           id = ForestAdminDatasourceToolkit::Utils::Record.primary_keys(context.collection, record)
           filter = ForestAdminDatasourceToolkit::Components::Query::Filter.new(
             condition_tree: ConditionTree::ConditionTreeFactory.match_ids(context.collection, [id])
@@ -37,24 +39,49 @@ module ForestAdminAgent
           }
         end
 
-        def link_one_to_one_relations(args, record, context)
-          args[:params][:data][:relationships]&.map do |field, value|
+        private
+
+        def assert_can_edit_linked_collections(relations, context)
+          relations.each { |relation| context.permissions.can?(:edit, relation[:foreign_collection]) }
+        end
+
+        def linked_one_to_one_relations(args, context)
+          args[:params][:data][:relationships]&.filter_map do |field, value|
             schema = context.collection.schema[:fields][field]
             next unless %w[OneToOne PolymorphicOneToOne].include?(schema.type)
 
-            primary_key_values = Utils::Id.unpack_id(context.collection, value['data']['id'], with_key: true)
-            foreign_collection = context.datasource.get_collection(schema.foreign_collection)
-            # Load the value that will be used as origin_key
+            id = value.dig('data', 'id')
+            next if id.nil?
+
+            {
+              schema: schema,
+              foreign_collection: context.datasource.get_collection(schema.foreign_collection),
+              id: id
+            }
+          end || []
+        end
+
+        def link_one_to_one_relations(relations, record, context)
+          relations.each do |relation|
+            schema = relation[:schema]
+            foreign_collection = relation[:foreign_collection]
+            primary_key_values = Utils::Id.unpack_id(foreign_collection, relation[:id], with_key: true)
             origin_value = record[schema.origin_key_target]
 
-            # update new relation (may update zero or one records).
             patch = { schema.origin_key => origin_value }
             if schema.type == 'PolymorphicOneToOne'
               patch[schema.origin_type_field] =
                 context.collection.name.gsub('__', '::')
             end
-            condition_tree = ConditionTree::ConditionTreeFactory.match_records(foreign_collection, [primary_key_values])
-            filter = Filter.new(condition_tree: condition_tree)
+            new_fk_owner = ConditionTree::ConditionTreeFactory.match_records(foreign_collection, [primary_key_values])
+            filter = Filter.new(
+              condition_tree: ConditionTree::ConditionTreeFactory.intersect(
+                [
+                  context.permissions.get_scope(foreign_collection),
+                  new_fk_owner
+                ]
+              )
+            )
             foreign_collection.update(context.caller, filter, patch)
           end
         end

--- a/packages/forest_admin_agent/lib/forest_admin_agent/routes/resources/store.rb
+++ b/packages/forest_admin_agent/lib/forest_admin_agent/routes/resources/store.rb
@@ -17,8 +17,7 @@ module ForestAdminAgent
         def handle_request(args = {})
           context = build(args)
           context.permissions.can?(:add, context.collection)
-          relations = linked_one_to_one_relations(args, context)
-          assert_can_edit_linked_collections(relations, context)
+          relations = resolve_linked_one_to_one_relations(args, context)
           data = format_attributes(args, context.collection)
           record = context.collection.create(context.caller, data)
           link_one_to_one_relations(relations, record, context)
@@ -41,43 +40,63 @@ module ForestAdminAgent
 
         private
 
-        def assert_can_edit_linked_collections(relations, context)
-          relations.each { |relation| context.permissions.can?(:edit, relation[:foreign_collection]) }
+        # Everything the linking pass needs is authorized and resolved before the parent record is
+        # created: a denied edit, an unresolvable scope or a malformed linked id must leave no
+        # committed parent row behind.
+        def resolve_linked_one_to_one_relations(args, context)
+          linked_one_to_one_relations(args, context).map do |relation|
+            foreign_collection = relation[:foreign_collection]
+
+            # Must run before unpack_id: unauthorized callers get a 403, not a validation error
+            context.permissions.can?(:edit, foreign_collection)
+
+            relation.merge(
+              scope: context.permissions.get_scope(foreign_collection),
+              primary_key_values: Utils::Id.unpack_id(foreign_collection, relation[:id], with_key: true)
+            )
+          end
         end
 
         def linked_one_to_one_relations(args, context)
-          args[:params][:data][:relationships]&.filter_map do |field, value|
-            schema = context.collection.schema[:fields][field]
-            next unless %w[OneToOne PolymorphicOneToOne].include?(schema.type)
+          relationships = args.dig(:params, :data, :relationships) || {}
 
-            id = value.dig('data', 'id')
-            next if id.nil?
-
-            {
-              schema: schema,
-              foreign_collection: context.datasource.get_collection(schema.foreign_collection),
-              id: id
-            }
-          end || []
+          relationships.filter_map { |field, value| linked_one_to_one_relation(field, value, context) }
         end
 
+        def linked_one_to_one_relation(field, value, context)
+          schema = context.collection.schema[:fields][field]
+          return unless %w[OneToOne PolymorphicOneToOne].include?(schema.type)
+
+          id = value.dig('data', 'id')
+          return if id.nil?
+
+          {
+            schema: schema,
+            foreign_collection: context.datasource.get_collection(schema.foreign_collection),
+            id: id
+          }
+        end
+
+        # A foreign record excluded by the caller's scope matches no row, so the link is silently
+        # dropped, as on the update_related route and in agent-nodejs.
         def link_one_to_one_relations(relations, record, context)
           relations.each do |relation|
             schema = relation[:schema]
             foreign_collection = relation[:foreign_collection]
-            primary_key_values = Utils::Id.unpack_id(foreign_collection, relation[:id], with_key: true)
-            origin_value = record[schema.origin_key_target]
 
-            patch = { schema.origin_key => origin_value }
+            patch = { schema.origin_key => record[schema.origin_key_target] }
             if schema.type == 'PolymorphicOneToOne'
               patch[schema.origin_type_field] =
                 context.collection.name.gsub('__', '::')
             end
-            new_fk_owner = ConditionTree::ConditionTreeFactory.match_records(foreign_collection, [primary_key_values])
+
+            new_fk_owner = ConditionTree::ConditionTreeFactory.match_records(
+              foreign_collection, [relation[:primary_key_values]]
+            )
             filter = Filter.new(
               condition_tree: ConditionTree::ConditionTreeFactory.intersect(
                 [
-                  context.permissions.get_scope(foreign_collection),
+                  relation[:scope],
                   new_fk_owner
                 ]
               )

--- a/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/resources/store_spec.rb
+++ b/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/resources/store_spec.rb
@@ -321,6 +321,72 @@ module ForestAdminAgent
                 .to raise_error(ForestAdminAgent::Http::Exceptions::ForbiddenError)
             end
 
+            it 'creates nothing when the linked id is malformed' do
+              args[:params][:data] = {
+                attributes: { 'name' => 'john' },
+                relationships: { 'passport' => { 'data' => { 'type' => 'passports', 'id' => 'malformed|id' } } },
+                type: 'persons'
+              }
+              args[:params]['collection_name'] = 'person'
+
+              expect { store.handle_request(args) }
+                .to raise_error(ForestAdminDatasourceToolkit::Exceptions::ForestException)
+              expect(@datasource.get_collection('person')).not_to have_received(:create)
+              expect(@datasource.get_collection('passport')).not_to have_received(:update)
+            end
+
+            it 'creates nothing when the scope cannot be resolved' do
+              args[:params][:data] = {
+                attributes: { 'name' => 'john' },
+                relationships: { 'passport' => { 'data' => { 'type' => 'passports', 'id' => 1 } } },
+                type: 'persons'
+              }
+              args[:params]['collection_name'] = 'person'
+              allow(permissions).to receive(:get_scope) do |collection|
+                raise ForestAdminDatasourceToolkit::Exceptions::ForestException, 'boom' if collection.name == 'passport'
+              end
+
+              expect { store.handle_request(args) }
+                .to raise_error(ForestAdminDatasourceToolkit::Exceptions::ForestException)
+              expect(@datasource.get_collection('person')).not_to have_received(:create)
+              expect(@datasource.get_collection('passport')).not_to have_received(:update)
+            end
+
+            it 'drops the link silently when the scope excludes the linked record' do
+              args[:params][:data] = {
+                attributes: { 'name' => 'john' },
+                relationships: { 'passport' => { 'data' => { 'type' => 'passports', 'id' => 1 } } },
+                type: 'persons'
+              }
+              args[:params]['collection_name'] = 'person'
+              allow(permissions).to receive(:get_scope) do |collection|
+                Nodes::ConditionTreeLeaf.new('person_id', Operators::EQUAL, 99) if collection.name == 'passport'
+              end
+              allow(@datasource.get_collection('person')).to receive_messages(
+                create: { 'id' => 1, 'name' => 'john' },
+                list: [{ 'id' => 1, 'name' => 'john' }]
+              )
+              # The ORM no-ops on a filter matching no row, so the caller gets a created parent
+              # and no relation, with nothing reporting the excluded target.
+              allow(@datasource.get_collection('passport')).to receive(:update).and_return(nil)
+
+              result = store.handle_request(args)
+
+              expect(result[:content]['data']['id']).to eq('1')
+              expect(@datasource.get_collection('person')).to have_received(:create)
+              expect(@datasource.get_collection('passport')).to have_received(:update) do |_caller, filter, _data|
+                expect(filter.condition_tree.to_h).to eq(
+                  {
+                    aggregator: 'And',
+                    conditions: [
+                      { field: 'person_id', operator: Operators::EQUAL, value: 99 },
+                      { field: 'id', operator: Operators::EQUAL, value: 1 }
+                    ]
+                  }
+                )
+              end
+            end
+
             it 'ignores a one to one relationship carrying no data' do
               args[:params][:data] = {
                 attributes: { 'name' => 'john' },
@@ -367,7 +433,7 @@ module ForestAdminAgent
                   origin_key_target: 'id',
                   foreign_collection: 'address',
                   origin_type_field: 'addressable_type',
-                  origin_type_value: 'person'
+                  origin_type_value: 'Person::Legacy'
                 )
             end
 

--- a/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/resources/store_spec.rb
+++ b/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/resources/store_spec.rb
@@ -25,7 +25,7 @@ module ForestAdminAgent
 
         before do
           allow(ForestAdminAgent::Services::Permissions).to receive(:new).and_return(permissions)
-          allow(permissions).to receive(:can?).and_return(true)
+          allow(permissions).to receive_messages(can?: true, get_scope: nil)
         end
 
         it 'adds the route forest_store' do
@@ -187,7 +187,10 @@ module ForestAdminAgent
                     is_primary_key: true,
                     filter_operators: [Operators::IN, Operators::EQUAL]
                   ),
-                  'person_id' => ColumnSchema.new(column_type: 'Number'),
+                  'person_id' => ColumnSchema.new(
+                    column_type: 'Number',
+                    filter_operators: [Operators::IN, Operators::EQUAL, Operators::NOT_EQUAL]
+                  ),
                   'person' => Relations::ManyToOneSchema.new(
                     foreign_key: 'person_id',
                     foreign_key_target: 'id',
@@ -201,7 +204,19 @@ module ForestAdminAgent
             allow(ForestAdminAgent::Builder::AgentFactory.instance).to receive(:send_schema).and_return(nil)
             ForestAdminAgent::Builder::AgentFactory.instance.add_datasource(@datasource)
             ForestAdminAgent::Builder::AgentFactory.instance.build
+
+            allow(permissions).to receive(:can?) do |action, collection|
+              checked_permissions << [action, collection.name]
+              raise ForestAdminAgent::Http::Exceptions::ForbiddenError if denied_permissions.include?(
+                [action, collection.name]
+              )
+
+              true
+            end
           end
+
+          let(:checked_permissions) { [] }
+          let(:denied_permissions) { [] }
 
           describe 'with one to one relation' do
             it 'call create and return an serialized content' do
@@ -220,6 +235,7 @@ module ForestAdminAgent
               )
 
               result = store.handle_request(args)
+              expect(checked_permissions).to eq([[:add, 'person'], [:edit, 'passport']])
               expect(@datasource.get_collection('person')).to have_received(:create) do |caller, data|
                 expect(caller).to be_instance_of(Components::Caller)
                 expect(data).to eq({ 'name' => 'john' })
@@ -244,6 +260,147 @@ module ForestAdminAgent
                     }
                   }
               )
+            end
+
+            it 'authorizes the edit on the foreign collection and intersects its scope' do
+              args[:params][:data] = {
+                attributes: { 'name' => 'john' },
+                relationships: { 'passport' => { 'data' => { 'type' => 'passports', 'id' => 1 } } },
+                type: 'persons'
+              }
+              args[:params]['collection_name'] = 'person'
+              allow(permissions).to receive(:get_scope) do |collection|
+                Nodes::ConditionTreeLeaf.new('person_id', Operators::NOT_EQUAL, 99) if collection.name == 'passport'
+              end
+              allow(@datasource.get_collection('person')).to receive_messages(
+                create: { 'id' => 1, 'name' => 'john' },
+                list: [{ 'id' => 1, 'name' => 'john' }]
+              )
+
+              store.handle_request(args)
+
+              expect(checked_permissions).to eq([[:add, 'person'], [:edit, 'passport']])
+              expect(@datasource.get_collection('passport')).to have_received(:update) do |_caller, filter, _data|
+                expect(filter.condition_tree.to_h).to eq(
+                  {
+                    aggregator: 'And',
+                    conditions: [
+                      { field: 'person_id', operator: Operators::NOT_EQUAL, value: 99 },
+                      { field: 'id', operator: Operators::EQUAL, value: 1 }
+                    ]
+                  }
+                )
+              end
+            end
+
+            it 'creates nothing when the edit is denied on the foreign collection' do
+              denied_permissions << [:edit, 'passport']
+              args[:params][:data] = {
+                attributes: { 'name' => 'john' },
+                relationships: { 'passport' => { 'data' => { 'type' => 'passports', 'id' => 1 } } },
+                type: 'persons'
+              }
+              args[:params]['collection_name'] = 'person'
+
+              expect { store.handle_request(args) }
+                .to raise_error(ForestAdminAgent::Http::Exceptions::ForbiddenError)
+              expect(@datasource.get_collection('person')).not_to have_received(:create)
+              expect(@datasource.get_collection('passport')).not_to have_received(:update)
+            end
+
+            it 'checks the edit permission before parsing the linked id' do
+              denied_permissions << [:edit, 'passport']
+              args[:params][:data] = {
+                attributes: { 'name' => 'john' },
+                relationships: { 'passport' => { 'data' => { 'type' => 'passports', 'id' => 'malformed|id' } } },
+                type: 'persons'
+              }
+              args[:params]['collection_name'] = 'person'
+
+              expect { store.handle_request(args) }
+                .to raise_error(ForestAdminAgent::Http::Exceptions::ForbiddenError)
+            end
+
+            it 'ignores a one to one relationship carrying no data' do
+              args[:params][:data] = {
+                attributes: { 'name' => 'john' },
+                relationships: { 'passport' => { 'data' => nil } },
+                type: 'persons'
+              }
+              args[:params]['collection_name'] = 'person'
+              allow(@datasource.get_collection('person')).to receive_messages(
+                create: { 'id' => 1, 'name' => 'john' },
+                list: [{ 'id' => 1, 'name' => 'john' }]
+              )
+
+              store.handle_request(args)
+
+              expect(checked_permissions).to eq([[:add, 'person']])
+              expect(@datasource.get_collection('passport')).not_to have_received(:update)
+            end
+          end
+
+          describe 'with polymorphic one to one relation' do
+            before do
+              collection_address = build_collection(
+                name: 'address',
+                schema: {
+                  fields: {
+                    'reference' => ColumnSchema.new(
+                      column_type: 'String',
+                      is_primary_key: true,
+                      filter_operators: [Operators::IN, Operators::EQUAL]
+                    ),
+                    'location' => ColumnSchema.new(
+                      column_type: 'String',
+                      filter_operators: [Operators::IN, Operators::EQUAL]
+                    ),
+                    'addressable_id' => ColumnSchema.new(column_type: 'Number'),
+                    'addressable_type' => ColumnSchema.new(column_type: 'String')
+                  }
+                }
+              )
+              @datasource.add_collection(collection_address)
+              @datasource.get_collection('person').schema[:fields]['address'] =
+                Relations::PolymorphicOneToOneSchema.new(
+                  origin_key: 'addressable_id',
+                  origin_key_target: 'id',
+                  foreign_collection: 'address',
+                  origin_type_field: 'addressable_type',
+                  origin_type_value: 'person'
+                )
+            end
+
+            it 'authorizes the edit, intersects the scope and matches the foreign primary key' do
+              args[:params][:data] = {
+                attributes: { 'name' => 'john' },
+                relationships: { 'address' => { 'data' => { 'type' => 'addresses', 'id' => 'ref-1' } } },
+                type: 'persons'
+              }
+              args[:params]['collection_name'] = 'person'
+              allow(permissions).to receive(:get_scope) do |collection|
+                Nodes::ConditionTreeLeaf.new('location', Operators::EQUAL, 'paris') if collection.name == 'address'
+              end
+              allow(@datasource.get_collection('person')).to receive_messages(
+                create: { 'id' => 1, 'name' => 'john' },
+                list: [{ 'id' => 1, 'name' => 'john' }]
+              )
+
+              store.handle_request(args)
+
+              expect(checked_permissions).to eq([[:add, 'person'], [:edit, 'address']])
+              expect(@datasource.get_collection('address')).to have_received(:update) do |_caller, filter, data|
+                expect(data).to eq({ 'addressable_id' => 1, 'addressable_type' => 'person' })
+                expect(filter.condition_tree.to_h).to eq(
+                  {
+                    aggregator: 'And',
+                    conditions: [
+                      { field: 'location', operator: Operators::EQUAL, value: 'paris' },
+                      { field: 'reference', operator: Operators::EQUAL, value: 'ref-1' }
+                    ]
+                  }
+                )
+              end
             end
           end
 

--- a/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/resources/store_spec.rb
+++ b/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/resources/store_spec.rb
@@ -366,8 +366,6 @@ module ForestAdminAgent
                 create: { 'id' => 1, 'name' => 'john' },
                 list: [{ 'id' => 1, 'name' => 'john' }]
               )
-              # The ORM no-ops on a filter matching no row, so the caller gets a created parent
-              # and no relation, with nothing reporting the excluded target.
               allow(@datasource.get_collection('passport')).to receive(:update).and_return(nil)
 
               result = store.handle_request(args)


### PR DESCRIPTION
Fixes [PRD-921](https://linear.app/forestadmin/issue/PRD-921/agent-ruby-create-with-a-linked-one-to-one-writes-the-foreign). Ruby counterpart of PRD-916, fixed in agent-nodejs [#1819](https://github.com/ForestAdmin/agent-nodejs/pull/1819).

## The bug

`POST /forest/:collection` with a linked `OneToOne` / `PolymorphicOneToOne` relation asserted only `add` on the **parent** collection, then updated the **foreign** collection with no authorization and no scope:

```ruby
condition_tree = ConditionTreeFactory.match_records(foreign_collection, [primary_key_values])
foreign_collection.update(context.caller, Filter.new(condition_tree: condition_tree), patch)
```

A user with `add` on `books` but no `edit` on `passports` could rewrite the foreign key of an arbitrary passport — stealing it from its owner — including a passport outside their scope. Worse than the Node instance on two counts: Node at least asserted `edit` (on the wrong side) and kept the writes scope-bounded.

## The fix

- Assert `edit` on the **foreign** collection, once per linked one-to-one relation, and **before** the parent record is created — a denied link writes nothing at all, and a denial on one relation no longer lets writes on the others through. The parent-side `add` check is unchanged.
- Intersect `get_scope(foreign_collection)` into the update filter, mirroring `create_new_one_to_one_relationship` in `update_related.rb` (PRD-908, #350).
- Resolve **everything** the linking pass needs — the `edit` assertion, the scope, and the unpacked linked id — in a single pre-create pass, and carry it in the relation hash. `get_scope` reads the `forest.rendering` cache that nothing earlier in this route warms, and unlike `can?` it has no `permission_system?` bypass; leaving it below `create` meant a cold cache, a Forest API 5xx or an unresolvable team/user raised **after** the parent row was committed, so the 500 the caller retried duplicated the parent. Same shape for a malformed packed id. The "a rejected link writes nothing at all" invariant now holds for failed lookups, not only for denied permissions.
- Single `linked_one_to_one_relations` helper feeding both the permission pass and the linking pass, so widening the guard on one side can no longer silently drop the check on the other.

## Observable contract when the scope excludes the target

A caller linking a foreign record outside their scope gets a **201 with the parent created and the relation absent** — the intersected filter matches no row and `entity&.update!` is a no-op, indistinguishable from linking an id that does not exist. This is deliberate: it is what agent-nodejs [#1819](https://github.com/ForestAdmin/agent-nodejs/pull/1819) and `create_new_one_to_one_relationship` in `update_related.rb` both do, and the PRD prescribes the mechanism without asking for a 403. Counting first to raise `ForbiddenError` would diverge from Node and cost an extra query; the contract is instead pinned by a test and stated at the call site.

Two defects on the rewritten lines, fixed along the way and each pinned by a test — flagging them explicitly as they sit outside the strict scope of the PRD:

- the linked id was unpacked against **`context.collection`** (the parent) while the `match_records` that follows targets the foreign collection, so the filter carried the wrong primary key names as soon as the two sides disagreed;
- a one-to-one relationship carrying `data: null` raised a `NoMethodError` (`value['data']['id']`); it is now ignored, matching Node's `linked !== null`.

## Deliberate divergence from Node

Node runs two updates (null the old foreign-key owner, then claim the new one); this route keeps its single update. On a create, `origin_value` is the id of a record that has just been born, so no foreign record can already carry it — Node's first update is a no-op costing one query. The PRD notes the same, and it has no bearing on the authorization gap.

## Tests

`store_spec.rb`: scope intersected (one-to-one and polymorphic), a denied `edit` creating neither parent nor link, `403` raised before the linked id is parsed (the invariant PRD-908 established on `update_related.rb`), a failed scope lookup and a malformed linked id each creating neither parent nor link, the silent no-op when the scope excludes the target, `data: null` ignored, and the parent-side `add` check pinned so removing it would not go unnoticed.

The polymorphic fixture carries `origin_type_value: 'Person::Legacy'` on a collection named `person`, so the `addressable_type` assertion pins `context.collection.name` as the source of the type column instead of passing under either candidate.

Permission assertions go through a collected `[action, collection_name]` list rather than `having_attributes` on the collection instances: on failure, rspec inspects the decorator chain and the run hangs instead of reporting.

Every new assertion was checked against the faulty implementation it guards — the pre-fix route, `unpack_id` hoisted back above the permission check, the parent collection restored as the unpack target, `get_scope` and `unpack_id` dropped back below `create`, and `schema.origin_type_value` swapped in for the collection name — and each mutation is caught.

842 examples, 0 failures on `forest_admin_agent`; rubocop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Authorize edit on linked one-to-one foreign collections before creating a record
> - The `Store#handle_request` action now resolves linked one-to-one (and polymorphic one-to-one) relations from the request payload before creating the main record, and calls `can?(:edit)` on each foreign collection, aborting if any permission is denied.
> - `link_one_to_one_relations` is refactored to accept a precomputed relations array and now unpacks the foreign record's primary key against the foreign collection (not the current collection), fixing incorrect record matching.
> - Scope from `permissions.get_scope` is intersected into the update filter for each foreign collection, ensuring scoped access controls are respected during relation linking.
> - One-to-one relationships with `nil` data ids are skipped rather than processed.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #353 opened
>
> - Added authorization checks for one-to-one linked relations during record creation [7a1a75c]
> - Removed inline comments from test files [7a1a75c]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 222e53d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
