### PR TITLE
fix(agent): authorize associate-related on the foreign collection and scope the many-to-many link

### DIFF
--- a/packages/forest_admin_agent/lib/forest_admin_agent/routes/resources/related/associate_related.rb
+++ b/packages/forest_admin_agent/lib/forest_admin_agent/routes/resources/related/associate_related.rb
@@ -83,21 +83,21 @@ module ForestAdminAgent
           end
 
           def associate_many_to_many(relation, parent_primary_key_values, target_primary_key_values, context)
-            foreign_id = Schema.primary_keys(context.child_collection)[0]
-            target = find_target_in_scope(target_primary_key_values, foreign_id, context)
+            target = find_target_in_scope(target_primary_key_values, relation.foreign_key_target, context)
             return if target.nil?
 
-            foreign_value = target[foreign_id]
-            origin_id = Schema.primary_keys(context.collection)[0]
             origin_value = Collection.get_value(context.collection, context.caller, parent_primary_key_values,
-                                                origin_id)
-            record = { relation.origin_key => origin_value, relation.foreign_key => foreign_value }
+                                                relation.origin_key_target)
+            record = {
+              relation.origin_key => origin_value,
+              relation.foreign_key => target[relation.foreign_key_target]
+            }
 
             through_collection = context.datasource.get_collection(relation.through_collection)
             through_collection.create(context.caller, record)
           end
 
-          def find_target_in_scope(target_primary_key_values, foreign_id, context)
+          def find_target_in_scope(target_primary_key_values, foreign_key_target, context)
             filter = Filter.new(
               condition_tree: ConditionTree::ConditionTreeFactory.intersect(
                 [
@@ -108,7 +108,7 @@ module ForestAdminAgent
               )
             )
 
-            context.child_collection.list(context.caller, filter, Projection.new([foreign_id])).first
+            context.child_collection.list(context.caller, filter, Projection.new([foreign_key_target])).first
           end
         end
       end

--- a/packages/forest_admin_agent/lib/forest_admin_agent/routes/resources/related/associate_related.rb
+++ b/packages/forest_admin_agent/lib/forest_admin_agent/routes/resources/related/associate_related.rb
@@ -22,7 +22,7 @@ module ForestAdminAgent
 
           def handle_request(args = {})
             context = build(args)
-            context.permissions.can?(:edit, context.collection)
+            context.permissions.can?(:edit, context.child_collection)
 
             parent_primary_key_values = Utils::Id.unpack_id(context.collection, args[:params]['id'], with_key: true)
             target_primary_key_values = Utils::Id.unpack_id(context.child_collection, args[:params]['data'][0]['id'],
@@ -83,15 +83,32 @@ module ForestAdminAgent
           end
 
           def associate_many_to_many(relation, parent_primary_key_values, target_primary_key_values, context)
-            id = Schema.primary_keys(context.child_collection)[0]
-            foreign_value = Collection.get_value(context.child_collection, context.caller, target_primary_key_values,
-                                                 id)
-            id = Schema.primary_keys(context.collection)[0]
-            origin_value = Collection.get_value(context.collection, context.caller, parent_primary_key_values, id)
+            foreign_id = Schema.primary_keys(context.child_collection)[0]
+            target = find_target_in_scope(target_primary_key_values, foreign_id, context)
+            return if target.nil?
+
+            foreign_value = target[foreign_id]
+            origin_id = Schema.primary_keys(context.collection)[0]
+            origin_value = Collection.get_value(context.collection, context.caller, parent_primary_key_values,
+                                                origin_id)
             record = { relation.origin_key => origin_value, relation.foreign_key => foreign_value }
 
             through_collection = context.datasource.get_collection(relation.through_collection)
             through_collection.create(context.caller, record)
+          end
+
+          def find_target_in_scope(target_primary_key_values, foreign_id, context)
+            filter = Filter.new(
+              condition_tree: ConditionTree::ConditionTreeFactory.intersect(
+                [
+                  ConditionTree::ConditionTreeFactory.match_ids(context.child_collection,
+                                                                [target_primary_key_values]),
+                  context.permissions.get_scope(context.child_collection)
+                ]
+              )
+            )
+
+            context.child_collection.list(context.caller, filter, Projection.new([foreign_id])).first
           end
         end
       end

--- a/packages/forest_admin_agent/lib/forest_admin_agent/routes/resources/related/associate_related.rb
+++ b/packages/forest_admin_agent/lib/forest_admin_agent/routes/resources/related/associate_related.rb
@@ -44,16 +44,7 @@ module ForestAdminAgent
           private
 
           def associate_one_to_many(relation, parent_primary_key_values, target_primary_key_values, context)
-            id = Schema.primary_keys(context.child_collection)[0]
-            value = Collection.get_value(context.child_collection, context.caller, target_primary_key_values, id)
-            filter = Filter.new(
-              condition_tree: ConditionTree::ConditionTreeFactory.intersect(
-                [
-                  ConditionTree::Nodes::ConditionTreeLeaf.new(id, 'Equal', value),
-                  context.permissions.get_scope(context.child_collection)
-                ]
-              )
-            )
+            filter = target_in_scope_filter(target_primary_key_values, context)
             value = Collection.get_value(context.collection, context.caller, parent_primary_key_values,
                                          relation.origin_key_target)
 
@@ -61,17 +52,7 @@ module ForestAdminAgent
           end
 
           def associate_polymorphic_one_to_many(relation, parent_primary_key_values, target_primary_key_values, context)
-            id = Schema.primary_keys(context.child_collection)[0]
-            value = Collection.get_value(context.child_collection, context.caller, target_primary_key_values, id)
-            filter = Filter.new(
-              condition_tree: ConditionTree::ConditionTreeFactory.intersect(
-                [
-                  ConditionTree::Nodes::ConditionTreeLeaf.new(id, 'Equal', value),
-                  context.permissions.get_scope(context.child_collection)
-                ]
-              )
-            )
-
+            filter = target_in_scope_filter(target_primary_key_values, context)
             value = Collection.get_value(context.collection, context.caller, parent_primary_key_values,
                                          relation.origin_key_target)
 
@@ -98,7 +79,15 @@ module ForestAdminAgent
           end
 
           def find_target_in_scope(target_primary_key_values, foreign_key_target, context)
-            filter = Filter.new(
+            context.child_collection.list(
+              context.caller,
+              target_in_scope_filter(target_primary_key_values, context),
+              Projection.new([foreign_key_target])
+            ).first
+          end
+
+          def target_in_scope_filter(target_primary_key_values, context)
+            Filter.new(
               condition_tree: ConditionTree::ConditionTreeFactory.intersect(
                 [
                   ConditionTree::ConditionTreeFactory.match_ids(context.child_collection,
@@ -107,8 +96,6 @@ module ForestAdminAgent
                 ]
               )
             )
-
-            context.child_collection.list(context.caller, filter, Projection.new([foreign_key_target])).first
           end
         end
       end

--- a/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/resources/related/associate_related_spec.rb
+++ b/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/resources/related/associate_related_spec.rb
@@ -88,7 +88,8 @@ module ForestAdminAgent
               name: 'address',
               schema: {
                 fields: {
-                  'id' => ColumnSchema.new(column_type: 'Number', is_primary_key: true),
+                  'id' => ColumnSchema.new(column_type: 'Number', is_primary_key: true,
+                                           filter_operators: [Operators::IN, Operators::EQUAL]),
                   'location' => ColumnSchema.new(column_type: 'String'),
                   'addressable_id' => ColumnSchema.new(column_type: 'Number'),
                   'addressable_type' => ColumnSchema.new(column_type: 'String'),
@@ -121,8 +122,24 @@ module ForestAdminAgent
             expect(associate.routes.length).to eq 1
           end
 
+          it 'checks the edit permission on the foreign collection before parsing any id' do
+            allow(permissions).to receive(:can?)
+              .and_raise(ForestAdminAgent::Http::Exceptions::ForbiddenError)
+
+            args[:params]['relation_name'] = 'addresses'
+            args[:params]['data'] = [{ 'id' => 'malformed|id' }]
+            args[:params]['id'] = 'malformed|id'
+
+            expect { associate.handle_request(args) }
+              .to raise_error(ForestAdminAgent::Http::Exceptions::ForbiddenError)
+            expect(permissions).to have_received(:can?) do |action, collection|
+              expect(action).to eq(:edit)
+              expect(collection.name).to eq('address')
+            end
+          end
+
           context 'when call on one to many relation' do
-            it 'call associate_one_to_many' do
+            before do
               args[:params]['relation_name'] = 'address_users'
               args[:params]['data'] = [{ 'id' => 1 }]
               args[:params]['id'] = 1
@@ -130,11 +147,18 @@ module ForestAdminAgent
                 .and_return(Nodes::ConditionTreeLeaf.new('user_id', Operators::NOT_EQUAL, 99))
               allow(@datasource.get_collection('user')).to receive(:list).and_return([User.new(1, 'foo')])
               allow(@datasource.get_collection('address_user')).to receive(:update).and_return(true)
+            end
+
+            it 'call associate_one_to_many' do
               result = associate.handle_request(args)
 
-              expect(permissions).to have_received(:can?).with(:edit, having_attributes(name: 'user'))
-              expect(permissions).to have_received(:get_scope).with(having_attributes(name: 'address_user'))
-              expect(permissions).not_to have_received(:get_scope).with(having_attributes(name: 'user'))
+              expect(permissions).to have_received(:can?) do |action, collection|
+                expect(action).to eq(:edit)
+                expect(collection.name).to eq('address_user')
+              end
+              expect(permissions).to have_received(:get_scope) do |collection|
+                expect(collection.name).to eq('address_user')
+              end
               expect(@datasource.get_collection('address_user')).to have_received(:update) do |caller, filter, data|
                 expect(caller).to be_instance_of(Components::Caller)
                 expect(filter).to have_attributes(
@@ -159,18 +183,28 @@ module ForestAdminAgent
           end
 
           context 'when call on many to many relation' do
-            it 'call associate_many_to_many' do
+            before do
               args[:params]['relation_name'] = 'addresses'
               args[:params]['data'] = [{ 'id' => 1 }]
               args[:params]['id'] = 1
+              allow(permissions).to receive(:get_scope)
+                .and_return(Nodes::ConditionTreeLeaf.new('location', Operators::EQUAL, 'paris'))
               allow(@datasource.get_collection('user')).to receive(:list).and_return([User.new(1, 'foo')])
-              allow(@datasource.get_collection('address')).to receive(:list)
-                .and_return([Address.new(1, 'foo location')])
               allow(@datasource.get_collection('address_user')).to receive(:create).and_return(true)
+            end
+
+            it 'call associate_many_to_many' do
+              allow(@datasource.get_collection('address')).to receive(:list)
+                .and_return([{ 'id' => 1, 'location' => 'paris' }])
               result = associate.handle_request(args)
 
-              expect(permissions).to have_received(:can?).with(:edit, having_attributes(name: 'user'))
-              expect(permissions).not_to have_received(:get_scope)
+              expect(permissions).to have_received(:can?) do |action, collection|
+                expect(action).to eq(:edit)
+                expect(collection.name).to eq('address')
+              end
+              expect(permissions).to have_received(:get_scope) do |collection|
+                expect(collection.name).to eq('address')
+              end
               expect(@datasource.get_collection('address_user')).to have_received(:create) do |caller, data|
                 expect(caller).to be_instance_of(Components::Caller)
                 expect(data).to eq({ 'address_id' => 1, 'user_id' => 1 })
@@ -178,10 +212,39 @@ module ForestAdminAgent
               expect(result[:content]).to be_nil
               expect(result[:status]).to eq 204
             end
+
+            it 'searches the target with the scope of the foreign collection' do
+              allow(@datasource.get_collection('address')).to receive(:list)
+                .and_return([{ 'id' => 1, 'location' => 'paris' }])
+              associate.handle_request(args)
+
+              expect(@datasource.get_collection('address')).to have_received(:list) do |caller, filter, projection|
+                expect(caller).to be_instance_of(Components::Caller)
+                expect(filter).to have_attributes(
+                  condition_tree: have_attributes(
+                    aggregator: 'And',
+                    conditions: [
+                      have_attributes(field: 'id', operator: Operators::EQUAL, value: 1),
+                      have_attributes(field: 'location', operator: Operators::EQUAL, value: 'paris')
+                    ]
+                  )
+                )
+                expect(projection).to eq(['id'])
+              end
+            end
+
+            it 'does not create the through record when the target is out of scope' do
+              allow(@datasource.get_collection('address')).to receive(:list).and_return([])
+              result = associate.handle_request(args)
+
+              expect(@datasource.get_collection('address_user')).not_to have_received(:create)
+              expect(result[:content]).to be_nil
+              expect(result[:status]).to eq 204
+            end
           end
 
           context 'when call on polymorphic one to many relation' do
-            it 'call associate_polymorphic_one_to_many' do
+            before do
               args[:params]['relation_name'] = 'addresses_poly'
               args[:params]['data'] = [{ 'id' => 1, 'type' => 'user' }]
               args[:params]['id'] = 1
@@ -189,11 +252,18 @@ module ForestAdminAgent
                 .and_return(Nodes::ConditionTreeLeaf.new('location', Operators::EQUAL, 'paris'))
               allow(@datasource.get_collection('user')).to receive(:list).and_return([User.new(1, 'foo')])
               allow(@datasource.get_collection('address')).to receive(:update).and_return(true)
+            end
+
+            it 'call associate_polymorphic_one_to_many' do
               result = associate.handle_request(args)
 
-              expect(permissions).to have_received(:can?).with(:edit, having_attributes(name: 'user'))
-              expect(permissions).to have_received(:get_scope).with(having_attributes(name: 'address'))
-              expect(permissions).not_to have_received(:get_scope).with(having_attributes(name: 'user'))
+              expect(permissions).to have_received(:can?) do |action, collection|
+                expect(action).to eq(:edit)
+                expect(collection.name).to eq('address')
+              end
+              expect(permissions).to have_received(:get_scope) do |collection|
+                expect(collection.name).to eq('address')
+              end
               expect(@datasource.get_collection('address')).to have_received(:update) do |caller, filter, data|
                 expect(caller).to be_instance_of(Components::Caller)
                 expect(filter).to have_attributes(

--- a/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/resources/related/associate_related_spec.rb
+++ b/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/resources/related/associate_related_spec.rb
@@ -67,6 +67,14 @@ module ForestAdminAgent
                     origin_key_target: 'id',
                     foreign_collection: 'note'
                   ),
+                  'notes_by_chapter' => Relations::ManyToManySchema.new(
+                    foreign_key: 'note_chapter',
+                    foreign_collection: 'note',
+                    foreign_key_target: 'chapter',
+                    through_collection: 'note_user',
+                    origin_key: 'user_id',
+                    origin_key_target: 'id'
+                  ),
                   'addresses_poly' => Relations::PolymorphicOneToManySchema.new(
                     origin_key: 'addressable_id',
                     foreign_collection: 'address',
@@ -135,9 +143,21 @@ module ForestAdminAgent
               }
             )
 
+            collection_note_user = build_collection(
+              name: 'note_user',
+              schema: {
+                fields: {
+                  'id' => ColumnSchema.new(column_type: 'Number', is_primary_key: true),
+                  'user_id' => ColumnSchema.new(column_type: 'Number'),
+                  'note_chapter' => ColumnSchema.new(column_type: 'String')
+                }
+              }
+            )
+
             allow(ForestAdminAgent::Builder::AgentFactory.instance).to receive(:send_schema).and_return(nil)
             datasource.add_collection(collection_user)
             datasource.add_collection(collection_note)
+            datasource.add_collection(collection_note_user)
             datasource.add_collection(collection_address_user)
             datasource.add_collection(collection_address)
             ForestAdminAgent::Builder::AgentFactory.instance.add_datasource(datasource)
@@ -293,6 +313,36 @@ module ForestAdminAgent
               expect(@datasource.get_collection('address_user')).not_to have_received(:create)
               expect(result[:content]).to be_nil
               expect(result[:status]).to eq 204
+            end
+
+            context 'when the target has a composite primary key' do
+              before do
+                args[:params]['relation_name'] = 'notes_by_chapter'
+                args[:params]['data'] = [{ 'id' => '7|intro' }]
+                allow(permissions).to receive(:get_scope)
+                  .and_return(Nodes::ConditionTreeLeaf.new('user_id', Operators::NOT_EQUAL, 99))
+                allow(@datasource.get_collection('note')).to receive(:list).and_return([{ 'chapter' => 'intro' }])
+                allow(@datasource.get_collection('note_user')).to receive(:create).and_return(true)
+              end
+
+              it 'matches every key column of the target before linking it' do
+                associate.handle_request(args)
+
+                expect(@datasource.get_collection('note')).to have_received(:list) do |_caller, filter, projection|
+                  expect(filter.condition_tree).to have_attributes(
+                    aggregator: 'And',
+                    conditions: [
+                      have_attributes(field: 'book_id', operator: Operators::EQUAL, value: 7),
+                      have_attributes(field: 'chapter', operator: Operators::EQUAL, value: 'intro'),
+                      have_attributes(field: 'user_id', operator: Operators::NOT_EQUAL, value: 99)
+                    ]
+                  )
+                  expect(projection).to eq(['chapter'])
+                end
+                expect(@datasource.get_collection('note_user')).to have_received(:create) do |_caller, data|
+                  expect(data).to eq({ 'user_id' => 1, 'note_chapter' => 'intro' })
+                end
+              end
             end
 
             context 'when the relation keys target a column that is not the primary key' do

--- a/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/resources/related/associate_related_spec.rb
+++ b/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/resources/related/associate_related_spec.rb
@@ -37,8 +37,10 @@ module ForestAdminAgent
               name: 'user',
               schema: {
                 fields: {
-                  'id' => ColumnSchema.new(column_type: 'Number', is_primary_key: true),
+                  'id' => ColumnSchema.new(column_type: 'Number', is_primary_key: true,
+                                           filter_operators: [Operators::IN, Operators::EQUAL]),
                   'name' => ColumnSchema.new(column_type: 'String'),
+                  'reference' => ColumnSchema.new(column_type: 'String'),
                   'addresses' => Relations::ManyToManySchema.new(
                     foreign_key: 'address_id',
                     foreign_collection: 'address',
@@ -46,6 +48,14 @@ module ForestAdminAgent
                     through_collection: 'address_user',
                     origin_key: 'user_id',
                     origin_key_target: 'id'
+                  ),
+                  'addresses_by_code' => Relations::ManyToManySchema.new(
+                    foreign_key: 'address_code',
+                    foreign_collection: 'address',
+                    foreign_key_target: 'code',
+                    through_collection: 'address_user',
+                    origin_key: 'user_reference',
+                    origin_key_target: 'reference'
                   ),
                   'address_users' => Relations::OneToManySchema.new(
                     origin_key: 'user_id',
@@ -70,6 +80,8 @@ module ForestAdminAgent
                   'id' => ColumnSchema.new(column_type: 'Number', is_primary_key: true),
                   'address_id' => ColumnSchema.new(column_type: 'Number'),
                   'user_id' => ColumnSchema.new(column_type: 'Number'),
+                  'address_code' => ColumnSchema.new(column_type: 'String'),
+                  'user_reference' => ColumnSchema.new(column_type: 'String'),
                   'address' => Relations::ManyToOneSchema.new(
                     foreign_key: 'address_id',
                     foreign_collection: 'address',
@@ -91,6 +103,7 @@ module ForestAdminAgent
                   'id' => ColumnSchema.new(column_type: 'Number', is_primary_key: true,
                                            filter_operators: [Operators::IN, Operators::EQUAL]),
                   'location' => ColumnSchema.new(column_type: 'String'),
+                  'code' => ColumnSchema.new(column_type: 'String'),
                   'addressable_id' => ColumnSchema.new(column_type: 'Number'),
                   'addressable_type' => ColumnSchema.new(column_type: 'String'),
                   'addressable' => Relations::PolymorphicManyToOneSchema.new(
@@ -240,6 +253,32 @@ module ForestAdminAgent
               expect(@datasource.get_collection('address_user')).not_to have_received(:create)
               expect(result[:content]).to be_nil
               expect(result[:status]).to eq 204
+            end
+
+            context 'when the relation keys target a column that is not the primary key' do
+              before do
+                args[:params]['relation_name'] = 'addresses_by_code'
+                allow(@datasource.get_collection('user')).to receive(:list)
+                  .and_return([{ 'reference' => 'REF-1' }])
+                allow(@datasource.get_collection('address')).to receive(:list)
+                  .and_return([{ 'code' => 'A1' }])
+              end
+
+              it 'writes the target keys in the through record, not the primary keys' do
+                associate.handle_request(args)
+
+                expect(@datasource.get_collection('address_user')).to have_received(:create) do |_caller, data|
+                  expect(data).to eq({ 'user_reference' => 'REF-1', 'address_code' => 'A1' })
+                end
+              end
+
+              it 'projects the foreign key target on the scoped target' do
+                associate.handle_request(args)
+
+                expect(@datasource.get_collection('address')).to have_received(:list) do |_caller, _filter, projection|
+                  expect(projection).to eq(['code'])
+                end
+              end
             end
           end
 

--- a/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/resources/related/associate_related_spec.rb
+++ b/packages/forest_admin_agent/spec/lib/forest_admin_agent/routes/resources/related/associate_related_spec.rb
@@ -62,6 +62,11 @@ module ForestAdminAgent
                     origin_key_target: 'id',
                     foreign_collection: 'address_user'
                   ),
+                  'notes' => Relations::OneToManySchema.new(
+                    origin_key: 'user_id',
+                    origin_key_target: 'id',
+                    foreign_collection: 'note'
+                  ),
                   'addresses_poly' => Relations::PolymorphicOneToManySchema.new(
                     origin_key: 'addressable_id',
                     foreign_collection: 'address',
@@ -77,7 +82,8 @@ module ForestAdminAgent
               name: 'address_user',
               schema: {
                 fields: {
-                  'id' => ColumnSchema.new(column_type: 'Number', is_primary_key: true),
+                  'id' => ColumnSchema.new(column_type: 'Number', is_primary_key: true,
+                                           filter_operators: [Operators::IN, Operators::EQUAL]),
                   'address_id' => ColumnSchema.new(column_type: 'Number'),
                   'user_id' => ColumnSchema.new(column_type: 'Number'),
                   'address_code' => ColumnSchema.new(column_type: 'String'),
@@ -116,8 +122,22 @@ module ForestAdminAgent
               }
             )
 
+            collection_note = build_collection(
+              name: 'note',
+              schema: {
+                fields: {
+                  'book_id' => ColumnSchema.new(column_type: 'Number', is_primary_key: true,
+                                                filter_operators: [Operators::IN, Operators::EQUAL]),
+                  'chapter' => ColumnSchema.new(column_type: 'String', is_primary_key: true,
+                                                filter_operators: [Operators::IN, Operators::EQUAL]),
+                  'user_id' => ColumnSchema.new(column_type: 'Number')
+                }
+              }
+            )
+
             allow(ForestAdminAgent::Builder::AgentFactory.instance).to receive(:send_schema).and_return(nil)
             datasource.add_collection(collection_user)
+            datasource.add_collection(collection_note)
             datasource.add_collection(collection_address_user)
             datasource.add_collection(collection_address)
             ForestAdminAgent::Builder::AgentFactory.instance.add_datasource(datasource)
@@ -160,6 +180,26 @@ module ForestAdminAgent
                 .and_return(Nodes::ConditionTreeLeaf.new('user_id', Operators::NOT_EQUAL, 99))
               allow(@datasource.get_collection('user')).to receive(:list).and_return([User.new(1, 'foo')])
               allow(@datasource.get_collection('address_user')).to receive(:update).and_return(true)
+            end
+
+            it 'matches every key column when the target has a composite primary key' do
+              args[:params]['relation_name'] = 'notes'
+              args[:params]['data'] = [{ 'id' => '7|intro' }]
+              allow(@datasource.get_collection('note')).to receive(:update).and_return(true)
+
+              associate.handle_request(args)
+
+              expect(@datasource.get_collection('note')).to have_received(:update) do |_caller, filter, data|
+                expect(filter.condition_tree).to have_attributes(
+                  aggregator: 'And',
+                  conditions: [
+                    have_attributes(field: 'book_id', operator: Operators::EQUAL, value: 7),
+                    have_attributes(field: 'chapter', operator: Operators::EQUAL, value: 'intro'),
+                    have_attributes(field: 'user_id', operator: Operators::NOT_EQUAL, value: 99)
+                  ]
+                )
+                expect(data).to eq({ 'user_id' => 1 })
+              end
             end
 
             it 'call associate_one_to_many' do


### PR DESCRIPTION
Fixes [PRD-927](https://linear.app/forestadmin/issue/PRD-927/agent-ruby-associate-related-authorizes-edit-on-the-parent-and-skips). Ruby counterpart of PRD-922, fixed in agent-nodejs [#1820](https://github.com/ForestAdmin/agent-nodejs/pull/1820).

## The bug

`POST /forest/:collection/:id/relationships/:relation` asserted `edit` on the **parent** collection, then mutated the **child** one — the OneToMany branches update the child's origin key, the ManyToMany branch creates a through row.

A user with `edit` on `companies` but none on `users` (relation `companies.users`, origin key `users.company_id`) could reassign a `users` row they cannot edit. `dissociate_related` already authorizes the child collection since #350, so associating was the cheaper inverse of a write that required more.

The ManyToMany branch also resolved its target through `Collection.get_value`, which short-circuits on a primary key and never queries, so the through row was created with no scope check at all. #350 excluded that branch explicitly.

## The fix, one commit per defect

1. **Authorize the mutated collection.** `can?(:edit, context.child_collection)`, above `unpack_id` so a denied caller still gets a `403` rather than an id-validation error.
2. **Scope the ManyToMany link.** The target is resolved through `list` with `match_ids(target) ∩ get_scope(child_collection)`, and the through row is skipped when it comes back empty.
3. **Write the relation's key targets, not the primary keys.** `associate_many_to_many` built the through record from `Schema.primary_keys(...)[0]` on both sides. ActiveRecord derives `foreign_key_target` / `origin_key_target` from an association's `primary_key:` option, so `has_and_belongs_to_many :addresses, primary_key: :reference` was enough to write a primary key into a column holding another key — and `make_through_filter`, which `dissociate_related` builds on, already read the targets, so associate wrote rows that dissociate could not match back. No-op wherever the targets default to the primary key.
4. **Match every column of a composite key.** The two OneToMany branches identified their target with a leaf on the *first* primary key, so on a composite-key child the `update` reassigned every row sharing that column, and a sibling row in scope was enough to let an out-of-scope target through. All three branches now build their filter through one `target_in_scope_filter`, which also stops them from drifting apart on the scope again.

## Contract when the scope excludes the target

**204, nothing written** — as in agent-nodejs [#1820](https://github.com/ForestAdmin/agent-nodejs/pull/1820) and as in the OneToMany branches, whose intersected filter simply matches no row. Pinned by a test.

## Notes for the reviewer

- `match_ids` requires `Equal`/`In` on the child's primary key, which the leaf did not. Every datasource in the tree declares them (ActiveRecord, Mongoid, `BASE_OPERATORS` in hasura, `STRING_OPS`/`NUMBER_OPS` in zendesk, `ID_OPS` in mambu's `reconcile_filter_operators!`). A hand-written datasource declaring `filter_operators: []` on a primary key would `500` here, but it is already broken on `show` and `dissociate`, which both go through `match_ids`.
- `origin_value` is still read on the parent without scope, as on Node — out of scope for this PRD.

## Tests

`edit` asserted on the child and never on the parent in all three branches, `403` raised before the target id is parsed, the scope-intersected filter, no link when the target is out of scope, and two new fixtures: a ManyToMany whose keys target `code` / `reference`, and a composite-key `note` collection reached both through a OneToMany and through a `note_user` through collection.

Every assertion was checked against the faulty implementation it guards — permission back on the parent, scope dropped, guard removed, key targets and the shared filter reverted — and each mutation is caught in a couple of seconds.

Permission and scope assertions compare collection *names* inside a `have_received do |...|` block instead of passing the collection to `having_attributes`: rspec formats the decorator chain on failure, and the example then takes minutes and reports no failure at all. #353 hit the same wall.

849 examples, 0 failures on `forest_admin_agent`; `bundle exec rubocop` clean over the package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
