### PR TITLE
chore(security): patch 11 Dependabot alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "semantic-release-slack-bot/**/micromatch": "^4.0.8",
     "brace-expansion": "^5.0.7",
     "fast-uri": "^3.1.4",
-    "tar": "^7.5.21"
+    "tar": "^7.5.21",
+    "ip-address": "^10.3.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1864,10 +1864,10 @@ init-package-json@^8.2.5:
     semver "^7.7.2"
     validate-npm-package-name "^7.0.0"
 
-ip-address@^10.1.1:
-  version "10.2.0"
-  resolved "https://registry.yarnpkg.com/ip-address/-/ip-address-10.2.0.tgz#805fc178b20c518bd4c8548b24fe30892d7f3206"
-  integrity sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==
+ip-address@^10.1.1, ip-address@^10.3.1:
+  version "10.5.0"
+  resolved "https://registry.yarnpkg.com/ip-address/-/ip-address-10.5.0.tgz#fcd6d7dfe9e68416b7cb71afe9bc960b3e38c13b"
+  integrity sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==
 
 is-alphabetical@^1.0.0:
   version "1.0.4"
@@ -4027,14 +4027,14 @@ uglify-js@^3.1.4:
   integrity sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==
 
 undici@^6.23.0, undici@^6.25.0:
-  version "6.27.0"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-6.27.0.tgz#41f9e48f7c5a40d27376caaead8c9a9fc7bca9c4"
-  integrity sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==
+  version "6.28.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-6.28.0.tgz#9f0e385744fef5021d6596c5bccd783f61193c1c"
+  integrity sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==
 
 undici@^7.0.0:
-  version "7.28.0"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-7.28.0.tgz#97d64564198b285bc281f0e8e29597e3d11fe7ec"
-  integrity sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==
+  version "7.29.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-7.29.0.tgz#ae0f6f62e06e057a9cbb7b2b5fde2bb74f791b8f"
+  integrity sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==
 
 unicode-emoji-modifier-base@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
> 👋 First-level support: see [Handling automated security PRs](https://forest.slite.com/app/docs/rmjdwFgmV2RzUp) for how to triage and merge this PR.

## Summary

11 fixed, 0 ignored, 1 deferred, 0 security pins added, 0 security pins removed, 0 could-not-auto-fix. | label: :lock: security applied

## Fixed

| Done | Alert | Gem | Ecosystem | From → To | Severity | What was bumped |
|---|---|---|---|---|---|---|
| - [ ] | [#106](https://github.com/ForestAdmin/agent-ruby/security/dependabot/106) | ip-address | npm | 10.2.0 → 10.5.0 | high | Added root `resolutions["ip-address"] = "^10.3.1"` in `package.json`; yarn re-resolved to 10.5.0 (transitive under `@octokit/*` etc.) |
| - [ ] | [#96](https://github.com/ForestAdmin/agent-ruby/security/dependabot/96) | ip-address | npm | 10.2.0 → 10.5.0 | medium | Same bump as #106 |
| - [ ] | [#95](https://github.com/ForestAdmin/agent-ruby/security/dependabot/95) | ip-address | npm | 10.2.0 → 10.5.0 | medium | Same bump as #106 |
| - [ ] | [#98](https://github.com/ForestAdmin/agent-ruby/security/dependabot/98) | undici | npm | 7.28.0 → 7.29.0 | high | Removed stale `undici@^7.0.0` block from `yarn.lock`; `yarn install` re-resolved v7 line to 7.29.0 (parent: `@semantic-release/github`) |
| - [ ] | [#105](https://github.com/ForestAdmin/agent-ruby/security/dependabot/105) | undici | npm | 7.28.0 → 7.29.0 | medium | Same bump as #98 |
| - [ ] | [#103](https://github.com/ForestAdmin/agent-ruby/security/dependabot/103) | undici | npm | 7.28.0 → 7.29.0 | medium | Same bump as #98 |
| - [ ] | [#102](https://github.com/ForestAdmin/agent-ruby/security/dependabot/102) | undici | npm | 7.28.0 → 7.29.0 | medium | Same bump as #98 |
| - [ ] | [#100](https://github.com/ForestAdmin/agent-ruby/security/dependabot/100) | undici | npm | 7.28.0 → 7.29.0 | medium | Same bump as #98 |
| - [ ] | [#104](https://github.com/ForestAdmin/agent-ruby/security/dependabot/104) | undici | npm | 6.27.0 → 6.28.0 | medium | Removed stale `undici@^6.23.0, undici@^6.25.0` block from `yarn.lock`; `yarn install` re-resolved v6 line to 6.28.0 (parents: `@actions/http-client`, `node-gyp`) |
| - [ ] | [#101](https://github.com/ForestAdmin/agent-ruby/security/dependabot/101) | undici | npm | 6.27.0 → 6.28.0 | medium | Same bump as #104 |
| - [ ] | [#99](https://github.com/ForestAdmin/agent-ruby/security/dependabot/99) | undici | npm | 6.27.0 → 6.28.0 | medium | Same bump as #104 |

## Ignored

None.

## Deferred

[#107](https://github.com/ForestAdmin/agent-ruby/security/dependabot/107) — js-yaml (opened 2026-08-10, < 7 days old at run time). Will be picked up by the next scheduled run.

## Risks

- **ip-address 10.2.0 → 10.5.0** — patch releases within the 10.x line. The fix in 10.3.1 tightens special-use / SSRF classification (leading-zero octets, CIDR-suffix bypass, IPv4-mapped/NAT64 classification). Only breaking risk would be code that relied on the previously-accepted-but-ambiguous parsing; this repo does not import `ip-address` directly (transitive under `@octokit/*` / semantic-release tooling), so exposure is limited to those tools.
- **undici v6 6.27.0 → 6.28.0** — patch bump; addresses CRLF injection, cookie-attribute injection, response desync, and cache-directive disclosure. Used by `@actions/http-client` (CI-only) and `node-gyp`. No behavior change beyond the patched vulns is expected.
- **undici v7 7.28.0 → 7.29.0** — patch bump; addresses the same class of issues on the v7 line. Used by `@semantic-release/github` (release tooling). No behavior change beyond the patched vulns is expected.
- All bumped packages are dev/tooling dependencies of the root `package.json`; none ships to consumers of the published Ruby gems.

## Manual testing

Covered by CI.

## Validation

✅ CI green (Actions + commit statuses; app-based checks not monitored)
